### PR TITLE
Add option to "compress" particle speed

### DIFF
--- a/src/components/wms/AnimatedStreamlineRasterLayer.vue
+++ b/src/components/wms/AnimatedStreamlineRasterLayer.vue
@@ -139,6 +139,7 @@ function mergeOptions(
     particleSize: streamlineOptions?.particleSize ?? 3,
     speedFactor: streamlineOptions?.speedFactor ?? 0.2,
     fadeAmountPerSecond: streamlineOptions?.fadeAmount ?? 0.1,
+    speedExponent: 1,
     particleColor: streamlineOptions?.particleColor
       ? `#${streamlineOptions?.particleColor}`
       : undefined,

--- a/src/lib/streamlines/layer.ts
+++ b/src/lib/streamlines/layer.ts
@@ -27,6 +27,7 @@ export interface WMSStreamlineLayerOptions {
   speedFactor: number
   fadeAmountPerSecond: number
   downsampleFactorWMS?: number
+  speedExponent?: number
   particleColor?: string
 }
 
@@ -447,6 +448,7 @@ export class WMSStreamlineLayer implements CustomLayerInterface {
       speedFactor: options.speedFactor,
       fadeAmountPerSecond: options.fadeAmountPerSecond,
       maxDisplacement: WMSStreamlineLayer.MAX_PARTICLE_DISPLACEMENT,
+      speedExponent: options.speedExponent,
       particleColor: options.particleColor,
     }
   }

--- a/src/lib/streamlines/render/propagator.ts
+++ b/src/lib/streamlines/render/propagator.ts
@@ -1,3 +1,4 @@
+import { SpeedCurve } from '../utils/speedcurve'
 import {
   ShaderProgram,
   bindAttribute,
@@ -7,13 +8,13 @@ import { VelocityImage } from '../utils/wms'
 
 export class ParticlePropagator {
   public numEliminatePerSecond: number
-  public speedFactor: number
 
   private program: ShaderProgram
   private width: number
   private height: number
   private numParticles: number
   private numParticlesAllocate: number
+  private speedCurve: SpeedCurve
   private inputBuffer: WebGLBuffer | null
   private outputBuffer: WebGLBuffer | null
   private transformFeedback: WebGLTransformFeedback | null
@@ -27,7 +28,7 @@ export class ParticlePropagator {
     numParticles: number,
     numParticlesAllocate: number,
     numEliminatePerSecond: number,
-    speedFactor: number,
+    speedCurve: SpeedCurve,
   ) {
     this.program = program
     this.width = width
@@ -39,7 +40,7 @@ export class ParticlePropagator {
 
     this.velocityImage = null
     this.velocityTexture = null
-    this.speedFactor = speedFactor
+    this.speedCurve = speedCurve
 
     this.inputBuffer = null
     this.outputBuffer = null
@@ -93,6 +94,10 @@ export class ParticlePropagator {
     this.inputBuffer = this.initialiseInputBuffer()
     this.outputBuffer = this.initialiseOutputBuffer()
     this.swapBuffers()
+  }
+
+  setSpeedCurve(speedCurve: SpeedCurve): void {
+    this.speedCurve = speedCurve
   }
 
   update(dt: number): void {
@@ -214,7 +219,11 @@ export class ParticlePropagator {
     )
     gl.uniform1f(
       this.program.getUniformLocation('u_speed_factor'),
-      this.speedFactor,
+      this.speedCurve.factor,
+    )
+    gl.uniform1f(
+      this.program.getUniformLocation('u_speed_exponent'),
+      this.speedCurve.exponent,
     )
 
     // Select a range of particle indices to eliminate and replace by newly

--- a/src/lib/streamlines/utils/speedcurve.ts
+++ b/src/lib/streamlines/utils/speedcurve.ts
@@ -1,0 +1,42 @@
+/**
+ * Speed curve of the form factor * speed ^ exponent.
+ */
+export class SpeedCurve {
+  private _exponent: number
+  private _factor: number
+
+  constructor(exponent: number, factor: number) {
+    this._exponent = exponent
+    this._factor = factor
+  }
+
+  /** Exponent of the curve. */
+  get exponent(): number {
+    return this._exponent
+  }
+
+  /** Factor applied after exponentiation. */
+  get factor(): number {
+    return this._factor
+  }
+
+  /**
+   * Returns a speed curve from an exponent and a speed.
+   *
+   * The specified speed is used to compute the factor of the curve. At this
+   * speed, the transformed speed is equal to the original speed.
+   *
+   * @param exponent  exponent applied to the speed.
+   * @param factor factor applied to the transformed speed.
+   * @param speed  speed where the transformation does not change the speed
+   */
+  static fromExponentFactorAndSpeed(
+    exponent: number,
+    factor: number,
+    speed: number,
+  ): SpeedCurve {
+    const transformedSpeed = Math.pow(speed, exponent)
+    const finalFactor = (factor * speed) / transformedSpeed
+    return new SpeedCurve(exponent, finalFactor)
+  }
+}

--- a/src/lib/streamlines/visualiser.ts
+++ b/src/lib/streamlines/visualiser.ts
@@ -128,7 +128,7 @@ export class StreamlineVisualiser {
       finalFragmentShaderSource,
     )
 
-    // Create a texture to use as the particle sprite: a filled black circle.
+    // Create a texture to use as the particle sprite.
     const particleTexture = this.createParticleTexture()
 
     // Create and the renderers for the different stages of the visualisation.


### PR DESCRIPTION
This adds the feature, but hard-codes using no speed compression. Once the back-end supports this option, we can pass it to the streamline visualiser.