### PR TITLE
Set content security policy header for vite server

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,41 +1,43 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
 
-const contentSecurityPolicy = [
-  `default-src 'self'`,
-  `script-src 'self'`,
-  `font-src 'self' https://*.basemaps.cartocdn.com`,
-  `style-src 'self' https://api.mapbox.com 'unsafe-inline'`,
-  `worker-src blob:`,
-  `img-src 'self' data: blob: rwsos-dataservices-ont.avi.deltares.nl`,
-  `child-src blob:`,
-  `connect-src 'self' https://basemaps.cartocdn.com https://*.basemaps.cartocdn.com https://*.mapbox.com https://rwsos-dataservices-ont.avi.deltares.nl`,
-]
-
 // https://vitejs.dev/config/
-export default defineConfig({
-  server: {
-    headers: {
-      'content-security-policy': contentSecurityPolicy.join('; '),
-    },
-  },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-    },
-  },
-  plugins: [
-    vue({
-      template: {
-        compilerOptions: {
-          isCustomElement: (tag) => tag === 'schematic-status-display',
-          // ...
-        },
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+
+  return {
+    server: {
+      headers: {
+        'content-security-policy': [
+          `default-src 'self'`,
+          `script-src 'self'`,
+          `font-src 'self' https://*.basemaps.cartocdn.com`,
+          `style-src 'self' https://api.mapbox.com 'unsafe-inline'`,
+          `worker-src blob:`,
+          `img-src 'self' data: blob: ${env.VITE_FEWS_WEBSERVICES_URL}`,
+          `child-src blob:`,
+          `connect-src 'self' https://basemaps.cartocdn.com https://*.basemaps.cartocdn.com https://*.mapbox.com ${env.VITE_FEWS_WEBSERVICES_URL}`,
+        ].join('; '),
       },
-    }),
-  ],
-  optimizeDeps: {
-    exclude: ['@deltares/fews-ssd-webcomponent'],
-  },
+    },
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
+    },
+    plugins: [
+      vue({
+        template: {
+          compilerOptions: {
+            isCustomElement: (tag) => tag === 'schematic-status-display',
+            // ...
+          },
+        },
+      }),
+    ],
+    optimizeDeps: {
+      exclude: ['@deltares/fews-ssd-webcomponent'],
+    },
+  }
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig(({ mode }) => {
           `worker-src blob:`,
           `img-src 'self' data: blob: ${env.VITE_FEWS_WEBSERVICES_URL}`,
           `child-src blob:`,
-          `connect-src 'self' https://basemaps.cartocdn.com https://*.basemaps.cartocdn.com https://*.mapbox.com ${env.VITE_FEWS_WEBSERVICES_URL}`,
+          `connect-src 'self' https://basemaps.cartocdn.com https://*.basemaps.cartocdn.com https://*.mapbox.com https://login.microsoftonline.com ${env.VITE_FEWS_WEBSERVICES_URL}`,
         ].join('; '),
       },
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,24 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import path from 'path'
 
+const contentSecurityPolicy = [
+  `default-src 'self'`,
+  `script-src 'self'`,
+  `font-src 'self' https://*.basemaps.cartocdn.com`,
+  `style-src 'self' https://api.mapbox.com 'unsafe-inline'`,
+  `worker-src blob:`,
+  `img-src 'self' data: blob: rwsos-dataservices-ont.avi.deltares.nl`,
+  `child-src blob:`,
+  `connect-src 'self' https://basemaps.cartocdn.com https://*.basemaps.cartocdn.com https://*.mapbox.com https://rwsos-dataservices-ont.avi.deltares.nl`,
+]
+
 // https://vitejs.dev/config/
 export default defineConfig({
+  server: {
+    headers: {
+      'content-security-policy': contentSecurityPolicy.join('; '),
+    },
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
Closes #698 

On Firefox seems to state that eval was blocked:
![image](https://github.com/Deltares/fews-web-oc/assets/144685504/66616dbf-b30f-44fb-9d0d-7d7a0bdcd79d)
but the program still seems to function.

On edge and chrome this is not shown.