### PR TITLE
Convert date/time slider to Vue3

### DIFF
--- a/src/components/general/DateTimeSlider.vue
+++ b/src/components/general/DateTimeSlider.vue
@@ -52,22 +52,21 @@ interface Properties {
   dates: Date[]
   isLoading?: boolean
   doFollowNow?: boolean
+  playInterval?: number
+  followNowInterval?: number
 }
 
 const props = withDefaults(defineProps<Properties>(), {
   isLoading: false,
   doFollowNow: false,
+  playInterval: 1000,
+  followNowInterval: 10000,
 })
 const emit = defineEmits(['update:selectedDate', 'update:doFollowNow'])
 
 // Step size when playing an animation, and when clicking the previous and next frame buttons.
 const playIncrement = 1
 const stepIncrement = 1
-// Interval between frame updates in playback mode.
-const playInterval = 1000
-// Interval between time updates when "follow now" is enabled.
-const followNowInterval = 10000
-
 const dateIndex = ref(0)
 
 const isPlaying = ref(false)
@@ -98,10 +97,13 @@ watch(
 
 // When the input dates change, make sure the selected index is updated to point to the correct
 // member of the new dates array.
-watch(() => props.dates, (_, oldDates) => {
-  const oldDate = oldDates[dateIndex.value]
-  dateIndex.value = findIndexForDate(oldDate)
-})
+watch(
+  () => props.dates,
+  (_, oldDates) => {
+    const oldDate = oldDates[dateIndex.value]
+    dateIndex.value = findIndexForDate(oldDate)
+  },
+)
 
 const maxIndex = computed(() => Math.max(props.dates.length - 1, 0))
 
@@ -136,7 +138,7 @@ function startFollowNow(): void {
   doFollowNow.value = true
   stopPlay()
   setDateToNow()
-  followNowIntervalTimer = setInterval(setDateToNow, followNowInterval)
+  followNowIntervalTimer = setInterval(setDateToNow, props.followNowInterval)
 }
 
 function stopFollowNow(): void {
@@ -172,7 +174,7 @@ function togglePlay(): void {
 function startPlay(): void {
   isPlaying.value = true
   stopFollowNow()
-  playIntervalTimer = setInterval(play, playInterval)
+  playIntervalTimer = setInterval(play, props.playInterval)
 }
 
 function stopPlay(): void {

--- a/src/components/general/DateTimeSlider.vue
+++ b/src/components/general/DateTimeSlider.vue
@@ -1,0 +1,216 @@
+<template>
+  <div class="slider-container">
+    <v-slider
+      v-model="dateIndex"
+      :max="maxIndex"
+      step="1"
+      hide-details
+      thumb-size="15"
+    />
+  </div>
+  <div class="controls-container">
+    <slot name="prepend"></slot>
+    <div class="now-tracking-control">
+      <v-btn
+        density="compact"
+        :icon="nowButtonIcon"
+        :color="nowButtonColor"
+        @click="toggleFollowNow"
+      />
+      <span class="text-body-2 selected-date">{{ dateString }}</span>
+    </div>
+    <v-spacer />
+    <div class="play-controls">
+      <v-btn
+        density="compact"
+        icon="mdi-skip-previous"
+        @mousedown="stepBackward"
+        @mouseup="stopPlay"
+      />
+      <v-btn
+        density="compact"
+        :icon="playButtonIcon"
+        :color="playButtonColor"
+        @click="togglePlay"
+      />
+      <v-btn
+        density="compact"
+        icon="mdi-skip-next"
+        @mousedown="stepForward"
+        @mouseup="stopPlay"
+      />
+    </div>
+    <slot name="append"></slot>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+
+interface Properties {
+  selectedDate: Date
+  dates: Date[]
+  isLoading?: boolean
+  doFollowNow?: boolean
+}
+
+const props = withDefaults(defineProps<Properties>(), {
+  isLoading: false,
+  doFollowNow: false,
+})
+const emit = defineEmits(['update:selectedDate', 'update:doFollowNow'])
+
+// Step size when playing an animation, and when clicking the previous and next frame buttons.
+const playIncrement = 1
+const stepIncrement = 1
+// Interval between frame updates in playback mode.
+const playInterval = 1000
+
+const isPlaying = ref(false)
+let playIntervalTimer: ReturnType<typeof setInterval> | null = null
+
+const dateIndex = ref(0)
+const doFollowNow = ref(props.doFollowNow)
+
+// Synchronise selectedDate property and local index variable.
+watch(dateIndex, (index) => emit('update:selectedDate', props.dates[index]))
+watch(
+  () => props.selectedDate,
+  (selectedDate) => {
+    dateIndex.value = findIndexForDate(selectedDate)
+  },
+)
+
+// Synchronise doFollowNow property and local variable.
+watch(doFollowNow, (doFollowNow) => {
+  emit('update:doFollowNow', doFollowNow)
+})
+watch(
+  () => props.doFollowNow,
+  (doFollowNowProp) => {
+    doFollowNow.value = doFollowNowProp
+  },
+)
+
+const maxIndex = computed(() => Math.max(props.dates.length - 1, 0))
+
+// Now and play button styling is dependent on properties.
+const nowButtonIcon = computed(() =>
+  props.isLoading ? 'mdi-loading mdi-spin' : 'mdi-clock',
+)
+const playButtonIcon = computed(() =>
+  isPlaying.value ? 'mdi-pause' : 'mdi-play',
+)
+const nowButtonColor = computed(() =>
+  doFollowNow.value ? 'orange' : undefined,
+)
+const playButtonColor = computed(() => (isPlaying.value ? 'orange' : undefined))
+
+const dateString = computed(() =>
+  props.dates[dateIndex.value]
+    ? props.dates[dateIndex.value].toLocaleString()
+    : '',
+)
+
+function toggleFollowNow(): void {
+  setDoFollowNow(!doFollowNow.value)
+}
+
+function setDoFollowNow(newDoFollowNow: boolean): void {
+  doFollowNow.value = newDoFollowNow
+  if (newDoFollowNow) setDateToNow()
+}
+
+function setDateToNow(): void {
+  const now = new Date()
+  dateIndex.value = findIndexForDate(now)
+}
+
+function findIndexForDate(date: Date): number {
+  const index = props.dates.findIndex((current) => current >= date)
+  if (index === -1) {
+    // No time was found that was larger than the current time, so use the last date.
+    return maxIndex.value
+  } else {
+    return index
+  }
+}
+
+function togglePlay(): void {
+  isPlaying.value = !isPlaying.value
+  if (isPlaying.value) {
+    startPlay()
+  } else {
+    stopPlay()
+  }
+}
+
+function startPlay(): void {
+  isPlaying.value = true
+  setDoFollowNow(false)
+  playIntervalTimer = setInterval(play, playInterval)
+}
+
+function stopPlay(): void {
+  isPlaying.value = false
+  if (playIntervalTimer) {
+    clearInterval(playIntervalTimer)
+    playIntervalTimer = null
+  }
+}
+
+function play(): void {
+  increment(playIncrement)
+  if (dateIndex.value === maxIndex.value) {
+    stopPlay()
+  }
+}
+
+function stepBackward(): void {
+  setDoFollowNow(false)
+  decrement(stepIncrement)
+}
+
+function stepForward(): void {
+  setDoFollowNow(false)
+  increment(stepIncrement)
+}
+
+function decrement(step: number): void {
+  dateIndex.value = Math.max(dateIndex.value - step, 0)
+}
+
+function increment(step: number): void {
+  dateIndex.value = Math.min(dateIndex.value + step, maxIndex.value)
+}
+</script>
+
+<style>
+.slider-container {
+  padding: 0px 10px;
+}
+
+.controls-container {
+  display: flex;
+  flex-direction: row;
+  padding: 0 16px 10px;
+}
+
+.selected-date {
+  margin: auto;
+  width: 30ch;
+  flex: 2 0 20%;
+}
+
+.now-tracking-control {
+  display: flex;
+  flex-direction: row;
+  gap: 15px;
+}
+
+.play-controls {
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+}
+</style>

--- a/src/components/general/DateTimeSlider.vue
+++ b/src/components/general/DateTimeSlider.vue
@@ -92,6 +92,13 @@ watch(
   },
 )
 
+// When the input dates change, make sure the selected index is updated to point to the correct
+// member of the new dates array.
+watch(() => props.dates, (_, oldDates) => {
+  const oldDate = oldDates[dateIndex.value]
+  dateIndex.value = findIndexForDate(oldDate)
+})
+
 const maxIndex = computed(() => Math.max(props.dates.length - 1, 0))
 
 // Now and play button styling is dependent on properties.


### PR DESCRIPTION
It also has new functionality compared to the old version:

- tracking of the current time is now done inside the date/time slider, instead of in the component that uses it;
- when the `dates` property is updated, the currently selected time is update to the closest value in the new `dates` array.

This reduces a lot of code duplication of date/time code in the components that use the date/time slider.