### PR TITLE
223 disable reshaping of drawrectanglemode

### DIFF
--- a/src/components/Regridder.vue
+++ b/src/components/Regridder.vue
@@ -114,6 +114,13 @@ export default class Regridder extends Mixins(PiRequestsMixin) {
       defaultMode: 'simple_select',
     })
 
+    const SimpleSelectMode = MapboxDraw.modes.simple_select as any
+    SimpleSelectMode.clickOnVertex = () => undefined
+
+    const DirectSelectMode = MapboxDraw.modes.direct_select as any;
+    DirectSelectMode.onMidpoint = () => undefined
+    DirectSelectMode.onVertex = () => undefined
+
     this.mapObject.addControl(this.draw)
     this.mapObject.on('draw.create', this.select)
 

--- a/src/components/Regridder.vue
+++ b/src/components/Regridder.vue
@@ -115,7 +115,12 @@ export default class Regridder extends Mixins(PiRequestsMixin) {
     })
 
     const SimpleSelectMode = MapboxDraw.modes.simple_select as any
+
     SimpleSelectMode.clickOnVertex = () => undefined
+
+    SimpleSelectMode.toDisplayFeatures = function(state: any, geojson: any, display: any) {
+      display(geojson)
+    }
 
     const DirectSelectMode = MapboxDraw.modes.direct_select as any;
     DirectSelectMode.onMidpoint = () => undefined

--- a/src/components/Regridder.vue
+++ b/src/components/Regridder.vue
@@ -114,20 +114,14 @@ export default class Regridder extends Mixins(PiRequestsMixin) {
       defaultMode: 'simple_select',
     })
 
-    const SimpleSelectMode = MapboxDraw.modes.simple_select as any
-
-    SimpleSelectMode.clickOnVertex = () => undefined
-
-    SimpleSelectMode.toDisplayFeatures = function(state: any, geojson: any, display: any) {
-      display(geojson)
-    }
-
-    const DirectSelectMode = MapboxDraw.modes.direct_select as any;
-    DirectSelectMode.onMidpoint = () => undefined
-    DirectSelectMode.onVertex = () => undefined
 
     this.mapObject.addControl(this.draw)
     this.mapObject.on('draw.create', this.select)
+    this.mapObject.on("draw.modechange", (e) => {
+      if (e.mode === "direct_select") {
+        this.draw.changeMode("simple_select")
+      }
+    })
 
     const trashElement = document.querySelector(".mapbox-gl-draw_trash") as HTMLElement
     if (trashElement) {


### PR DESCRIPTION
Only disables the reshaping by never changing from `simple_select` to `direct_select`.
Does not make reshaping confined to a rectangle which would be nice in the future.