### PR TITLE
Fix colourbar infinite loop

### DIFF
--- a/src/components/ColourBar.vue
+++ b/src/components/ColourBar.vue
@@ -69,8 +69,8 @@ export default class ColourBar extends Vue {
     const firstChild = d3.select("#colourbar > g > g.axis").selectChild()
     const lastChild = d3.select("#colourbar > g > g.axis").selectChild(':last-child')
 
-    this.range.min = firstChild.selectChild("text").property("innerHTML")
-    this.range.max = lastChild.selectChild("text").property("innerHTML")
+    this.range.min = this.value[0].lowerValue
+    this.range.max = this.value[this.value.length - 1].lowerValue
 
     firstChild.on('click', () => this.isEditingMin = true)
     lastChild.on('click', () => this.isEditingMax = true)


### PR DESCRIPTION
Closes #497 

Happened when rendered numbers where not scale range max
![image](https://github.com/Deltares/fews-web-oc/assets/144685504/af85c88c-7d12-4a47-ac3a-36f73979c304)

When clicking on `77.9` the input still shows up slightly to the right
![image](https://github.com/Deltares/fews-web-oc/assets/144685504/63209f25-747b-4a68-a741-68eb67062810)
