### PR TITLE
Time range control

### DIFF
--- a/src/components/TimeSeriesComponent/ConfigurableChart.vue
+++ b/src/components/TimeSeriesComponent/ConfigurableChart.vue
@@ -98,7 +98,7 @@ export default class ConfigurableChart extends Vue {
     window.addEventListener('resize', this.resize)
   }
 
-  @Watch('series')
+  @Watch('series', { deep: true})
   @Watch('value')
   onValueChange(): void {
     this.clearChart()

--- a/src/components/systemmonitor/RunningTasks.vue
+++ b/src/components/systemmonitor/RunningTasks.vue
@@ -54,6 +54,7 @@ export default class RunningTasks extends Mixins(PiRequestsMixin) {
   ]
   runningTasks: TaskRun[] = []
   active: boolean = false;
+  abortController?: AbortController
 
   destroyed() {
     this.active = false;
@@ -79,7 +80,12 @@ export default class RunningTasks extends Mixins(PiRequestsMixin) {
   async loadRunningTasks() {
     try {
       if (!this.active) return
-      const provider = new PiWebserviceProvider(this.baseUrl, {transformRequestFn: this.transformRequest});
+      if (this.abortController !== undefined) {
+        this.abortController.abort()
+      }
+      this.abortController= new AbortController()
+      const transformRequest = this.getTransformRequest(this.abortController)
+      const provider = new PiWebserviceProvider(this.baseUrl, {transformRequestFn: transformRequest});
       const taskRunFilter: TaskRunsFilter = {
         taskRunStatusIds: ["R", "P"],
         documentFormat: DocumentFormat.PI_JSON,

--- a/src/components/timecontrol/TimeControl.vue
+++ b/src/components/timecontrol/TimeControl.vue
@@ -29,14 +29,14 @@
 
 
 <script lang="ts">
-import { Component } from 'vue-property-decorator'
+import { Component, Vue } from 'vue-property-decorator'
 import { Duration, DateTime } from 'luxon'
 import { namespace } from 'vuex-class';
 
 const sytemTimeModule = namespace('systemTime')
 
 @Component
-export default class TimeControl {
+export default class TimeControl extends Vue {
 
   intervalItems = [
     '-P1D',

--- a/src/components/timecontrol/TimeControl.vue
+++ b/src/components/timecontrol/TimeControl.vue
@@ -1,0 +1,75 @@
+<template>
+  <v-menu
+    left
+    bottom
+    :close-on-content-click="false"
+    class="menu"
+  >
+    <template v-slot:activator="{ on, attrs }">
+      <v-btn icon v-bind="attrs" v-on="on">
+        <v-icon>mdi-clock</v-icon>
+      </v-btn>
+    </template>
+    <v-card>
+      <v-list>
+        <v-list-item v-for="(item) in intervalItems" :key="item" @click="setInterval(item)">
+          {{ localeString(item) }}
+        </v-list-item>
+        <v-list-item>
+          Browser Time: {{ now.toLocaleTimeString('en-UK', { timeZoneName : 'short' }) }}
+        </v-list-item>
+      </v-list>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn plain>Reset</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-menu>
+</template>
+
+
+<script lang="ts">
+import { Component } from 'vue-property-decorator'
+import { Duration, DateTime } from 'luxon'
+import { namespace } from 'vuex-class';
+
+const sytemTimeModule = namespace('systemTime')
+
+@Component
+export default class TimeControl {
+
+  intervalItems = [
+    '-P1D',
+    '-P7D',
+  ]
+
+  now = new Date()
+
+  setInterval(interval: string) {
+    const duration = Duration.fromISO(interval)
+    const startDateTime = DateTime.fromJSDate(this.now).plus( duration)
+    const endDateTime = DateTime.fromJSDate(this.now)
+    this.$store.commit('systemTime/setInterval', { startTime: startDateTime.toJSDate(), endTime: endDateTime.toJSDate()})
+  }
+
+  localeString(item: string) {
+    const duration = Duration.fromISO(item)
+    const startDateTime = DateTime.fromJSDate(this.now).plus( duration)
+    return startDateTime.toRelative()
+  }
+
+}
+</script>
+
+<style>
+.menu {
+  position: relative;
+  z-index: 10000;
+}
+
+input {
+  width: 100%;
+  color: white;
+}
+
+</style>

--- a/src/components/timecontrol/TimeControl.vue
+++ b/src/components/timecontrol/TimeControl.vue
@@ -11,17 +11,29 @@
       </v-btn>
     </template>
     <v-card>
+      <v-subheader>Time range</v-subheader>
       <v-list>
-        <v-list-item v-for="(item) in intervalItems" :key="item" @click="setInterval(item)">
-          {{ localeString(item) }}
+        <v-list-item @click="setInterval(null)">
+          <v-list-item-title>
+            Default
+          </v-list-item-title>
+          <v-list-item-icon>
+              <v-icon v-show="selectedInterval === null" small>mdi-check</v-icon>
+            </v-list-item-icon>
         </v-list-item>
-        <v-list-item>
-          Browser Time: {{ now.toLocaleTimeString('en-UK', { hour: '2-digit', minute: '2-digit', timeZoneName : 'short' }) }}
+        <v-list-item v-for="(item) in intervalItems" :key="item" @click="setInterval(item)">
+          <v-list-item-title>
+            {{ localeString(item) }}
+            </v-list-item-title>
+            <v-list-item-icon>
+              <v-icon v-show="item === selectedInterval" small>mdi-check</v-icon>
+            </v-list-item-icon>
         </v-list-item>
       </v-list>
+      <v-divider />
       <v-card-actions>
-        <v-spacer />
-        <v-btn plain>Reset</v-btn>
+        <span class="mr-2">Browser time:</span>
+        <v-chip small>{{ now.toLocaleTimeString('en-UK', { hour: '2-digit', minute: '2-digit', timeZoneName : 'short' }) }}</v-chip>
       </v-card-actions>
     </v-card>
   </v-menu>
@@ -46,17 +58,23 @@ export default class TimeControl extends Vue {
   @sytemTimeModule.Mutation('setInterval')
   storeSetInterval!: (payload: any) => Date
 
+  selectedInterval: string|null = null
   intervalItems = [
     '-P1D',
     '-P7D',
   ]
 
-  setInterval(interval: string) {
+  setInterval(interval: string | null) {
     const now = this.getSystemTime()
-    const duration = Duration.fromISO(interval)
-    const startDateTime = DateTime.fromJSDate(now).plus( duration)
-    const endDateTime = DateTime.fromJSDate(now)
-    this.storeSetInterval({ startTime: startDateTime.toJSDate(), endTime: endDateTime.toJSDate()})
+    this.selectedInterval = interval
+    if (interval == null) {
+      this.storeSetInterval({ startTime: null, endTime: null})
+    } else {
+      const duration = Duration.fromISO(interval)
+      const startDateTime = DateTime.fromJSDate(now).plus( duration)
+      const endDateTime = DateTime.fromJSDate(now)
+      this.storeSetInterval({ startTime: startDateTime.toJSDate(), endTime: endDateTime.toJSDate()})
+    }
   }
 
   localeString(item: string) {

--- a/src/components/timecontrol/TimeControl.vue
+++ b/src/components/timecontrol/TimeControl.vue
@@ -6,8 +6,8 @@
     class="menu"
   >
     <template v-slot:activator="{ on, attrs }">
-      <v-btn icon v-bind="attrs" v-on="on">
-        <v-icon>mdi-clock</v-icon>
+      <v-btn text v-bind="attrs" v-on="on">
+        <v-icon>mdi-clock</v-icon>{{ now.toLocaleTimeString('en-UK', { hour: '2-digit', minute: '2-digit', timeZoneName : 'short' }) }}
       </v-btn>
     </template>
     <v-card>
@@ -16,7 +16,7 @@
           {{ localeString(item) }}
         </v-list-item>
         <v-list-item>
-          Browser Time: {{ now.toLocaleTimeString('en-UK', { timeZoneName : 'short' }) }}
+          Browser Time: {{ now.toLocaleTimeString('en-UK', { hour: '2-digit', minute: '2-digit', timeZoneName : 'short' }) }}
         </v-list-item>
       </v-list>
       <v-card-actions>
@@ -37,19 +37,26 @@ const sytemTimeModule = namespace('systemTime')
 
 @Component
 export default class TimeControl extends Vue {
+  @sytemTimeModule.State('systemTime')
+  now!: Date
+
+  @sytemTimeModule.Getter('getSystemTime')
+  getSystemTime!: () => Date
+
+  @sytemTimeModule.Mutation('setInterval')
+  storeSetInterval!: (payload: any) => Date
 
   intervalItems = [
     '-P1D',
     '-P7D',
   ]
 
-  now = new Date()
-
   setInterval(interval: string) {
+    const now = this.getSystemTime()
     const duration = Duration.fromISO(interval)
-    const startDateTime = DateTime.fromJSDate(this.now).plus( duration)
-    const endDateTime = DateTime.fromJSDate(this.now)
-    this.$store.commit('systemTime/setInterval', { startTime: startDateTime.toJSDate(), endTime: endDateTime.toJSDate()})
+    const startDateTime = DateTime.fromJSDate(now).plus( duration)
+    const endDateTime = DateTime.fromJSDate(now)
+    this.storeSetInterval({ startTime: startDateTime.toJSDate(), endTime: endDateTime.toJSDate()})
   }
 
   localeString(item: string) {

--- a/src/layouts/Default.vue
+++ b/src/layouts/Default.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app id="app">
     <v-app-bar color="#080C80" dense app dark :clipped-left="!$vuetify.rtl" :clipped-right="$vuetify.rtl">
-      <v-btn v-if="!$vuetify.breakpoint.mobile" text :to="{ name: 'Home' }">
+      <v-btn v-if="!$vuetify.breakpoint.mobile" text :to="{ name: 'Home' }" class="fews-home">
         Delft-FEWS Web OC
       </v-btn>
       <v-menu offset-y>
@@ -26,6 +26,7 @@
         </v-list>
       </v-menu>
       <v-spacer />
+      <TimeControl/>
       <CogMenu/>
       <login-component v-if="$config.authenticationIsEnabled"/>
     </v-app-bar>
@@ -53,6 +54,7 @@
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator'
 import CogMenu from '@/components/CogMenu.vue'
+import TimeControl from '@/components/timecontrol/TimeControl.vue'
 import LoginComponent from '@/components/LoginComponent.vue'
 import { namespace } from 'vuex-class'
 import { Alert } from '@/store/modules/alerts/types'
@@ -65,7 +67,8 @@ const fewsConfigModule = namespace('fewsconfig')
 @Component({
   components: {
     CogMenu,
-    LoginComponent
+    LoginComponent,
+    TimeControl,
   }
 })
 export default class Default extends Vue {
@@ -141,6 +144,10 @@ html, body {
   -moz-osx-font-smoothing: grayscale;
   height: 100%;
   overflow: hidden;
+}
+
+.fews-home.v-btn {
+  text-transform: capitalize !important;
 }
 
 #app.theme--light {

--- a/src/mixins/PiRequestsMixin.ts
+++ b/src/mixins/PiRequestsMixin.ts
@@ -4,10 +4,14 @@ import { Vue, Component } from 'vue-property-decorator'
 @Component({})
 export default class PiRequestsMixin extends Vue {
 
-  async transformRequest(request: Request): Promise<Request> {
-    if (!this.$config.authenticationIsEnabled) return request
-    // $auth only exists if authentication is enabled.
-    const newRequest = await this.$auth.transformRequestAuth(request)
-    return newRequest
+  getTransformRequest(controller?: AbortController) {
+    return async (request: Request): Promise<Request> => {
+      if (!this.$config.authenticationIsEnabled) return request
+      // $auth only exists if authentication is enabled.
+      if (controller !== undefined) {
+        return await this.$auth.transformRequestAuth(request, controller.signal)
+      }
+      return await this.$auth.transformRequestAuth(request)
+    }
   }
 }

--- a/src/mixins/TimeSeriesMixin.ts
+++ b/src/mixins/TimeSeriesMixin.ts
@@ -52,17 +52,17 @@ export default class TimeSeriesMixin extends Mixins(PiRequestsMixin) {
          && options?.endTime) {
         const startTime = DateTime.fromJSDate(options?.startTime, {zone: 'UTC'})
         const endTime = DateTime.fromJSDate(options?.endTime, {zone: 'UTC'})
-        const intervalInMillis = Interval.fromDateTimes(startTime, endTime).length()
-        url.searchParams.set('startTime', startTime.toISO({ suppressMilliseconds: true}) ?? '')
-        url.searchParams.set('endTime', endTime.toISO({ suppressMilliseconds: true}) ?? '')
-        url.searchParams.set('thinning', `${intervalInMillis / window.outerWidth}`)
+        const timeStepPerPixel = Math.round(Interval.fromDateTimes(startTime, endTime).length() / window.outerWidth /2)
+        url.searchParams.set('startTime', startTime.toISO({ suppressMilliseconds: true }) ?? '')
+        url.searchParams.set('endTime', endTime.toISO({ suppressMilliseconds: true }) ?? '')
+        url.searchParams.set('thinning', `${timeStepPerPixel}`)
       } else if ( startTimeString !== null && endTimeString !== null) {
         const startTime = DateTime.fromISO(startTimeString, {zone: 'UTC'})
         const endTime = DateTime.fromISO(endTimeString, {zone: 'UTC'})
-        const intervalInMillis = Interval.fromDateTimes(startTime, endTime).length()
-        url.searchParams.set('startTime', startTime.toISO({ suppressMilliseconds: true}) ?? '')
-        url.searchParams.set('endTime', endTime.toISO({ suppressMilliseconds: true}) ?? '')
-        url.searchParams.set('thinning', `${intervalInMillis / window.outerWidth}`)
+        const timeStepPerPixel =  Math.round(Interval.fromDateTimes(startTime, endTime).length() / window.outerWidth /2)
+        url.searchParams.set('startTime', startTime.toISO({ suppressMilliseconds: true }) ?? '')
+        url.searchParams.set('endTime', endTime.toISO({ suppressMilliseconds: true }) ?? '')
+        url.searchParams.set('thinning', `${timeStepPerPixel}`)
       }
       const resourceId = `${request.key}`
       const relativeUrl = request.request.split('?')[0] + url.search

--- a/src/services/authentication/AuthenticationManager.ts
+++ b/src/services/authentication/AuthenticationManager.ts
@@ -35,16 +35,10 @@ export class AuthenticationManager {
     }
   }
 
-  public transformRequestAuth(request: Request): Request {
+  public transformRequestAuth(request: Request, signal?: AbortSignal): Request {
     const requestAuthHeaders = this.getAuthorizationHeaders()
-    const requestInit = { headers: requestAuthHeaders}
-    return new Request(request, requestInit)
-  }
-
-  public transformRequest(request: Request): Request {
-    if (!configManager.authenticationIsEnabled) return request
-    // $auth only exists if authentication is enabled.
-    const newRequest = this.transformRequestAuth(request)
+    const requestInit = { headers: requestAuthHeaders, signal: signal}
+    const newRequest = new Request(request, requestInit)
     return newRequest
   }
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -3,6 +3,8 @@ import Vuex from 'vuex'
 import { RootState } from './types';
 import Alerts from '@/store/modules/alerts';
 import { fewsconfig } from '@/store/modules/fews-config';
+import SystemTime from '@/store/modules/system-time';
+
 Vue.use(Vuex)
 
 const store = new Vuex.Store<RootState>({
@@ -14,7 +16,9 @@ const store = new Vuex.Store<RootState>({
   },
   modules: {
     alerts: Alerts,
+    systemTime: SystemTime,
     fewsconfig
   }
 })
+console.log(store)
 export default store

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,9 +1,9 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
-import { RootState } from './types';
-import Alerts from '@/store/modules/alerts';
-import { fewsconfig } from '@/store/modules/fews-config';
-import SystemTime from '@/store/modules/system-time';
+import { RootState } from './types'
+import Alerts from '@/store/modules/alerts'
+import { fewsconfig } from '@/store/modules/fews-config'
+import { systemTime } from '@/store/modules/system-time'
 
 Vue.use(Vuex)
 
@@ -16,9 +16,10 @@ const store = new Vuex.Store<RootState>({
   },
   modules: {
     alerts: Alerts,
-    systemTime: SystemTime,
+    systemTime,
     fewsconfig
   }
 })
-console.log(store)
+
+store.dispatch('systemTime/startClock')
 export default store

--- a/src/store/modules/system-time/actions.ts
+++ b/src/store/modules/system-time/actions.ts
@@ -1,0 +1,13 @@
+import { ActionTree } from 'vuex'
+import { RootState } from '../../types'
+import { SystemTimeState } from './types'
+
+export const actions: ActionTree<SystemTimeState, RootState>= {
+  startClock: async (context, _payload: any ) => {
+    context.commit('setSystemTime', new Date())
+    const intervalTimer = setInterval(() => {
+      context.commit('setSystemTime', new Date()) },
+      1000)
+    context.commit('setIntervalTimer', intervalTimer)
+  },
+}

--- a/src/store/modules/system-time/getters.ts
+++ b/src/store/modules/system-time/getters.ts
@@ -1,0 +1,10 @@
+
+import { GetterTree } from 'vuex';
+import { SystemTimeState } from './types';
+import { RootState } from '../../types';
+
+export const getters: GetterTree<SystemTimeState, RootState> = {
+  getSystemTime: (state, _getters, _rootState: RootState, rootGetters) => () => {
+    return state.systemTime
+  },
+}

--- a/src/store/modules/system-time/index.ts
+++ b/src/store/modules/system-time/index.ts
@@ -1,0 +1,26 @@
+import { Module, Mutation, VuexModule } from 'vuex-module-decorators'
+import { SystemTimeState } from './types'
+
+@Module({ namespaced: true, name: 'systemTime' })
+export default class SystemTime extends VuexModule<SystemTimeState> {
+  systemTime: Date = new Date()
+  startTime: Date | null = null
+  endTime: Date | null = null
+
+  @Mutation
+  setStartTime(startTime: Date) {
+    this.startTime = startTime
+  }
+
+  @Mutation
+  setEndTime(endTime: Date) {
+    this.endTime = endTime
+  }
+
+  @Mutation
+  setInterval(payload: { startTime: Date, endTime: Date}) {
+    console.log('system time store', payload.startTime, payload.endTime)
+    this.startTime = payload.startTime
+    this.endTime = payload.endTime
+  }
+}

--- a/src/store/modules/system-time/index.ts
+++ b/src/store/modules/system-time/index.ts
@@ -1,26 +1,24 @@
-import { Module, Mutation, VuexModule } from 'vuex-module-decorators'
+
+import { Module } from 'vuex';
 import { SystemTimeState } from './types'
+import { RootState } from '../../types';
+import { getters } from './getters';
+import { actions } from './actions';
+import { mutations } from './mutations';
 
-@Module({ namespaced: true, name: 'systemTime' })
-export default class SystemTime extends VuexModule<SystemTimeState> {
-  systemTime: Date = new Date()
-  startTime: Date | null = null
-  endTime: Date | null = null
+export const state: SystemTimeState = {
+  systemTime: new Date(),
+  startTime: null,
+  endTime: null,
+  intervalTimer: null,
+};
 
-  @Mutation
-  setStartTime(startTime: Date) {
-    this.startTime = startTime
-  }
+const namespaced: boolean = true;
 
-  @Mutation
-  setEndTime(endTime: Date) {
-    this.endTime = endTime
-  }
-
-  @Mutation
-  setInterval(payload: { startTime: Date, endTime: Date}) {
-    console.log('system time store', payload.startTime, payload.endTime)
-    this.startTime = payload.startTime
-    this.endTime = payload.endTime
-  }
+export const systemTime: Module<SystemTimeState, RootState> = {
+  namespaced,
+  state,
+  getters,
+  actions,
+  mutations
 }

--- a/src/store/modules/system-time/mutations.ts
+++ b/src/store/modules/system-time/mutations.ts
@@ -1,0 +1,24 @@
+import { MutationTree } from 'vuex';
+import { SystemTimeState } from './types';
+
+export const mutations: MutationTree<SystemTimeState> = {
+  setSystemTime(state, systemTime: Date) {
+    state.systemTime = systemTime
+  },
+  setStartTime(state, startTime: Date) {
+    state.startTime = startTime
+  },
+  setEndTime(state, endTime: Date) {
+    state.endTime = endTime
+  },
+  setInterval(state, payload: { startTime: Date, endTime: Date}) {
+    state.startTime = payload.startTime
+    state.endTime = payload.endTime
+  },
+  setIntervalTimer(state, intervalTimer: number) {
+    if (state.intervalTimer) {
+      clearInterval(state.intervalTimer)
+    }
+    state.intervalTimer = intervalTimer
+  }
+}

--- a/src/store/modules/system-time/types.ts
+++ b/src/store/modules/system-time/types.ts
@@ -1,0 +1,5 @@
+export interface SystemTimeState {
+  systemTime: Date
+  startTime: Date | null
+  endTime: Date | null
+}

--- a/src/store/modules/system-time/types.ts
+++ b/src/store/modules/system-time/types.ts
@@ -2,4 +2,5 @@ export interface SystemTimeState {
   systemTime: Date
   startTime: Date | null
   endTime: Date | null
+  intervalTimer: number | null
 }

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,5 +1,7 @@
 import { AlertState } from './modules/alerts/types';
+import { SystemTimeState } from './modules/system-time/types';
 
 export interface RootState {
   alerts?: AlertState
+  systemTime?: SystemTimeState
 }

--- a/src/views/TimeSeriesDisplay.vue
+++ b/src/views/TimeSeriesDisplay.vue
@@ -133,7 +133,8 @@ export default class TimeSeriesDisplay extends Mixins(TimeSeriesMixin, PiRequest
   }
 
   async mounted(): Promise<void> {
-    this.webServiceProvider = new PiWebserviceProvider(this.baseUrl, {transformRequestFn: this.transformRequest});
+    const transformRequestFn = this.getTransformRequest()
+    this.webServiceProvider = new PiWebserviceProvider(this.baseUrl, {transformRequestFn});
     await this.loadNodes()
     await this.onNodeChange()
   }
@@ -208,10 +209,8 @@ export default class TimeSeriesDisplay extends Mixins(TimeSeriesMixin, PiRequest
 
   @Watch('$store.state.systemTime.startTime')
   async onTimeChanged(): Promise<void> {
-    console.log('systemTime')
     await this.loadTimeSeries(this.selectedItem);
   }
-
 
   @Watch('selectedItem')
   async onPlotChanged(): Promise<void> {

--- a/src/views/TimeSeriesDisplay.vue
+++ b/src/views/TimeSeriesDisplay.vue
@@ -93,7 +93,10 @@ import {DisplayConfig, DisplayType} from '@/lib/Layout/DisplayConfig'
 import {PiWebserviceProvider, ActionRequest} from "@deltares/fews-pi-requests";
 import PiRequestsMixin from "@/mixins/PiRequestsMixin"
 import type { TopologyActionFilter, ActionsResponse, TopologyNode } from "@deltares/fews-pi-requests";
+import { namespace } from 'vuex-class'
 import { timeSeriesDisplayToChartConfig } from '@/lib/ChartConfig/timeSeriesDisplayToChartConfig'
+
+const sytemTimeModule = namespace('systemTime')
 
 @Component({
   components: {
@@ -105,6 +108,11 @@ import { timeSeriesDisplayToChartConfig } from '@/lib/ChartConfig/timeSeriesDisp
 export default class TimeSeriesDisplay extends Mixins(TimeSeriesMixin, PiRequestsMixin) {
   @Prop({default: '', type: String})
   nodeId!: string
+
+  @sytemTimeModule.State('startTime')
+    startTime!: Date
+  @sytemTimeModule.State('endTime')
+    endTime!: Date
 
   urlTopologyNodeMap: Map<string,string> = new Map<string, string>()
   selectedItem: number = -1
@@ -198,6 +206,13 @@ export default class TimeSeriesDisplay extends Mixins(TimeSeriesMixin, PiRequest
     this.open = [items[0].id]
   }
 
+  @Watch('$store.state.systemTime.startTime')
+  async onTimeChanged(): Promise<void> {
+    console.log('systemTime')
+    await this.loadTimeSeries(this.selectedItem);
+  }
+
+
   @Watch('selectedItem')
   async onPlotChanged(): Promise<void> {
     this.displays = this.allDisplays[this.selectedItem];
@@ -236,7 +251,7 @@ export default class TimeSeriesDisplay extends Mixins(TimeSeriesMixin, PiRequest
   }
 
   private async loadTimeSeries(index: number) {
-    this.updateTimeSeries(this.requests[index])
+    this.updateTimeSeries(this.requests[index], {startTime: this.startTime, endTime: this.endTime, thinning: true})
   }
 
   @Watch('active')


### PR DESCRIPTION
Add support for selecting different time range in the time series chart.
This is a first version that only works in the topology view `<TimeSeriesDisplay>`.
Only two periods, or the default can be selected.
