### PR TITLE
Only show component selection if there are more than 1 component

### DIFF
--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -14,7 +14,11 @@
           <v-spacer />
           <login-component v-if="configManager.authenticationIsEnabled" />
         </v-toolbar>
-        <v-menu origin="left" min-width="320">
+        <v-menu
+          origin="left"
+          min-width="320"
+          v-if="configStore.activeComponents.length > 1"
+        >
           <template #activator="{ isActive, props }">
             <v-list-item
               aria-label="Menu button"


### PR DESCRIPTION
Closes #690 

Does not fix `durban` since it still has 2 components:

```
  "components" : [ {
    "id" : "topologyDisplay",
    "type" : "TopologyDisplay",
    "title" : "Overview",
    "showLeafNodesAsButtons" : false,
    "defaultPath" : {
      "nodeId" : "viewer_saws_1x1"
    }
  }, {
    "id" : "htmlDisplay",
    "type" : "HtmlDisplay",
    "title" : "Terms of use",
    "path" : "terms-of-use",
    "url" : "terms-of-use.html"
  } ]
```