### PR TITLE
584 fix topology display router issues

### DIFF
--- a/src/components/spatialdisplay/SpatialDisplayComponent.vue
+++ b/src/components/spatialdisplay/SpatialDisplayComponent.vue
@@ -130,16 +130,21 @@ const legendTitle = computed(() => {
   return `${selectedLayer.value?.title}${unitString}`
 })
 
-watch(times, () => {
-  const timesValue = times.value
-  if (timesValue) {
-    times.value = timesValue
-    dateController.dates = timesValue
-    dateController.selectDate(currentTime.value)
-    currentTime.value = dateController.currentTime
-  }
-  setLayerOptions()
-})
+watch(
+  times,
+  () => {
+    const timesValue = times.value
+    if (timesValue) {
+      times.value = timesValue
+      dateController.dates = timesValue
+      dateController.selectDate(currentTime.value)
+      currentTime.value = dateController.currentTime
+    }
+    setLayerOptions()
+  },
+
+  { immediate: true },
+)
 
 function setCurrentTime(enabled: boolean): void {
   if (enabled) {

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -175,9 +175,10 @@ function recursiveUpdateNode(nodes: TopologyNode[], skipLeaves = false) {
         icon: getIcon(node),
         href: getUrl(node),
         to: {
-          name: 'TopologyDisplay',
+          name: 'TopologySpatialDisplay',
           params: {
             nodeId: node.id,
+            layerName: node.gridDisplaySelection?.plotId
           },
         },
       }
@@ -203,9 +204,10 @@ function nodeButtonItems(nodes: TopologyNode[]) {
         name: node.name,
         icon: getIcon(node),
         to: {
-          name: 'TopologyDisplay',
+          name: 'TopologySpatialDisplay',
           params: {
             nodeId: node.id,
+            layerName: node.gridDisplaySelection?.plotId
           },
         },
       }

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -178,7 +178,7 @@ function recursiveUpdateNode(nodes: TopologyNode[], skipLeaves = false) {
           name: 'TopologySpatialDisplay',
           params: {
             nodeId: node.id,
-            layerName: node.gridDisplaySelection?.plotId
+            layerName: node.gridDisplaySelection?.plotId,
           },
         },
       }
@@ -207,7 +207,7 @@ function nodeButtonItems(nodes: TopologyNode[]) {
           name: 'TopologySpatialDisplay',
           params: {
             nodeId: node.id,
-            layerName: node.gridDisplaySelection?.plotId
+            layerName: node.gridDisplaySelection?.plotId,
           },
         },
       }

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -315,11 +315,6 @@ watchEffect(() => {
     const to = _displayTabs[0].to
     if (to.params?.layerName === undefined) {
       router.push(_displayTabs[0].to)
-    } else if (
-      props.nodeId !== to.params.nodeId ||
-      props.layerName !== to.params.layerName
-    ) {
-      router.push(_displayTabs[0].to)
     }
   } else {
     activeTab.value = 0


### PR DESCRIPTION
Before this change the route first goes to: `/topology/node/:nodeId?` and then to `/topology/node/:nodeId?/map/:layerName?`. This causes the `SpatialDisplay` component to rerender and flicker. 
When directly linking to `TopologySpatialDisplay` we get the same behaviour as in the spatial display route (http://localhost:5174/map/oceanographic_water_level_d3d). 

With this change it also seems to be that the keep-alive is not needed anymore:
```vue
  <router-view v-slot="{ Component }">
    <keep-alive include="SpatialDisplay">
      <component :is="Component" />
    </keep-alive>
  </router-view>

<!-- can just be -->
<router-view />

```
But this could potentially still be useful for switching from the `TopologyTimeSeries` tab back to the `TopologySpatialDisplay` tab.