### PR TITLE
Only allow double clicking on a wms map if the layers are all grids.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@deltares/fews-ssd-requests": "^1.0.1",
         "@deltares/fews-ssd-webcomponent": "^1.0.1",
         "@deltares/fews-web-oc-charts": "^3.0.3-beta.3",
-        "@deltares/fews-wms-requests": "^1.0.0",
+        "@deltares/fews-wms-requests": "^1.0.1",
         "@jsonforms/core": "^3.1.0",
         "@jsonforms/vue": "^3.1.0",
         "@jsonforms/vue-vuetify": "^3.1.0-preview.0",
@@ -143,9 +143,9 @@
       }
     },
     "node_modules/@deltares/fews-wms-requests": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@deltares/fews-wms-requests/-/fews-wms-requests-1.0.0.tgz",
-      "integrity": "sha512-aqh2cBGdmsPcJhyPoQZV2TmwwTx68e3NdWZiELdtklkG/sEncxiELLVFOqdwruFIdGZCw5uYzrKwPqLOwjCnHg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@deltares/fews-wms-requests/-/fews-wms-requests-1.0.1.tgz",
+      "integrity": "sha512-BxC629Gu51vBkCT1qZwPKQuSpI5Uj/Z2byfYQ+y97ujbky9HL9XD7srsqfxHBdYpo9JWI6O2zAdRwNdp26JBRw==",
       "dependencies": {
         "@deltares/fews-web-oc-utils": "^1.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@deltares/fews-ssd-requests": "^1.0.1",
     "@deltares/fews-ssd-webcomponent": "^1.0.1",
     "@deltares/fews-web-oc-charts": "^3.0.3-beta.3",
-    "@deltares/fews-wms-requests": "^1.0.0",
+    "@deltares/fews-wms-requests": "^1.0.1",
     "@jsonforms/core": "^3.1.0",
     "@jsonforms/vue": "^3.1.0",
     "@jsonforms/vue-vuetify": "^3.1.0-preview.0",

--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -88,18 +88,11 @@ const maxValuesTimeSeries = useWmsMaxValuesTimeSeries(
   end,
 )
 
-const onlyCoverageLayersAvailable = computed(() => {
-  if (
-    layerCapabilities.value?.keywordList !== undefined &&
-    layerCapabilities.value?.keywordList.length > 0
-  ) {
-    layerCapabilities.value.keywordList.forEach((keyword) => {
-      if (keyword.type != 'COVERAGE') return false
-    })
-    return true
-  }
-  return false
-})
+const onlyCoverageLayersAvailable = computed(() =>
+  layerCapabilities.value?.keywordList?.every(
+    (keyword) => keyword.type === 'COVERAGE',
+  ),
+)
 
 function getFilterActionsFilter(): filterActionsFilter &
   UseDisplayConfigOptions {

--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -80,12 +80,26 @@ const end = computed(() => {
   if (!times.value || times.value.length === 0) return null
   return times.value[times.value.length - 1]
 })
+
 const maxValuesTimeSeries = useWmsMaxValuesTimeSeries(
   baseUrl,
   () => props.layerName,
   start,
   end,
 )
+
+const onlyCoverageLayersAvailable = computed(() => {
+  if (
+    layerCapabilities.value?.keywordList !== undefined &&
+    layerCapabilities.value?.keywordList.length > 0
+  ) {
+    layerCapabilities.value.keywordList.forEach((keyword) => {
+      if (keyword.type != 'COVERAGE') return false
+    })
+    return true
+  }
+  return false
+})
 
 function getFilterActionsFilter(): filterActionsFilter &
   UseDisplayConfigOptions {
@@ -197,6 +211,7 @@ function onCoordinateClick(latitude: number, longitude: number): void {
 }
 
 function openCoordinatesTimeSeriesDisplay(latitude: number, longitude: number) {
+  if (!onlyCoverageLayersAvailable.value) return
   const routeName = route.name
     ?.toString()
     .replace('SpatialDisplay', 'SpatialTimeSeriesDisplay')

--- a/src/components/spatialdisplay/SpatialDisplayComponent.vue
+++ b/src/components/spatialdisplay/SpatialDisplayComponent.vue
@@ -268,7 +268,6 @@ watch(
           colourMap: legend,
           range: legendToRange(legend),
           initialRange: legendToRange(legend),
-          // @ts-expect-error: remove once fews-wms-requests is updated
           useGradients: !legend.some((entry) => entry.colorSmoothing === false),
         })
         colourScalesStore.scales[styleId] = newColourScale


### PR DESCRIPTION
Only allow double clicking on a wms map if the layers are all grids.