### PR TITLE
Make the v-chip-group mandatory

### DIFF
--- a/src/components/DataSourceControl.vue
+++ b/src/components/DataSourceControl.vue
@@ -7,6 +7,7 @@
       v-model="selected"
       @change="onChangeSelection"
       active-class="primary--text"
+      mandatory
     >
       <v-chip
         v-for="item in items"


### PR DESCRIPTION
It should always have one chip selected
Fixes #361