### PR TITLE
Skip login if the authority is not configured in your .env

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -96,13 +96,10 @@ const router = new VueRouter({
 
 router.beforeEach(async (to, from, next) => {
   // redirect to login page if not logged in and trying to access a restricted page
-  console.log('authority = ', process.env.VUE_APP_AUTH_AUTHORITY)
   if (process.env.VUE_APP_AUTH_AUTHORITY)
   {
     const authorize = to.meta?.authorize
-
     const currentUser = await authenticationService.getUser()
-
     if (authorize) {
         if (currentUser === null) {
         return next({ name: 'Login', query: { redirect: to.name } })


### PR DESCRIPTION
when VUE_APP_AUTH_AUTHORITY is either empty or omitted from the .env file, you no longer are redirected to log in.