### PR TITLE
Hide period preset title and allow for direct period selection

### DIFF
--- a/src/components/time-control/IntervalSelector.vue
+++ b/src/components/time-control/IntervalSelector.vue
@@ -12,19 +12,21 @@
         <v-icon v-show="isActive" small> mdi-check </v-icon>
       </template>
     </v-list-item>
-    <v-divider></v-divider>
-    <v-list-subheader>Period presets</v-list-subheader>
-    <v-list-item
-      v-for="(item, index) in props.items"
-      :key="index"
-      :active="index === selectedIndex - 2"
-      @click="onSelectInterval(index + 2)"
-    >
-      {{ item.label }}
-      <template v-slot:append="{ isActive }">
-        <v-icon v-show="isActive" small> mdi-check </v-icon>
-      </template>
-    </v-list-item>
+    <template v-if="props.items.length">
+      <v-divider></v-divider>
+      <v-list-subheader>Period presets</v-list-subheader>
+      <v-list-item
+        v-for="(item, index) in props.items"
+        :key="index"
+        :active="index === selectedIndex - 2"
+        @click="onSelectInterval(index + 2)"
+      >
+        {{ item.label }}
+        <template v-slot:append="{ isActive }">
+          <v-icon v-show="isActive" small> mdi-check </v-icon>
+        </template>
+      </v-list-item>
+    </template>
   </v-list>
 </template>
 

--- a/src/components/time-control/TimeControlMenu.vue
+++ b/src/components/time-control/TimeControlMenu.vue
@@ -16,11 +16,10 @@
     <v-card width="500px">
       <v-row no-gutters>
         <v-col>
-          <v-form ref="form" :disabled="!isCustomInterval">
+          <v-form ref="form">
             <div class="pa-4">
               <v-date-input
                 v-model="customStartDate"
-                :disabled="!isCustomInterval"
                 label="Start"
                 density="compact"
                 variant="solo-filled"
@@ -32,7 +31,6 @@
               />
               <v-date-input
                 v-model="customEndDate"
-                :disabled="!isCustomInterval"
                 label="End"
                 density="compact"
                 variant="solo-filled"
@@ -110,7 +108,10 @@ watchEffect(() => {
   }
 })
 
-watch([customStartDate, customEndDate], () => form.value?.validate())
+watch([customStartDate, customEndDate], () => {
+  store.selectedInterval = 'custom'
+  form.value?.validate()
+})
 
 function onIntervalChange() {
   store.changeInterval()


### PR DESCRIPTION
### Description
- Hides the period presets title when no presets are set in the backend.
- Enables selection of custom period directly and switches to `'custom'` interval when a date is selected

### Screenshots
![Screenshot 2024-06-20 111804](https://github.com/Deltares/fews-web-oc/assets/144685504/bcd41a1f-f29b-46d4-9a59-a712ca723d29)
![image](https://github.com/Deltares/fews-web-oc/assets/144685504/8de93f3b-1bad-400a-a6e0-2afc928d14e7)

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [ ] Update documentation.
- [ ] Update tests.
