### PR TITLE
Add only download metadata checkbox

### DIFF
--- a/src/components/download/DataDownloadDisplayComponent.vue
+++ b/src/components/download/DataDownloadDisplayComponent.vue
@@ -107,14 +107,22 @@
         </v-col>
       </v-row>
       <v-card-actions>
-        <v-row class="ma-1">
+        <v-row class="mx-1 mb-1">
           <v-col>
+            <v-checkbox
+              v-model="onlyDownloadMetaData"
+              label="Only download meta-data"
+              hide-details
+              density="compact"
+              class="mb-2"
+            />
             <v-btn
               variant="flat"
               prepend-icon="mdi-download"
               color="primary"
               @click="downloadData"
-              >Download
+            >
+              Download
             </v-btn>
           </v-col>
         </v-row>
@@ -196,6 +204,7 @@ const selectedLocations = ref<Location[]>([])
 const parameterQualifiers = ref<ParameterQualifiersHeader[]>([])
 const selectedParameterQualifiers = ref<ParameterQualifiersHeader[]>([])
 const selectableAttributes = ref<string[][]>([])
+const onlyDownloadMetaData = ref(false)
 
 getLocations().then((locationsResponse) => {
   allLocations.value = locationsResponse
@@ -391,6 +400,7 @@ function downloadData() {
       .join(','),
     parameterIds: uniqWith(parameterIds).join(','),
     qualifierIds: uniqWith(qualifiersIds).join(','),
+    onlyHeaders: onlyDownloadMetaData.value,
   }
   const queryParameters = filterToParams(timeSeriesFilter.value)
   if (queryParameters.length > 7500) {

--- a/src/lib/download/types/DataDownloadFilter.ts
+++ b/src/lib/download/types/DataDownloadFilter.ts
@@ -3,4 +3,5 @@ export interface DataDownloadFilter {
   parameterIds: string | undefined
   locationIds: string | undefined
   qualifierIds: string | undefined
+  onlyHeaders: boolean | undefined
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -28,7 +28,7 @@ const SpatialTimeSeriesDisplay = () =>
 const TimeSeriesDisplayView = () => import('../views/TimeSeriesDisplayView.vue')
 const TopologyDisplayView = () => import('../views/TopologyDisplayView.vue')
 const DataDownloadDisplayView = () =>
-  import('../components/download/DataDownloadDisplayComponent.vue')
+  import('../views/DataDownloadDisplayView.vue')
 const TimeSeriesDisplay = () =>
   import('../components/timeseries/TimeSeriesDisplay.vue')
 const HtmlDisplay = () => import('../views/HtmlDisplayView.vue')

--- a/src/views/DataDownloadDisplayView.vue
+++ b/src/views/DataDownloadDisplayView.vue
@@ -1,5 +1,10 @@
 <template>
-  <DataDownloadDisplayComponent v-if="topologyNode" :nodeId :topologyNode />
+  <DataDownloadDisplayComponent
+    v-if="topologyNode"
+    :key="topologyNode.id"
+    :nodeId="nodeId"
+    :topologyNode="topologyNode"
+  />
 </template>
 
 <script setup lang="ts">

--- a/src/views/DataDownloadDisplayView.vue
+++ b/src/views/DataDownloadDisplayView.vue
@@ -1,0 +1,15 @@
+<template>
+  <DataDownloadDisplayComponent v-if="topologyNode" :nodeId :topologyNode />
+</template>
+
+<script setup lang="ts">
+import DataDownloadDisplayComponent from '@/components/download/DataDownloadDisplayComponent.vue'
+import { TopologyNode } from '@deltares/fews-pi-requests'
+
+interface Props {
+  nodeId?: string | string[]
+  topologyNode?: TopologyNode
+}
+
+defineProps<Props>()
+</script>


### PR DESCRIPTION
### Description
- Adds button to only download metadata.
- Fixes `DataDownloadDisplay` erroring on page refresh due to undefined topologyNode

### Screenshots
Checkbox added.
#### Default
![image](https://github.com/Deltares/fews-web-oc/assets/144685504/87ff3447-d5c2-4295-a109-e0f4844de7c9)
#### Checked
![image](https://github.com/Deltares/fews-web-oc/assets/144685504/373b6c68-0447-446d-83ce-b1f81b38e9c7)
#### Json selected and CSV grayed out
![image](https://github.com/Deltares/fews-web-oc/assets/144685504/6fa6a827-298f-43f0-b30a-2ecb15bd8027)
Will stay on CSV afterwards

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [ ] Update documentation.
- [ ] Update tests.
