### PR TITLE
Set elevation ticks based on backend

### DIFF
--- a/src/components/spatialdisplay/SpatialDisplayComponent.vue
+++ b/src/components/spatialdisplay/SpatialDisplayComponent.vue
@@ -14,6 +14,7 @@
       :key="layerOptions?.name"
       :min-value="minElevation"
       :max-value="maxElevation"
+      :ticks="elevationTicks"
       :unit="elevationUnit"
     ></ElevationSlider>
     <LocationsLayerComponent
@@ -99,6 +100,7 @@ const dateController = new DateController([])
 const currentElevation = ref<number>(0)
 const minElevation = ref<number>(-Infinity)
 const maxElevation = ref<number>(Infinity)
+const elevationTicks = ref<number[]>()
 const elevationUnit = ref('')
 
 const currentTime = ref<Date>(new Date())
@@ -132,6 +134,7 @@ watch(
       maxElevation.value = max
       elevationUnit.value =
         (layer.elevation as ElevationWithUnitSymbol).unitSymbol ?? ''
+      elevationTicks.value = layer.elevation.irregularTicks
     }
   },
   { immediate: true, deep: true },

--- a/src/components/wms/ElevationSlider.vue
+++ b/src/components/wms/ElevationSlider.vue
@@ -63,6 +63,7 @@ interface Props {
   minValue: number
   maxValue: number
   unit: string
+  ticks?: number[]
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -160,6 +161,11 @@ const onValueChange = () => {
 watch(() => props.modelValue, onValueChange)
 
 watchEffect(() => {
+  if (props.ticks) {
+    marks.value = props.ticks
+    return
+  }
+
   const scale = scaleLinear(
     [props.minValue, props.maxValue],
     [props.minValue, props.maxValue],


### PR DESCRIPTION
Closes #609 
![image](https://github.com/Deltares/fews-web-oc/assets/144685504/ee25980d-6631-41b4-8f4a-bec030689cb4)

Only found it present in:

`currents/oceanographic_currents_d3d/map/oceanographic_currents_d3d`

![image](https://github.com/Deltares/fews-web-oc/assets/144685504/59d31f4c-54f7-48c0-b384-b002689be097)

Which currently does not show data:
![image](https://github.com/Deltares/fews-web-oc/assets/144685504/9a915c23-7fe6-4a2c-a6d5-14c50ffbe552)
https://rwsos-dataservices-ont.avi.deltares.nl/wqps/FewsWebServices//wms?service=WMS&request=GetMap&version=1.3&layers=oceanographic_currents_d3d&crs=EPSG%3A3857&bbox=1034090.1263145615%2C-1132701.9280704241%2C8826455.651986895%2C6736892.195477719&height=1019&width=1009&time=2024-02-07T16%3A00%3A00.000Z&elevation=-1000
