### PR TITLE
Make date/time slider "floating"

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -119,4 +119,17 @@ html, body {
   outline-offset: -1px;
 }
 
+/* Hacky way to get the Mapbox logo and attribution control to not be hidden behind the floating
+   date/time slider for the Data View and Spatial Display. */
+.mapboxgl-ctrl-logo {
+  position: relative;
+  left: 8px;
+  bottom: 70px;
+}
+
+.mapboxgl-ctrl-attrib {
+  position: relative;
+  bottom: 70px;
+  right: 15px;
+}
 </style>

--- a/src/components/DateTimeSlider.vue
+++ b/src/components/DateTimeSlider.vue
@@ -1,5 +1,8 @@
 <template>
-  <div>
+  <div
+    class="time-slider-container"
+    :class="[themeClass, floatingClass]"
+  >
     <v-slider v-model="index" :max="max" step="1" tick-size="6" tabindex="0" @input="onInput" hide-details
       height="0">
     </v-slider>
@@ -47,6 +50,7 @@ export default class DateTimeSlider extends Vue {
   @Prop({ default: () => { return [new Date(1970)] } }) private dates!: Date[]
   @Prop({ default: false, type: Boolean }) private loading!: boolean
   @Prop({ default: false, type: Boolean }) private now!: boolean
+  @Prop({ default: false, type: Boolean }) private floating!: boolean
 
   index: number = 0
   currentDate!: Date
@@ -75,6 +79,14 @@ export default class DateTimeSlider extends Vue {
 
   get playColor (): string {
     return this.isPlaying ? 'orange' : ''
+  }
+
+  get themeClass (): string {
+    return this.$vuetify.theme.dark ? 'dark' : 'light'
+  }
+
+  get floatingClass (): string {
+    return this.floating ? 'floating' : 'non-floating'
   }
 
   togglePlay (): void {
@@ -183,8 +195,22 @@ export default class DateTimeSlider extends Vue {
 }
 </script>
 <style scoped>
-.time-slider-container {
-  height: 104px;
-  z-index: 100;
+.time-slider-container.non-floating {
+  height: 48px;
+}
+
+.time-slider-container.floating {
+  height: 63px;
+  background-clip: content-box;
+  padding: 0 15px 15px;
+  filter: drop-shadow(3px 3px 3px #888);
+}
+
+.time-slider-container.dark {
+  background-color: black;
+}
+
+.time-slider-container.light {
+  background-color: white;
 }
 </style>

--- a/src/views/DataView.vue
+++ b/src/views/DataView.vue
@@ -549,6 +549,7 @@ export default class DataView extends Mixins(WMSMixin, TimeSeriesMixin, PiReques
   }
 
   .grid-map {
+    position: relative;
     display: flex;
     flex-basis: 400px;
     flex: 1 1 auto;
@@ -653,16 +654,11 @@ export default class DataView extends Mixins(WMSMixin, TimeSeriesMixin, PiReques
     height: 100%;
   }
 
-  .datetime-control-container {
-    flex-grow: 0;
-    z-index: 1000;
-  }
-
   .date-time-slider {
     position: absolute;
     bottom: 0px;
     left: 0px;
-    width: 100%;
+    right: 0px;
     z-index: 100;
   }
 

--- a/src/views/DataView.vue
+++ b/src/views/DataView.vue
@@ -41,7 +41,7 @@
     </portal>
     <div class="grid-root" :class="layoutClass">
       <div class="grid-map" v-show="showMap">
-        <div class="map-container" style="height: calc(100% - 48px); position: relative;">
+        <div class="map-container">
           <MapComponent>
             <MapboxLayer v-if="showLayer" :layer="layerOptions"></MapboxLayer>
             <v-mapbox-layer v-if="showLocationsLayer" :options="locationsLayer" clickable @click="onLocationClick"></v-mapbox-layer>
@@ -61,9 +61,15 @@
             <LocationsLayerControl v-model="showLocationsLayer"/>
           </v-chip-group>
         </div>
-        <DateTimeSlider class="date-time-slider" v-model="currentTime" :dates="times" @update:now="setCurrentTime"
-          @input="debouncedSetLayerOptions" @timeupdate="updateTime">
-        </DateTimeSlider>
+        <DateTimeSlider
+          class="date-time-slider"
+          v-model="currentTime"
+          :dates="times"
+          @update:now="setCurrentTime"
+          @input="debouncedSetLayerOptions"
+          @timeupdate="updateTime"
+          floating
+        />
       </div>
       <div class="grid-charts" ref="grid-charts" v-if="hasSelectedLocation && !$vuetify.breakpoint.mobile">
         <v-toolbar class="toolbar-charts" dense flat>
@@ -643,8 +649,7 @@ export default class DataView extends Mixins(WMSMixin, TimeSeriesMixin, PiReques
   }
 
   .map-container {
-    display: flex;
-    flex: 1 1;
+    width: 100%;
     height: 100%;
   }
 
@@ -653,16 +658,24 @@ export default class DataView extends Mixins(WMSMixin, TimeSeriesMixin, PiReques
     z-index: 1000;
   }
 
-.v-list-item--dense, .v-list--dense .v-list-item {
-  min-height: 28px !important;
-}
+  .date-time-slider {
+    position: absolute;
+    bottom: 0px;
+    left: 0px;
+    width: 100%;
+    z-index: 100;
+  }
 
-.v-treeview--dense .v-treeview-node__root {
-  min-height: 28px !important;
-}
+  .v-list-item--dense, .v-list--dense .v-list-item {
+    min-height: 28px !important;
+  }
 
-.v-treeview-node__level {
-  width: 12px !important;
-}
+  .v-treeview--dense .v-treeview-node__root {
+    min-height: 28px !important;
+  }
+
+  .v-treeview-node__level {
+    width: 12px !important;
+  }
 
 </style>

--- a/src/views/MetocDataView.vue
+++ b/src/views/MetocDataView.vue
@@ -43,6 +43,7 @@
           :dates="times"
           @input="debouncedSetWMSLayerOptions"
           @update:now="setCurrentTime"
+          floating
         />
         <div class="colourbar">
           <ColourBar v-model="legend" v-if="legend.length > 0"/>
@@ -645,5 +646,13 @@ export default class MetocDataView extends Mixins(WMSMixin, TimeSeriesMixin, PiR
   position: absolute;
   top: 0px;
   left: -15px;
+}
+
+.date-time-slider {
+  position: absolute;
+  bottom: 0px;
+  left: 0px;
+  width: 100%;
+  z-index: 100;
 }
 </style>

--- a/src/views/SpatialDisplay.vue
+++ b/src/views/SpatialDisplay.vue
@@ -26,7 +26,7 @@
         :open.sync="open"
       />
     </portal>
-    <div style="height: calc(100% - 48px); position: relative">
+    <div class="map-container">
       <MapComponent>
         <MapboxLayer :layer="layerOptions" />
       </MapComponent>
@@ -34,9 +34,15 @@
         <ColourBar v-model="legend" v-if="legend.length > 0"/>
       </div>
     </div>
-    <DateTimeSlider class="date-time-slider" v-model="currentTime" :dates="times" @update:now="setCurrentTime"
-      @input="debouncedSetLayerOptions" @timeupdate="updateTime">
-    </DateTimeSlider>
+    <DateTimeSlider
+      class="date-time-slider"
+      v-model="currentTime"
+      :dates="times"
+      @update:now="setCurrentTime"
+      @input="debouncedSetLayerOptions"
+      @timeupdate="updateTime"
+      floating
+    />
   </div>
 </template>
 
@@ -220,6 +226,19 @@ export default class SpatialDisplay extends Mixins(WMSMixin) {
     width: 500px;
     height: 100px;
     position: absolute;
-    bottom: 10px;
+    bottom: 85px;
+  }
+
+  .map-container {
+    width: 100%;
+    height: 100%;
+  }
+
+  .date-time-slider {
+    position: absolute;
+    bottom: 0px;
+    left: 0px;
+    width: 100%;
+    z-index: 100;
   }
 </style>


### PR DESCRIPTION
Similar to #196, but that one is waiting until `@deltares/fews-web-oc-components` works properly. Something is currently still going wrong with exporting the Vue component.

For this release, we can merge the date/time slider changes in the main repo? After the Vue 3 migration, we can then (finally) start using the components library...