### PR TITLE
METOC:show time series when double clicking on wms layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "fews-web-oc",
       "version": "0.5.0",
       "dependencies": {
-        "@deltares/fews-pi-requests": "^0.6.4-beta.0",
+        "@deltares/fews-pi-requests": "^0.6.4-beta.1",
         "@deltares/fews-ssd-requests": "^0.2.11",
         "@deltares/fews-ssd-webcomponent": "^0.3.0-alpha.0",
         "@deltares/fews-web-oc-charts": "^3.0.0-alpha.7",
@@ -1726,9 +1726,9 @@
       "license": "MIT"
     },
     "node_modules/@deltares/fews-pi-requests": {
-      "version": "0.6.4-beta.0",
-      "resolved": "https://registry.npmjs.org/@deltares/fews-pi-requests/-/fews-pi-requests-0.6.4-beta.0.tgz",
-      "integrity": "sha512-E+fNiVzCLBWp9+uNdUAp2OCdGQb4NpODmd5QjQpk9AAOk2G8N1icFc5+i+bETK5o2IenPQkrj/4GMkd3SPe3HA==",
+      "version": "0.6.4-beta.1",
+      "resolved": "https://registry.npmjs.org/@deltares/fews-pi-requests/-/fews-pi-requests-0.6.4-beta.1.tgz",
+      "integrity": "sha512-HOOzYuY0cchnLgYXtfMT+BWXuIk4yfQ58eyKjEX17lMhSpX/3A7BowLvBIa6Jl9bu2wUePmqnZyV/g+qO2Da2w==",
       "dependencies": {
         "@deltares/fews-web-oc-utils": "^0.2.1-alpha.1"
       },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "sonar": "sonar-scanner -Dsonar.host.url=$SONAR_URL -Dsonar.login=$SONAR_TOKEN -Dsonar.projectKey=$SONAR_KEY -Dsonar.projectName='Delft-FEWS Web OC'"
   },
   "dependencies": {
-    "@deltares/fews-pi-requests": "^0.6.4-beta.0",
+    "@deltares/fews-pi-requests": "^0.6.4-beta.1",
     "@deltares/fews-ssd-requests": "^0.2.11",
     "@deltares/fews-ssd-webcomponent": "^0.3.0-alpha.0",
     "@deltares/fews-web-oc-charts": "^3.0.0-alpha.7",

--- a/src/components/AnimatedMapboxLayer.vue
+++ b/src/components/AnimatedMapboxLayer.vue
@@ -182,11 +182,11 @@ export default class AnimatedMapboxLayer extends  Vue {
   }
 
   setDoubleClickLayer() {
-    if (this.mapObject) {
+    if (this.mapObject && this.mapObject.doubleClickZoom.isEnabled()) {
       // deactivate double click zoom
       this.mapObject.doubleClickZoom.disable()
       this.mapObject.on("dblclick", (e) => {
-        this.$emit("doubleClick", e)       
+        this.$emit("doubleclick", e)
       })
     }
   }

--- a/src/components/AnimatedMapboxLayer.vue
+++ b/src/components/AnimatedMapboxLayer.vue
@@ -181,10 +181,12 @@ export default class AnimatedMapboxLayer extends  Vue {
     }
   }
 
-  setDoubleClickLayer() {
-    if (this.mapObject && this.mapObject.doubleClickZoom.isEnabled()) {
-      // deactivate double click zoom
-      this.mapObject.doubleClickZoom.disable()
+  enableDoubleClickLayer() {
+    if (this.mapObject) {
+      if(this.mapObject.doubleClickZoom.isEnabled()){
+        // deactivate double click zoom
+        this.mapObject.doubleClickZoom.disable()
+      }
       this.mapObject.on("dblclick", (e) => {
         this.$emit("doubleclick", e)
       })
@@ -213,7 +215,7 @@ export default class AnimatedMapboxLayer extends  Vue {
     this.newLayerId = getFrameId(this.layer.name, this.counter)
     const source = this.mapObject.getSource(this.newLayerId)
     const baseUrl = this.$config.get("VUE_APP_FEWS_WEBSERVICES_URL")
-    this.setDoubleClickLayer()
+    this.enableDoubleClickLayer()
     if (this.currentLayer !== originalLayerName) {
       // set default zoom only if layer is changed
       this.setDefaultZoom()

--- a/src/components/AnimatedMapboxLayer.vue
+++ b/src/components/AnimatedMapboxLayer.vue
@@ -81,7 +81,7 @@ function getMercatorBboxFromBounds(bounds: LngLatBounds): number[] {
 }
 
 @Component
-export default class AnimatedMapboxLayer extends Vue {
+export default class AnimatedMapboxLayer extends  Vue {
   @Prop({
     default: () => {
       return null
@@ -181,6 +181,16 @@ export default class AnimatedMapboxLayer extends Vue {
     }
   }
 
+  setDoubleClickLayer() {
+    if (this.mapObject) {
+      // deactivate double click zoom
+      this.mapObject.doubleClickZoom.disable()
+      this.mapObject.on("dblclick", (e) => {
+        this.$emit("doubleClick", e)       
+      })
+    }
+  }
+
   @Watch("layer")
   onLayerChange(): void {
     if (!this.isInitialized) return
@@ -203,6 +213,7 @@ export default class AnimatedMapboxLayer extends Vue {
     this.newLayerId = getFrameId(this.layer.name, this.counter)
     const source = this.mapObject.getSource(this.newLayerId)
     const baseUrl = this.$config.get("VUE_APP_FEWS_WEBSERVICES_URL")
+    this.setDoubleClickLayer()
     if (this.currentLayer !== originalLayerName) {
       // set default zoom only if layer is changed
       this.setDefaultZoom()

--- a/src/components/AnimatedMapboxLayer.vue
+++ b/src/components/AnimatedMapboxLayer.vue
@@ -182,11 +182,12 @@ export default class AnimatedMapboxLayer extends  Vue {
   }
 
   enableDoubleClickLayer() {
-    if (this.mapObject) {
-      if(this.mapObject.doubleClickZoom.isEnabled()){
-        // deactivate double click zoom
-        this.mapObject.doubleClickZoom.disable()
-      }
+    const hasNotBeenDisabledYet = this.mapObject.doubleClickZoom.isEnabled()
+    if (this.mapObject && hasNotBeenDisabledYet) {
+      // deactivate double click zoom
+      this.mapObject.doubleClickZoom.disable()
+
+      // Only do this once, otherwise this event will be fired multiple times
       this.mapObject.on("dblclick", (e) => {
         this.$emit("doubleclick", e)
       })

--- a/src/components/AnimatedMapboxLayer.vue
+++ b/src/components/AnimatedMapboxLayer.vue
@@ -81,7 +81,7 @@ function getMercatorBboxFromBounds(bounds: LngLatBounds): number[] {
 }
 
 @Component
-export default class AnimatedMapboxLayer extends  Vue {
+export default class AnimatedMapboxLayer extends Vue {
   @Prop({
     default: () => {
       return null

--- a/src/lib/TimeSeries/timeSeries.ts
+++ b/src/lib/TimeSeries/timeSeries.ts
@@ -17,6 +17,15 @@ const timeSeriesResourceType = (resource: SeriesResource) => {
       return SeriesResource
   }
 }
+export interface domainAxisValue {
+  values: Array<string>
+  parameterId: string
+}
+
+export interface Domain {
+  domainAxisValues?: domainAxisValue[]
+  events: Array<any> // eslint-disable-line @typescript-eslint/no-explicit-any
+}
 
 @JsonObject()
 export class Series {
@@ -36,6 +45,7 @@ export class Series {
   start?: Date;
   end?: Date;
   lastUpdated?: Date;
+  domains?: Domain[]; 
 
   constructor (
     resource: SeriesResource | SeriesRequest | SeriesUrlRequest | SeriesDerived

--- a/src/lib/TimeSeries/timeSeries.ts
+++ b/src/lib/TimeSeries/timeSeries.ts
@@ -2,6 +2,7 @@ import { JsonObject, JsonProperty } from 'typescript-json-serializer'
 import { SeriesHeader } from './types'
 import { SeriesResource, SeriesRequest, SeriesUrlRequest, SeriesDerived } from './timeSeriesResource'
 import MD5 from 'crypto-js/md5'
+import { Domains } from '@deltares/fews-pi-requests'
 
 const timeSeriesResourceType = (resource: SeriesResource) => {
   switch (resource.type) {
@@ -36,7 +37,7 @@ export class Series {
   start?: Date;
   end?: Date;
   lastUpdated?: Date;
-  domains?: any[]; 
+  domains?: Domains[]; 
   timeZone?: string;
   missingValue?: string;
 

--- a/src/lib/TimeSeries/timeSeries.ts
+++ b/src/lib/TimeSeries/timeSeries.ts
@@ -17,15 +17,6 @@ const timeSeriesResourceType = (resource: SeriesResource) => {
       return SeriesResource
   }
 }
-export interface domainAxisValue {
-  values: Array<string>
-  parameterId: string
-}
-
-export interface Domain {
-  domainAxisValues?: domainAxisValue[]
-  events: Array<any> // eslint-disable-line @typescript-eslint/no-explicit-any
-}
 
 @JsonObject()
 export class Series {
@@ -45,7 +36,9 @@ export class Series {
   start?: Date;
   end?: Date;
   lastUpdated?: Date;
-  domains?: Domain[]; 
+  domains?: any[]; 
+  timeZone?: string;
+  missingValue?: string;
 
   constructor (
     resource: SeriesResource | SeriesRequest | SeriesUrlRequest | SeriesDerived

--- a/src/lib/Topology/timeseriesdisplay.ts
+++ b/src/lib/Topology/timeseriesdisplay.ts
@@ -32,8 +32,8 @@ export async function fetchTimeSeriesDisplaysAndRequests(
       const [displaysCur, requestsCur] = await fetchTimeSeriesDisplaysAndRequestsForSingleFilter(
         provider, filter
       )
-      displays = displays.concat(displaysCur)
-      requests = requests.concat(requestsCur)
+    displays = displays.concat(displaysCur)
+    requests = requests.concat(requestsCur)
   }
   return [displays, requests]
 }

--- a/src/lib/Topology/timeseriesdisplay.ts
+++ b/src/lib/Topology/timeseriesdisplay.ts
@@ -1,30 +1,16 @@
 import { ActionsResponse, ActionRequest, PiWebserviceProvider } from "@deltares/fews-pi-requests";
 import { DisplayType, DisplayConfig } from "@/lib/Layout/DisplayConfig";
 import { timeSeriesDisplayToChartConfig } from "@/lib/ChartConfig/timeSeriesDisplayToChartConfig";
-import { timeSeriesGridActionsFilter } from "@deltares/fews-pi-requests";
+import { timeSeriesGridActionsFilter, filterActionsFilter } from "@deltares/fews-pi-requests";
 
-/**
- * Retrieves filter actions from the FEWS PI Webservice.
- *
- * @todo: Remove once this has been implemented in @deltares/fews-pi-requests.
- *
- * @param provider FEWS PI Webservices provider.
- * @param filterId FilterId to get actions for.
- * @param locationId LocationId to get the actions for.
- * @returns Filter actions response for this location and these filters.
- */
-async function getFilterLocationsActions(provider: PiWebserviceProvider, filterId: string, locationId: string): Promise<ActionsResponse> {
-  // Hacky way to get the base URL from the provider.
-  // TODO: will this work with authentication?
-  const baseUrl = provider.locationsUrl({}).href.replace('/locations', '')
-  const actionsUrl = new URL(`${baseUrl}/filters/actions`)
-  actionsUrl.searchParams.append('filterId', filterId)
-  actionsUrl.searchParams.append('locationIds', locationId)
+type FilterArray = (timeSeriesGridActionsFilter | filterActionsFilter)[];
+// guard fuctions, needed because is not possible to use instanceof/ typeof on interfaces
+function isFilterActionsFilter(filter: timeSeriesGridActionsFilter | filterActionsFilter): filter is filterActionsFilter {
+  return (filter as filterActionsFilter).filterId !== undefined;
+}
 
-  const response = await fetch(actionsUrl)
-  const data: ActionsResponse = await response.json()
-
-  return data
+function isTimeSeriesGridActionsFilter(filter: timeSeriesGridActionsFilter | filterActionsFilter): filter is timeSeriesGridActionsFilter {
+  return (filter as timeSeriesGridActionsFilter).x !== undefined;
 }
 
 /**
@@ -39,13 +25,12 @@ async function getFilterLocationsActions(provider: PiWebserviceProvider, filterI
  * @returns 2-tuple with the displays and associated time series requests for all filters.
  */
 export async function fetchTimeSeriesDisplaysAndRequests(
-  provider: PiWebserviceProvider, filterIds: string[], locationId?: string, coordsFilter?: timeSeriesGridActionsFilter
-): Promise<[DisplayConfig[], ActionRequest[]]> {
+  provider: PiWebserviceProvider, filters: FilterArray): Promise<[DisplayConfig[], ActionRequest[]]> {
   let displays: DisplayConfig[] = []
   let requests: ActionRequest[] = []
-  for (const filterId of filterIds) {
-      const [displaysCur, requestsCur] = await fetchTimeSeriesDisplaysAndRequestsForSingleFilterId(
-        provider, filterId, locationId, coordsFilter
+  for (const filter of filters) {
+      const [displaysCur, requestsCur] = await fetchTimeSeriesDisplaysAndRequestsForSingleFilter(
+        provider, filter
       )
       displays = displays.concat(displaysCur)
       requests = requests.concat(requestsCur)
@@ -62,23 +47,18 @@ export async function fetchTimeSeriesDisplaysAndRequests(
  * @param coordinates Coordinates to get displays and requests for.
  * @returns 2-tuple with the displays and associated time series requests.
  */
-async function fetchTimeSeriesDisplaysAndRequestsForSingleFilterId(
-  provider: PiWebserviceProvider, filterId: string, locationId?: string, coordsFilter?: timeSeriesGridActionsFilter
+async function fetchTimeSeriesDisplaysAndRequestsForSingleFilter(
+  provider: PiWebserviceProvider, filter: timeSeriesGridActionsFilter | filterActionsFilter
 ): Promise<[DisplayConfig[], ActionRequest[]]> {
 
   let response: ActionsResponse | null = null
-  if (!locationId && !coordsFilter) {
-    throw new Error('Either locationId or coordinates filter must be specified')
-  } else if (locationId && coordsFilter) {
-    throw new Error('Only one of locationId or coordinates filter can be specified')
-  } else if (coordsFilter) {
-    response = await provider.getTimeSeriesGridActions(coordsFilter)
-  } else if (locationId) {
-    response = await getFilterLocationsActions(provider, filterId, locationId)
-  }
 
-  if (!response) {
-    throw new Error('No response received from FEWS PI Webservice')
+  if (isFilterActionsFilter(filter)) {
+    response = await provider.getFilterActions(filter)
+  } else if (isTimeSeriesGridActionsFilter(filter)) {
+    response = await provider.getTimeSeriesGridActions(filter)
+  } else {
+    throw new Error('Filter type not supported')
   }
 
   let displays: DisplayConfig[] = []

--- a/src/mixins/TimeSeriesMixin.ts
+++ b/src/mixins/TimeSeriesMixin.ts
@@ -1,6 +1,6 @@
 import { Component, Mixins, Vue } from 'vue-property-decorator'
 import { Series, SeriesUrlRequest } from '@/lib/TimeSeries'
-import {ActionRequest, PiWebserviceProvider} from '@deltares/fews-pi-requests'
+import {ActionRequest,DomainAxisEvent,PiWebserviceProvider} from '@deltares/fews-pi-requests'
 import PiRequestsMixin from "@/mixins/PiRequestsMixin"
 import { DateTime, Interval } from 'luxon'
 
@@ -11,7 +11,7 @@ function timeZoneOffsetString (offset: number): string {
   return `+${hours.toString().padStart(2,'0')}:${minutes.toString().padStart(2,'0')}`
 }
 
-function parsePiDateTime(event: {date: string, time: string} , timeZone: string) {
+function parsePiDateTime(event: DomainAxisEvent, timeZone: string) {
   return `${event.date}T${event.time}${timeZone}`
 }
 
@@ -125,12 +125,11 @@ export default class TimeSeriesMixin extends Mixins(PiRequestsMixin) {
         }
       }
 
-      const events = timeSeries.domains.slice(1)
-      timeSeries.data = events.map((event: any) => {
-        const e = event.events[0]
+      timeSeries.data = timeSeries.domains.slice(1).map(singleDomain => {
+        const e = singleDomain.events![0]
         return {
           x: new Date( parsePiDateTime(e, timeSeries.timeZone? timeSeries.timeZone : 'Z')),
-          y: e.values[elevationIndex][0] === timeSeries.missingValue ? null : +e.values[elevationIndex][0]
+          y: e.values![elevationIndex][0] === timeSeries.missingValue ? null : +e.values![elevationIndex][0]
         }
       })
     }

--- a/src/mixins/TimeSeriesMixin.ts
+++ b/src/mixins/TimeSeriesMixin.ts
@@ -95,7 +95,7 @@ export default class TimeSeriesMixin extends Mixins(PiRequestsMixin) {
               series.domains = timeSeries.domains
               this.updateTimeSeriesWithElevation(series, elevation)
             } else {
-              throw new Error('No data found')
+              throw new Error('Timeseries data should include ' + (elevation ? 'domains' : 'events'))
             }
           }
           Vue.set(this.timeSeriesStore, resourceId, series)

--- a/src/mixins/TimeSeriesMixin.ts
+++ b/src/mixins/TimeSeriesMixin.ts
@@ -110,15 +110,20 @@ export default class TimeSeriesMixin extends Mixins(PiRequestsMixin) {
     }
     const domainAxisValues = timeSeries.domains[0].domainAxisValues
     if (domainAxisValues !== undefined) {
-      const domain= domainAxisValues[0]
-      // convert domain.values to an array of numbers
-      domain.values = domain.values.map((value: [string]) => {
-        return +value[0]
-      })
-      // find the index of the closest number to the elevation
-      const elevationIndex = domain.values.reduce((prev: number, curr: number, index: number) => {
-        return (Math.abs(curr - elevation) < Math.abs(domain.values[prev] - elevation) ? index : prev)
-      }, 0)
+      const domain = domainAxisValues[0]
+
+      if (!domain.values) return
+
+      let elevationIndex = 0
+      let closestValue = +domain.values[0]
+      for (let i = 0; i < domain.values.length; i++) {
+        const curr = +domain.values[i];
+
+        if (Math.abs(curr - elevation) < Math.abs(closestValue - elevation)) {
+          closestValue = curr
+          elevationIndex = i
+        }
+      }
 
       const events = timeSeries.domains.slice(1)
       timeSeries.data = events.map((event: any) => {

--- a/src/mixins/TimeSeriesMixin.ts
+++ b/src/mixins/TimeSeriesMixin.ts
@@ -125,11 +125,13 @@ export default class TimeSeriesMixin extends Mixins(PiRequestsMixin) {
         }
       }
 
-      timeSeries.data = timeSeries.domains.slice(1).map(singleDomain => {
-        const e = singleDomain.events![0]
+      const domainsWithoutFirst = timeSeries.domains.slice(1)
+      timeSeries.data = domainsWithoutFirst.map(singleDomain => {
+        const event = singleDomain.events![0]
+        const eventValue = event.values![elevationIndex][0]
         return {
-          x: new Date( parsePiDateTime(e, timeSeries.timeZone? timeSeries.timeZone : 'Z')),
-          y: e.values![elevationIndex][0] === timeSeries.missingValue ? null : +e.values![elevationIndex][0]
+          x: new Date(parsePiDateTime(event, timeSeries.timeZone ?? 'Z')),
+          y: eventValue === timeSeries.missingValue ? null : +eventValue
         }
       })
     }

--- a/src/mixins/TimeSeriesMixin.ts
+++ b/src/mixins/TimeSeriesMixin.ts
@@ -32,7 +32,7 @@ export default class TimeSeriesMixin extends Mixins(PiRequestsMixin) {
   timeSeriesStore: Record<string, Series> = {}
   controller: AbortController = new AbortController
 
-  async updateTimeSeries(requests: ActionRequest[], options?: { startTime: Date, endTime: Date, thinning: boolean}, elevation?: number 
+  async updateTimeSeries(requests: ActionRequest[], options?: { startTime: Date, endTime: Date, thinning: boolean}, elevation?: number
   ): Promise<void> {
     this.controller.abort()
     const baseUrl = this.$config.get('VUE_APP_FEWS_WEBSERVICES_URL')
@@ -67,7 +67,7 @@ export default class TimeSeriesMixin extends Mixins(PiRequestsMixin) {
       const relativeUrl = request.request.split('?')[0] + url.search
       webServiceProvider.getTimeSeriesWithRelativeUrl(relativeUrl).then( piSeries =>
       {
-        if ( piSeries.timeSeries !== undefined)
+        if ( piSeries?.timeSeries !== undefined)
         for (const timeSeries of piSeries.timeSeries) {
           const resource = new SeriesUrlRequest('fews-pi', 'dummyUrl')
           const series = new Series(resource)
@@ -83,7 +83,7 @@ export default class TimeSeriesMixin extends Mixins(PiRequestsMixin) {
             series.header.location = header.stationName
             series.header.source = header.moduleInstanceId
             series.start = new Date(parsePiDateTime(header.startDate, timeZone) )
-            series.end = new Date(parsePiDateTime(header.endDate, timeZone) )            
+            series.end = new Date(parsePiDateTime(header.endDate, timeZone) )
             if (!elevation && timeSeries.events !== undefined) {
               series.data = timeSeries.events.map((event) => {
                 return {
@@ -92,8 +92,8 @@ export default class TimeSeriesMixin extends Mixins(PiRequestsMixin) {
                 }
               })
             } else if (elevation && timeSeries.domains !== undefined && timeSeries) {
-              series.domains = timeSeries.domains   
-              this.updateTimeSeriesWithElevation(series, elevation)           
+              series.domains = timeSeries.domains
+              this.updateTimeSeriesWithElevation(series, elevation)
             } else {
               throw new Error('No data found')
             }
@@ -115,14 +115,14 @@ export default class TimeSeriesMixin extends Mixins(PiRequestsMixin) {
       domain.values = domain.values.map((value: [string]) => {
         return +value[0]
       })
-      // find the index of the closest number to the elevation 
+      // find the index of the closest number to the elevation
       const elevationIndex = domain.values.reduce((prev: number, curr: number, index: number) => {
         return (Math.abs(curr - elevation) < Math.abs(domain.values[prev] - elevation) ? index : prev)
       }, 0)
-      
+
       const events = timeSeries.domains.slice(1)
       timeSeries.data = events.map((event: any) => {
-        const e = event.events[0]                  
+        const e = event.events[0]
         return {
           x: new Date( parsePiDateTime(e, timeSeries.timeZone? timeSeries.timeZone : 'Z')),
           y: e.values[elevationIndex][0] === timeSeries.missingValue ? null : +e.values[elevationIndex][0]

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -85,6 +85,13 @@ export const routesViews: Array<RouteConfig> = [
         component: ComponentsPanel,
         props: route => ({ ...route.params }),
         meta: { authorize: [], sidebar: true }
+      },
+      {
+        path: 'coordinates/:xCoord/:yCoord',
+        name: 'MetocDataViewerWithCoordinates',
+        component: ComponentsPanel,
+        props: route => ({ ...route.params }),
+        meta: { authorize: [], sidebar: true }
       }
     ]
   },

--- a/src/views/MetocDataView.vue
+++ b/src/views/MetocDataView.vue
@@ -7,7 +7,7 @@
       <div class="grid-map" v-show="showMap">
         <div class="map-container">
           <MapComponent>
-            <MapboxLayer v-if="showLayer" :layer="wmsLayerOptions" @doubleClick="onLayerDoubleClick">
+            <MapboxLayer v-if="showLayer" :layer="wmsLayerOptions" @doubleclick="onLayerDoubleClick">
               <ElevationSlider
                 v-if="currentElevation !== null"
                 v-model="currentElevation"
@@ -360,25 +360,22 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
    * @param coordinates coordinates to navigate to.
    */
   setCoordinates(coords: number[]) {
-    if (!coords) {
-      this.closeCharts()
-    } else {
-      const xCoord: string = coords[0].toString()
-      const yCoord: string = coords[1].toString()
+    const xCoord: string = coords[0].toString()
+    const yCoord: string = coords[1].toString()
 
-      if (xCoord === this.xCoord && yCoord === this.yCoord) {
-        return
+    if (xCoord === this.xCoord && yCoord === this.yCoord) {
+      return
+    }
+
+    this.$router.push({
+      name: 'MetocDataViewerWithCoordinates',
+      params: {
+        ...this.$route.params,
+        xCoord,
+        yCoord
       }
-      this.$router.push({
-        name: 'MetocDataViewerWithCoordinates',
-        params: {
-          ...this.$route.params,
-          xCoord,
-          yCoord
-        }
-      })
-    }
-    }
+    })
+  }
 
   /**
    * Updates the locations layers with new GeoJSON data.

--- a/src/views/MetocDataView.vue
+++ b/src/views/MetocDataView.vue
@@ -583,9 +583,13 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
       startTime: this.firstValueTime,
       endTime: this.lastValueTime,
       bbox: bbox,
-      documentFormat: "PI_JSON",
-      showVerticalProfile: !!this.currentWMSLayer?.elevation
+      documentFormat: "PI_JSON"
     }
+
+    if (this.currentElevation !== null) {
+      coordsFilter.elevation = this.currentElevation
+    }
+
     const [displays, requests] = await fetchTimeSeriesDisplaysAndRequests(
       this.webServiceProvider, [coordsFilter]
     )

--- a/src/views/MetocDataView.vue
+++ b/src/views/MetocDataView.vue
@@ -351,6 +351,26 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
     }
   }
 
+  setCoordinates(x: number| null, y: number| null) {
+    if (this.x === x && this.y === y) return
+
+    if (!x || !y) {
+      this.closeCharts()
+    } else {
+      const xCoord: string = x.toString()
+      const yCoord: string = y.toString()
+      console.log(xCoord, yCoord)
+      this.$router.push({
+        name: 'MetocDataViewerWithCoordinates',
+        params: {
+          ...this.$route.params,
+          xCoord,
+          yCoord
+        }
+      })
+    }
+    }
+
   /**
    * Updates the locations layers with new GeoJSON data.
    *
@@ -484,10 +504,10 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
   }
 
   onLayerDoubleClick(event: MapLayerMouseEvent) {
-    console.log('double click', event)
     const mercator = toMercator(point([event.lngLat.lng, event.lngLat.lat]))
-    this.x = mercator.geometry.coordinates[0]
-    this.y = mercator.geometry.coordinates[1]    
+    const x = mercator.geometry.coordinates[0]
+    const y = mercator.geometry.coordinates[1]
+    this.setCoordinates(x, y)    
   }
 
   /**

--- a/src/views/MetocDataView.vue
+++ b/src/views/MetocDataView.vue
@@ -99,7 +99,7 @@ import { Component, Mixins, Prop, Watch } from 'vue-property-decorator'
 
 import type { Location } from "@deltares/fews-pi-requests";
 import { PiWebserviceProvider} from "@deltares/fews-pi-requests";
-import { timeSeriesGridActionsFilter } from "@deltares/fews-pi-requests";
+import { timeSeriesGridActionsFilter, filterActionsFilter } from "@deltares/fews-pi-requests";
 import { ColourMap } from '@deltares/fews-web-oc-charts';
 
 import { DateController } from '@/lib/TimeControl/DateController';
@@ -532,8 +532,15 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
 
     this.selectedLocationId = this.locationId
 
+    const locationFilters = this.currentDataSource.filterIds.map(filterId => {
+      return {
+        filterId: filterId,
+        locationIds: this.locationId
+      }
+    })
+
     const [displays, requests] = await fetchTimeSeriesDisplaysAndRequests(
-      this.webServiceProvider, this.currentDataSource.filterIds, this.locationId
+      this.webServiceProvider, locationFilters
     )
     this.displays = displays
 
@@ -570,7 +577,7 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
       documentFormat: "PI_JSON"
     }    
     const [displays, requests] = await fetchTimeSeriesDisplaysAndRequests(
-      this.webServiceProvider, this.currentDataSource.filterIds, '', coordsFilter
+      this.webServiceProvider, [coordsFilter]
     )
     this.displays = displays
 

--- a/src/views/MetocDataView.vue
+++ b/src/views/MetocDataView.vue
@@ -188,7 +188,7 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
   @Prop({ default: '', type: String }) locationId!: string
   @Prop({ default: '', type: String }) xCoord!: string
   @Prop({ default: '', type: String }) yCoord!: string
-  
+
   webServiceProvider!: PiWebserviceProvider
   categories: Category[] = []
   selectedDataSource: DataSource | null = null
@@ -214,7 +214,7 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
   currentElevation: number|null = 0
   minElevation: number|null = 0
   maxElevation: number|null = 0
-  
+
   selectedLocationId: string | null = null
   locations: Location[] = []
   showLocationsLayer = true
@@ -284,10 +284,10 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
         name: this.currentDataSource.wmsLayerId,
         time: this.currentTime
       }
-      
+
         this.maxElevation = this.currentWMSLayer?.elevation?.upperValue ?? null
         this.minElevation = this.currentWMSLayer?.elevation?.lowerValue ?? null
-        this.wmsLayerOptions.elevation = this.currentElevation      
+        this.wmsLayerOptions.elevation = this.currentElevation
     }
   }
 
@@ -338,7 +338,7 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
    */
   setLocation(locationId: string | null): void {
     // We don't need to do anything if we are already at this locationId.
-        if (this.locationId === locationId) return
+    if (this.locationId === locationId) return
 
     if (!locationId) {
       this.closeCharts()
@@ -355,9 +355,9 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
 
   /**
    * Sets the coordinates to navigate to, opening the appropriate chart panel.
-   * 
+   *
    * This updates the route, thus spawning the chart panel.
-   * 
+   *
    * @param coordinates coordinates to navigate to.
    */
   setCoordinates() {
@@ -417,6 +417,10 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
    * without the chart panel.
    */
   closeCharts(): void {
+    if (!this.hasSelectedCoordinates && !this.hasSelectedLocation) {
+      return
+    }
+
     const params = { ...this.$route.params }
     if (this.hasSelectedLocation) {
       // Remove the locationId from the parameters.
@@ -461,10 +465,10 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
     this.dateController.dates = this.times
     this.dateController.selectDate(this.currentTime ?? new Date())
     this.currentTime = this.dateController.currentTime
-    
+
     // Select the elevation if present
     this.currentElevation = this.currentWMSLayer?.elevation?.upperValue ?? null
-    
+
     this.setWMSLayerOptions()
 
     // Update the WMS layer legend.
@@ -472,7 +476,7 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
     this.unit = legend.unit ?? '—'
     this.legend = legend.legend
     this.legendTitle = `${this.currentWMSLayer?.title} [${this.unit}]`
-    
+
     // Update locations for the current data source.
     const geojson = await fetchLocationsAsGeoJson(
       this.webServiceProvider, this.currentDataSource.filterIds
@@ -570,9 +574,9 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
     }
     // convert BoundingBox to bbox
     const bbox = [
-      Number(this.currentWMSLayer?.boundingBox.minx), 
-      Number(this.currentWMSLayer?.boundingBox.miny), 
-      Number(this.currentWMSLayer?.boundingBox.maxx), 
+      Number(this.currentWMSLayer?.boundingBox.minx),
+      Number(this.currentWMSLayer?.boundingBox.miny),
+      Number(this.currentWMSLayer?.boundingBox.maxx),
       Number(this.currentWMSLayer?.boundingBox.maxy)
   ]
     const coordsFilter: timeSeriesGridActionsFilter = {
@@ -584,7 +588,7 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
       bbox: bbox,
       documentFormat: "PI_JSON",
       showVerticalProfile: this.currentWMSLayer?.elevation ? true : false
-    } 
+    }
     const [displays, requests] = await fetchTimeSeriesDisplaysAndRequests(
       this.webServiceProvider, [coordsFilter]
     )
@@ -620,15 +624,15 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
 
   /**
    * Updates the route upon double clicking a location.
-   * 
+   *
    * This effectively rerenders this component with the coordinates set.
-   * 
+   *
    * @param event location layer double click event.
    */
   onLayerDoubleClick(event: MapLayerMouseEvent) {
     const mercator = toMercator(point([event.lngLat.lng, event.lngLat.lat]))
     this.coordinates = [mercator.geometry.coordinates[0], mercator.geometry.coordinates[1]]
-    this.setCoordinates()    
+    this.setCoordinates()
   }
 
   /**
@@ -644,7 +648,7 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
   }
 
   get currentDataLayer(): DataLayer | null {
-    
+
     if (!this.currentCategory) return null
 
     return this.currentCategory.dataLayers.find(dataLayer => dataLayer.id === this.dataLayerId) ?? null
@@ -688,7 +692,7 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
   }
 
   get hasSelectedCoordinates(): boolean {
-    return this.coordinates !== null 
+    return this.coordinates !== null
   }
 
   get selectedLocationFilter(): Expression {

--- a/src/views/MetocDataView.vue
+++ b/src/views/MetocDataView.vue
@@ -241,6 +241,7 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
     // potentially data source.
     await this.onDataSourceChange()
     await this.onLocationChange()
+    await this.onCoordinatesChange()
 
     // Force resize to fix strange starting position of the map, caused by the expandable navigation
     // drawer.

--- a/src/views/MetocDataView.vue
+++ b/src/views/MetocDataView.vue
@@ -561,8 +561,7 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
    * Updates the chart panel for newly selected coordinates.
    */
 
-  @Watch('xCoord')
-  @Watch('yCoord')
+  @Watch('xCoordyCoordcurrentElevation')
   async onCoordinatesChange(): Promise<void> {
 
     if (!this.coordinates || !this.currentDataSource || !this.firstValueTime || !this.lastValueTime || !this.currentWMSLayer?.boundingBox) {
@@ -583,15 +582,16 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
       startTime: this.firstValueTime,
       endTime: this.lastValueTime,
       bbox: bbox,
-      documentFormat: "PI_JSON"
-    }    
+      documentFormat: "PI_JSON",
+      showVerticalProfile: this.currentWMSLayer?.elevation ? true : false
+    } 
     const [displays, requests] = await fetchTimeSeriesDisplaysAndRequests(
       this.webServiceProvider, [coordsFilter]
     )
     this.displays = displays
 
     // Fetch time series for all displays.
-    await this.updateTimeSeries(requests)
+    await this.updateTimeSeries(requests, undefined ,this.currentElevation ? this.currentElevation : undefined)
 
     this.onResize()
   }
@@ -693,6 +693,10 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
 
   get selectedLocationFilter(): Expression {
     return ['==', 1, 0]
+  }
+
+  get xCoordyCoordcurrentElevation(): string {
+    return `${this.xCoord}, ${this.yCoord}, ${this.currentElevation}`
   }
 }
 

--- a/src/views/MetocDataView.vue
+++ b/src/views/MetocDataView.vue
@@ -218,8 +218,7 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
   locationsLayerOptions: CircleLayer = {...defaultLocationsLayerOptions}
   selectedLocationsLayerOptions: CircleLayer = {...selectedLocationsLayerOptions}
 
-  x: number|null = null
-  y: number|null = null
+  coordinates: number[] | null = null
 
   async mounted() {
     // Create FEWS PI Webservices provider.
@@ -351,11 +350,11 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
     }
   }
   setCoordinates() {
-    if (!this.x || !this.y) {
+    if (!this.coordinates) {
       this.closeCharts()
     } else {
-      const xCoord: string = this.x.toString()
-      const yCoord: string = this.y.toString()
+      const xCoord: string = this.coordinates[0].toString()
+      const yCoord: string = this.coordinates[1].toString()
       this.$router.push({
         name: 'MetocDataViewerWithCoordinates',
         params: {
@@ -417,8 +416,7 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
       })
     }
     if(this.hasSelectedCoordinates) {
-      this.x = null
-      this.y = null
+      this.coordinates = null
       const params = { ...this.$route.params }
       delete params.xCoord
       delete params.yCoord
@@ -512,8 +510,7 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
 
   onLayerDoubleClick(event: MapLayerMouseEvent) {
     const mercator = toMercator(point([event.lngLat.lng, event.lngLat.lat]))
-    this.x = mercator.geometry.coordinates[0]
-    this.y = mercator.geometry.coordinates[1]
+    this.coordinates = [mercator.geometry.coordinates[0], mercator.geometry.coordinates[1]]
     this.setCoordinates()    
   }
 
@@ -622,7 +619,7 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
   }
 
   get hasSelectedCoordinates(): boolean {
-    return this.x !== null && this.y !== null
+    return this.coordinates !== null 
   }
 
   get selectedLocationFilter(): Expression {

--- a/src/views/MetocDataView.vue
+++ b/src/views/MetocDataView.vue
@@ -584,7 +584,7 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
       endTime: this.lastValueTime,
       bbox: bbox,
       documentFormat: "PI_JSON",
-      showVerticalProfile: this.currentWMSLayer?.elevation ? true : false
+      showVerticalProfile: !!this.currentWMSLayer?.elevation
     }
     const [displays, requests] = await fetchTimeSeriesDisplaysAndRequests(
       this.webServiceProvider, [coordsFilter]

--- a/src/views/MetocDataView.vue
+++ b/src/views/MetocDataView.vue
@@ -349,6 +349,14 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
       })
     }
   }
+
+  /**
+   * Sets the coordinates to navigate to, opening the appropriate chart panel.
+   * 
+   * This updates the route, thus spawning the chart panel.
+   * 
+   * @param coordinates coordinates to navigate to.
+   */
   setCoordinates() {
     if (!this.coordinates) {
       this.closeCharts()
@@ -508,12 +516,6 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
     }
   }
 
-  onLayerDoubleClick(event: MapLayerMouseEvent) {
-    const mercator = toMercator(point([event.lngLat.lng, event.lngLat.lat]))
-    this.coordinates = [mercator.geometry.coordinates[0], mercator.geometry.coordinates[1]]
-    this.setCoordinates()    
-  }
-
   /**
    * Updates the chart panel for a newly selected location.
    */
@@ -539,6 +541,14 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
 
     this.onResize()
   }
+  /**
+   * Updates the chart panel for newly selected coordinates.
+   */
+
+  @Watch('coordinates')
+  async onCoordinatesChange(): Promise<void> {
+    //
+  }
 
   /**
    * Updates the chart panel for a location selected from the locations control.
@@ -560,6 +570,19 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin) {
     const locationId: string | null = event.features[0].properties?.locationId ?? null
 
     this.setLocation(locationId)
+  }
+
+  /**
+   * Updates the route upon double clicking a location.
+   * 
+   * This effectively rerenders this component with the coordinates set.
+   * 
+   * @param event location layer double click event.
+   */
+  onLayerDoubleClick(event: MapLayerMouseEvent) {
+    const mercator = toMercator(point([event.lngLat.lng, event.lngLat.lat]))
+    this.coordinates = [mercator.geometry.coordinates[0], mercator.geometry.coordinates[1]]
+    this.setCoordinates()    
   }
 
   /**


### PR DESCRIPTION
Still to do:

- [ ] In `MetocDataView` execute `onCoordinatesChange` only when the coordinates change, add another watch for when the elevation changes and call `updateTimeSeriesWithElevation`  . This should improve the performance of the slider. It should look something like this, (but this doesn't work)
```
  @Watch('currentElevation')
  onCurrentElevationChange(): void {
    if (!this.currentElevation) return
    for (const resourceId in this.timeSeriesStore) {
      const series = this.timeSeriesStore[resourceId];
      this.updateTimeSeriesWithElevation(series, this.currentElevation)
      Vue.set(this.timeSeriesStore, resourceId, series)
    }
  }
```
- [x] there seem to be some problems with coordinates route, some errors are printed and if the coordinates values are inserted via the searchbar the plots are not shown.
- [x] whenever the user switches between layers, the window with the coordinates plot is not closed.
- [x] whenever the user clicks on coordinates on the map a point should appear. 
- [ ] set coordinates as title
- [ ] show vertical profile
- [ ] update chart legend