### PR TITLE
Add tooltip edit for depth slider

### DIFF
--- a/src/components/ElevationSlider.vue
+++ b/src/components/ElevationSlider.vue
@@ -17,6 +17,8 @@
             @keydown.enter.stop="acceptTooltipEdit"
             @blur="acceptTooltipEdit"
             v-model.number="currentTooltipValue"
+            hide-spin-buttons
+            hide-details
             type="number"
             class="tooltip-input"
           />
@@ -72,6 +74,9 @@ export default class ElevationSlider extends Vue {
     this.$nextTick(() => {
       const tooltipInputRef = this.$refs.tooltipInput as HTMLElement
       tooltipInputRef.focus()
+
+      const sliderRef = this.$refs.slider as VueSlider
+      sliderRef.blur()
     })
   }
 
@@ -144,7 +149,7 @@ export default class ElevationSlider extends Vue {
 }
 
 .tooltip-input {
-  width: 70px;
+  width: 50px;
   height: 40px;
   margin: 0;
   padding: 0;

--- a/src/components/ElevationSlider.vue
+++ b/src/components/ElevationSlider.vue
@@ -6,15 +6,14 @@
       :min="minValue"
       :marks="marks"
       :interval="interval"
-      :keydownHook="onKeydown"
+      :keydownHook="onSliderKeydown"
       v-on:change="onInputChange"
       :hideLabel="true"
       lazy direction="btt" tooltip="always" tooltipPlacement="left" height="200px" ref="slider">
       <template v-slot:tooltip>
         <div class="vue-slider-dot-tooltip-inner vue-slider-dot-tooltip-inner-left vue-slider-dot-tooltip-text" >
           <v-text-field ref="tooltipInput" v-if="isEditingTooltip"
-            @keydown.escape.stop="disableTooltipEdit"
-            @keydown.enter.stop="acceptTooltipEdit"
+            @keydown.stop="onTooltipKeydown"
             @blur="acceptTooltipEdit"
             v-model.number="currentTooltipValue"
             hide-spin-buttons
@@ -102,7 +101,18 @@ export default class ElevationSlider extends Vue {
     this.currentValue = this.value
   }
 
-  onKeydown(e: KeyboardEvent) {
+  onTooltipKeydown(e: KeyboardEvent) {
+    switch (e.key) {
+      case "Enter":
+        this.acceptTooltipEdit()
+        break;
+      case "Escape":
+        this.disableTooltipEdit()
+        break;
+    }
+  }
+
+  onSliderKeydown(e: KeyboardEvent) {
     let newValue: number | undefined = 0;
 
     switch (e.key) {


### PR DESCRIPTION
Closes #329 

# Preview
![image](https://github.com/Deltares/fews-web-oc/assets/144685504/76baf694-61d6-4476-a87e-14517669c2e6)

# Controls
When slider focused press enter to enable input
When input focused press enter to accept new value
When input focused click outside element to accept new value
When input focused press esc to cancel

Focus switches between slider and input allowing for constant keyboard usage