### PR TITLE
DWO-655 Respect coloredParticles field in GetCapabilities

### DIFF
--- a/src/components/wms/AnimatedStreamlineMapboxLayer.vue
+++ b/src/components/wms/AnimatedStreamlineMapboxLayer.vue
@@ -129,7 +129,9 @@ function mergeOptions(
   return {
     baseUrl: baseUrlWms,
     layer: layerOptions.name,
-    streamlineStyle: StreamlineStyle.ColoredParticles,
+    streamlineStyle: streamlineOptions?.coloredParticles
+      ? StreamlineStyle.MagnitudeColoredParticles
+      : StreamlineStyle.ColoredParticles,
     numParticles: streamlineOptions?.numberOfParticles ?? 1000,
     particleSize: streamlineOptions?.particleSize ?? 3,
     speedFactor: streamlineOptions?.speedFactor ?? 0.2,


### PR DESCRIPTION
It was ignored before, the particles were always colored with the configured color. Now, if the `coloredParticles` field is set, the particles will be colored according to the velocity magnitude.