### PR TITLE
Disable double click, pitch and rotate on the mapObject itself

### DIFF
--- a/src/components/map/MapComponent.vue
+++ b/src/components/map/MapComponent.vue
@@ -7,6 +7,11 @@
     :scroll-zoom="true"
     :transform-request="transformRequest"
     :mapStyle="baseLayerStyle"
+    :doubleClickZoom="false"
+    :pitchWithRotate="false"
+    :dragRotate="false"
+    :touchZoomRotate="false"
+    :touchPitch="false"
   >
     <slot></slot>
   </mgl-map>

--- a/src/components/wms/AnimatedRasterLayer.vue
+++ b/src/components/wms/AnimatedRasterLayer.vue
@@ -82,19 +82,14 @@ function onDoubleClick(event: MapLayerMouseEvent | MapLayerTouchEvent): void {
 }
 
 function addHooksToMapObject() {
-  map?.once('load', () => {
-    onLayerChange()
-
-    map.dragRotate.disable()
-    map.touchZoomRotate.disableRotation()
-    map.doubleClickZoom.disable()
-  })
+  map?.on('load', onLayerChange)
   map?.on('moveend', onMapMove)
   map?.on('sourcedata', onDataChange)
   map?.on('dblclick', onDoubleClick)
 }
 
 function removeHooksFromMapObject(): void {
+  map?.off('load', onLayerChange)
   map?.off('moveend', onMapMove)
   map?.off('sourcedata', onDataChange)
   map?.off('dblclick', onDoubleClick)


### PR DESCRIPTION
Closes #827 