### PR TITLE
Also Hide splashscreen when clicking on it

### DIFF
--- a/src/components/SplashScreen.vue
+++ b/src/components/SplashScreen.vue
@@ -1,6 +1,6 @@
 <template>
   <v-dialog v-model="showDialog" max-width="900">
-    <v-card v-if="!showDisclaimer">
+    <v-card v-if="!showDisclaimer" @click="showDialog = false">
       <v-img :src="splashUrl" />
       <a class="terms-of-use-link" @click="showDisclaimer = true">Terms of Use</a>
     </v-card>


### PR DESCRIPTION
closes #367 

Only adds this for splashscreen.
When going to the terms of use you still need to press outside it.
