### PR TITLE
Fix location names being cut off in location search

### DIFF
--- a/src/components/spatialdisplay/SpatialDisplayComponent.vue
+++ b/src/components/spatialdisplay/SpatialDisplayComponent.vue
@@ -64,6 +64,7 @@
         </v-btn>
         <LocationsSearchControl
           v-if="showLocationsLayer"
+          width="250"
           :locations="locations"
           :selectedLocationId="props.locationId"
           @changeLocationId="onLocationChange"

--- a/src/components/spatialdisplay/SpatialDisplayComponent.vue
+++ b/src/components/spatialdisplay/SpatialDisplayComponent.vue
@@ -64,7 +64,8 @@
         </v-btn>
         <LocationsSearchControl
           v-if="showLocationsLayer"
-          width="250"
+          width="50vw"
+          max-width="250"
           :locations="locations"
           :selectedLocationId="props.locationId"
           @changeLocationId="onLocationChange"

--- a/src/components/wms/LocationsSearchControl.vue
+++ b/src/components/wms/LocationsSearchControl.vue
@@ -1,31 +1,46 @@
 <template>
-  <v-autocomplete
-    class="locations-search"
-    v-model="selectedLocation"
-    label="Search Locations"
-    single-line
-    hide-details
-    rounded="0"
-    :items="props.locations"
-    item-title="locationName"
-    item-value="locationId"
-    return-object
-    :style="autocompleteStyle"
-    density="compact"
+  <v-tooltip
+    :open-delay="tooltipOpenDelay"
+    :disabled="isExpanded || !selectedLocationId"
   >
-    <template v-slot:item="{ props }">
-      <v-list-item
-        v-bind="props"
-        :width="width"
-        :max-width="maxWidth"
+    <template #activator="{ props: autocompleteProps }">
+      <v-autocomplete
+        v-bind="autocompleteProps"
+        class="locations-search"
+        v-model="selectedLocation"
+        label="Search Locations"
+        single-line
+        hide-details
+        rounded="0"
+        :items="props.locations"
+        item-title="locationName"
+        item-value="locationId"
+        return-object
+        :style="autocompleteStyle"
         density="compact"
-      />
+        @update:focused="(isFocused) => (isExpanded = isFocused)"
+      >
+        <template #item="{ item, props }">
+          <v-tooltip :open-delay="tooltipOpenDelay">
+            <template #activator="{ props: itemProps }">
+              <v-list-item
+                v-bind="{ ...itemProps, ...props }"
+                :width="width"
+                :max-width="maxWidth"
+                density="compact"
+              />
+            </template>
+            <span>{{ getTooltipTextFromId(item.value) }}</span>
+          </v-tooltip>
+        </template>
+      </v-autocomplete>
     </template>
-  </v-autocomplete>
+    <span>{{ getTooltipText(selectedLocation) }}</span>
+  </v-tooltip>
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch, watchEffect } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { type Location } from '@deltares/fews-pi-requests'
 
 interface Props {
@@ -33,15 +48,18 @@ interface Props {
   selectedLocationId?: string | null
   maxWidth?: string | number
   width?: string | number
+  tooltipOpenDelay?: number
 }
 
 const props = withDefaults(defineProps<Props>(), {
   locations: () => [],
   selectedLocationId: null,
+  tooltipOpenDelay: 500,
 })
 
 const emit = defineEmits(['changeLocationId'])
 
+const isExpanded = ref(false)
 const selectedLocation = ref<Location | null>(null)
 
 function convertWidthToCss(inputWidth: number | string | undefined) {
@@ -63,12 +81,50 @@ const autocompleteStyle = computed(() => {
   }
 })
 
-watchEffect(() => {
-  selectedLocation.value =
-    props.locations.find(
-      (location) => location.locationId === props.selectedLocationId,
-    ) ?? null
-})
+function getLocationFromId(locationId: string | null) {
+  if (locationId === null) return null
+  return (
+    props.locations.find((location) => location.locationId === locationId) ??
+    null
+  )
+}
+
+function degreesToString(raw: number): string {
+  let remainder = raw
+
+  const degrees = Math.floor(raw)
+  remainder -= degrees
+
+  remainder *= 60
+  const minutes = Math.floor(remainder)
+  remainder -= minutes
+
+  const seconds = (remainder * 60).toFixed(2)
+
+  return `${degrees}°${minutes}'${seconds}''`
+}
+
+function getTooltipText(location: Location | null): string {
+  if (!location) return ''
+
+  let tooltip = `${location.locationName}`
+  if (location.lat && location.lon) {
+    const lat = degreesToString(+location.lat)
+    const lon = degreesToString(+location.lon)
+    tooltip += ` (${lat} N, ${lon} E)`
+  }
+  return tooltip
+}
+
+function getTooltipTextFromId(locationId: string): string {
+  const location = getLocationFromId(locationId)
+  return getTooltipText(location)
+}
+
+watch(
+  () => props.selectedLocationId,
+  () => (selectedLocation.value = getLocationFromId(props.selectedLocationId)),
+)
 
 watch(selectedLocation, onSelectLocation)
 function onSelectLocation(newValue: Location | null) {
@@ -82,5 +138,10 @@ function onSelectLocation(newValue: Location | null) {
 <style>
 .locations-search > .v-field__overlay {
   display: none;
+}
+
+/* Hide horizontal scrollbar in autocomplete dropdown menu on FireFox. */
+.v-autocomplete__content > .v-list {
+  overflow-x: hidden !important;
 }
 </style>

--- a/src/components/wms/LocationsSearchControl.vue
+++ b/src/components/wms/LocationsSearchControl.vue
@@ -10,22 +10,23 @@
     item-title="locationName"
     item-value="locationId"
     return-object
-    style="width: 250px"
+    :style="autocompleteStyle"
     density="compact"
   >
     <template v-slot:item="{ props }">
-      <v-list-item v-bind="props" width="250px" density="compact" />
+      <v-list-item v-bind="props" :width="width" density="compact" />
     </template>
   </v-autocomplete>
 </template>
 
 <script setup lang="ts">
-import { ref, watch, watchEffect } from 'vue'
+import { computed, ref, watch, watchEffect } from 'vue'
 import { type Location } from '@deltares/fews-pi-requests'
 
 interface Props {
   locations?: Location[]
   selectedLocationId?: string | null
+  width?: string | number
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -36,6 +37,20 @@ const props = withDefaults(defineProps<Props>(), {
 const emit = defineEmits(['changeLocationId'])
 
 const selectedLocation = ref<Location | null>(null)
+
+const autocompleteStyle = computed(() => {
+  if (!props.width) return undefined
+
+  let width: number | string = props.width
+  if (typeof width === 'string') {
+    // Try to parse width as a number, if it fails, assume it's a CSS string.
+    const numericWidth = parseFloat(width)
+    if (!isNaN(numericWidth)) width = numericWidth
+  }
+
+  const cssWidth = typeof width === 'number' ? `${width}px` : width
+  return `width: ${cssWidth}`
+})
 
 watchEffect(() => {
   selectedLocation.value =

--- a/src/components/wms/LocationsSearchControl.vue
+++ b/src/components/wms/LocationsSearchControl.vue
@@ -24,8 +24,8 @@ import { ref, watch, watchEffect } from 'vue'
 import { type Location } from '@deltares/fews-pi-requests'
 
 interface Props {
-  locations: Location[]
-  selectedLocationId: string | null
+  locations?: Location[]
+  selectedLocationId?: string | null
 }
 
 const props = withDefaults(defineProps<Props>(), {

--- a/src/components/wms/LocationsSearchControl.vue
+++ b/src/components/wms/LocationsSearchControl.vue
@@ -14,7 +14,12 @@
     density="compact"
   >
     <template v-slot:item="{ props }">
-      <v-list-item v-bind="props" :width="width" density="compact" />
+      <v-list-item
+        v-bind="props"
+        :width="width"
+        :max-width="maxWidth"
+        density="compact"
+      />
     </template>
   </v-autocomplete>
 </template>
@@ -26,6 +31,7 @@ import { type Location } from '@deltares/fews-pi-requests'
 interface Props {
   locations?: Location[]
   selectedLocationId?: string | null
+  maxWidth?: string | number
   width?: string | number
 }
 
@@ -38,18 +44,23 @@ const emit = defineEmits(['changeLocationId'])
 
 const selectedLocation = ref<Location | null>(null)
 
-const autocompleteStyle = computed(() => {
-  if (!props.width) return undefined
+function convertWidthToCss(inputWidth: number | string | undefined) {
+  if (inputWidth === undefined) return undefined
 
-  let width: number | string = props.width
+  let width = inputWidth
   if (typeof width === 'string') {
     // Try to parse width as a number, if it fails, assume it's a CSS string.
-    const numericWidth = parseFloat(width)
+    const numericWidth = Number(width)
     if (!isNaN(numericWidth)) width = numericWidth
   }
 
-  const cssWidth = typeof width === 'number' ? `${width}px` : width
-  return `width: ${cssWidth}`
+  return typeof width === 'number' ? `${width}px` : width
+}
+const autocompleteStyle = computed(() => {
+  return {
+    width: convertWidthToCss(props.width),
+    'max-width': convertWidthToCss(props.maxWidth),
+  }
 })
 
 watchEffect(() => {


### PR DESCRIPTION
Currently, location names in the locations search bar are being cut off because the menu is too narrow, and there is no way to read the entire location name. This PR adds `width` and `max-width` properties to the search component, and adds a tooltip with the full name (and coordinates) that appears on hover.