### PR TITLE
Fix timeseries table data clearing when reopening

### DIFF
--- a/src/components/timeseries/TimeSeriesComponent.vue
+++ b/src/components/timeseries/TimeSeriesComponent.vue
@@ -19,16 +19,14 @@
       :value="DisplayType.TimeSeriesTable"
       class="time-series-component__container max-height"
     >
-      <KeepAlive>
-        <TimeSeriesTable
-          :config="tableConfig"
-          :series="series"
-          :key="tableConfig.title"
-          class="single"
-          @change="(event) => onDataChange(event)"
-        >
-        </TimeSeriesTable>
-      </KeepAlive>
+      <TimeSeriesTable
+        :config="tableConfig"
+        :series="series"
+        :key="tableConfig.title"
+        class="single"
+        @change="(event) => onDataChange(event)"
+      >
+      </TimeSeriesTable>
     </v-window-item>
     <v-window-item
       :value="DisplayType.ElevationChart"


### PR DESCRIPTION
Closes #815

KeepAlive keeps all tables alive and their watches, causing ever increasing triggers on location clicks.

![image](https://github.com/Deltares/fews-web-oc/assets/144685504/40cfeb3c-24dc-40ab-8cd5-4450c8ace4c6)

One click after having opened 6 locations:
![image](https://github.com/Deltares/fews-web-oc/assets/144685504/c1ea353d-0a95-40da-8f7d-db456cbece1b)
```ts
watchDebounced(
  props.series,
  () => {
    if (props.series === undefined) return
    console.log('Running createTableData')
    tableData.value = createTableData(
      props.config.series,
      props.series,
      seriesIds.value,
    )
  },
  { debounce: 500, maxWait: 1000 },
)
```
Starts lagging my laptop after around 7 locations.

Could potentially also lead to issues with other KeepAlive's.