### PR TITLE
Change path to terms-and-conditions

### DIFF
--- a/src/components/dialog/SplashScreenDialog.vue
+++ b/src/components/dialog/SplashScreenDialog.vue
@@ -31,7 +31,7 @@ const showDialog = defineModel({ default: false })
 
 const router = useRouter()
 
-const termsPath = 'terms-of-use'
+const termsPath = 'terms-and-conditions'
 const configStore = useConfigStore()
 const termsComponent = computed(() =>
   configStore

--- a/src/components/dialog/TermsOfUseDialog.vue
+++ b/src/components/dialog/TermsOfUseDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <v-dialog v-model="showTermsDialog" persistent max-width="900">
     <v-card style="cursor: default">
-      <v-card-title class="text-h5">Terms of Use</v-card-title>
+      <v-card-title class="text-h5">Terms and Conditions</v-card-title>
       <HtmlDisplay :url="url" />
       <v-card-actions class="pt-0">
         <v-checkbox
@@ -33,7 +33,7 @@ import HtmlDisplay from '@/components/general/HtmlDisplay.vue'
 const showTermsDialog = defineModel({ default: false })
 const isInAgreement = ref(false)
 
-const termsPath = 'terms-of-use'
+const termsPath = 'terms-and-conditions'
 const configStore = useConfigStore()
 const url = computed(() => {
   const matchingComponent = configStore


### PR DESCRIPTION
### Description

Terminology for "Terms of Use" is changed to "Terms and Conditions". The related special endpoint is renamed from from `terms-of-use` to `terms-and-conditions`. Update the `<path>terms-of-use<path>` to `<path>terms-and-conditions</path>` in the `WebOperatorClient.xml` file.

### Link to documentation (if applicable)

https://publicwiki.deltares.nl/display/FEWSDOC/11+Web+Operator+Client

### Checklist
- [ ] Make the title short and concise
- [ ] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [ ] Update documentation.
- [ ] Update tests.
