### PR TITLE
Fix pixelated particle trails

### DIFF
--- a/src/lib/streamlines/layer.ts
+++ b/src/lib/streamlines/layer.ts
@@ -49,7 +49,7 @@ function mapBoundsToEpsg3857BoundingBox(
 }
 
 export class WMSStreamlineLayer implements CustomLayerInterface {
-  private static readonly MAX_PARTICLE_DISPLACEMENT = 2
+  private static readonly MAX_PARTICLE_DISPLACEMENT = 1
   private static readonly PARTICLE_TEXTURE_SIZE = 32
 
   public readonly renderingMode = '2d'

--- a/src/lib/streamlines/layer.ts
+++ b/src/lib/streamlines/layer.ts
@@ -49,7 +49,7 @@ function mapBoundsToEpsg3857BoundingBox(
 }
 
 export class WMSStreamlineLayer implements CustomLayerInterface {
-  public static readonly MAX_PARTICLE_DISPLACEMENT = 2
+  private static readonly MAX_PARTICLE_DISPLACEMENT = 2
   private static readonly PARTICLE_TEXTURE_SIZE = 8
 
   public readonly renderingMode = '2d'

--- a/src/lib/streamlines/layer.ts
+++ b/src/lib/streamlines/layer.ts
@@ -50,7 +50,7 @@ function mapBoundsToEpsg3857BoundingBox(
 
 export class WMSStreamlineLayer implements CustomLayerInterface {
   private static readonly MAX_PARTICLE_DISPLACEMENT = 2
-  private static readonly PARTICLE_TEXTURE_SIZE = 8
+  private static readonly PARTICLE_TEXTURE_SIZE = 32
 
   public readonly renderingMode = '2d'
   public readonly type = 'custom'

--- a/src/lib/streamlines/render/particles.ts
+++ b/src/lib/streamlines/render/particles.ts
@@ -97,6 +97,7 @@ export class ParticleRenderer {
     // top of it, ignoring alpha for this blending as it has already been taken
     // care of in the texture render.
     gl.enable(gl.BLEND)
+    gl.blendEquationSeparate(gl.FUNC_ADD, gl.MAX)
     gl.blendFunc(gl.ONE, gl.ONE)
 
     gl.bindVertexArray(this.vertexArray)

--- a/src/lib/streamlines/render/texture.ts
+++ b/src/lib/streamlines/render/texture.ts
@@ -51,8 +51,6 @@ export class TextureRenderer {
     const gl = this.program.gl
     this.program.use()
 
-    gl.disable(gl.BLEND)
-
     gl.bindVertexArray(this.vertexArray)
     bindTexture(this.program, 'u_texture', 0, inputTexture)
     gl.uniform1f(this.program.getUniformLocation('u_fade_amount'), fadeAmount)
@@ -87,6 +85,9 @@ export class TextureRenderer {
       outputTexture,
       0,
     )
+    gl.clearColor(0.0, 0.0, 0.0, 0.0)
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT)
+    gl.disable(gl.BLEND)
   }
 
   private disableRenderToTexture(): void {

--- a/src/lib/streamlines/visualiser.ts
+++ b/src/lib/streamlines/visualiser.ts
@@ -375,11 +375,18 @@ export class StreamlineVisualiser {
       throw new Error('Could not initialise 2D offscreen canvas.')
     }
 
-    context.beginPath()
     const x = radius
     const y = radius
+    const gradient = context.createRadialGradient(x, y, 0, x, y, radius)
+
+    const particleColor = this.options.particleColor ?? 'black'
+    gradient.addColorStop(0, particleColor)
+    gradient.addColorStop(0.8, particleColor)
+    gradient.addColorStop(1, 'rgba(0, 0, 0, 0)')
+
+    context.beginPath()
     context.arc(x, y, radius, 0, 2 * Math.PI, false)
-    context.fillStyle = this.options.particleColor ?? 'black'
+    context.fillStyle = gradient
     context.fill()
 
     const data = context.getImageData(0, 0, width, height).data


### PR DESCRIPTION
Particle trails were jagged, which was visually unappealing. This PR fixes the blending during particle rendering and softens the particle edges with a radial gradient to reduce this effect.