### PR TITLE
Add ability to view reports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "fews-weboc",
       "version": "1.1.0",
       "dependencies": {
-        "@deltares/fews-pi-requests": "^1.2.4",
+        "@deltares/fews-pi-requests": "^1.2.6",
         "@deltares/fews-ssd-requests": "^1.0.1",
         "@deltares/fews-ssd-webcomponent": "^1.0.1",
         "@deltares/fews-web-oc-charts": "^3.0.3-beta.3",
@@ -90,9 +90,10 @@
       }
     },
     "node_modules/@deltares/fews-pi-requests": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@deltares/fews-pi-requests/-/fews-pi-requests-1.2.4.tgz",
-      "integrity": "sha512-ZhfONChzD25nUcACd8mP0AqjXrp+n1PaaMbZdU4587r6Br9qp1/zVIwJDJF3RZqsBJa12qcMWULdQRWCW4mGeA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@deltares/fews-pi-requests/-/fews-pi-requests-1.2.6.tgz",
+      "integrity": "sha512-fQRQb7KItCsK6BGzeQ29z9LzqcgtRvj9zyTpSb9gNz0pOg3IOay0ISAyRtohz8jsfOLobNQa2iSrXFflBzFeyQ==",
+      "license": "MIT",
       "dependencies": {
         "@deltares/fews-web-oc-utils": "^1.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test-ct": "playwright test -c playwright-ct.config.ts"
   },
   "dependencies": {
-    "@deltares/fews-pi-requests": "^1.2.4",
+    "@deltares/fews-pi-requests": "^1.2.6",
     "@deltares/fews-ssd-requests": "^1.0.1",
     "@deltares/fews-ssd-webcomponent": "^1.0.1",
     "@deltares/fews-web-oc-charts": "^3.0.3-beta.3",

--- a/src/components/dialog/TermsOfUseDialog.vue
+++ b/src/components/dialog/TermsOfUseDialog.vue
@@ -2,7 +2,7 @@
   <v-dialog v-model="showTermsDialog" persistent max-width="900">
     <v-card style="cursor: default">
       <v-card-title class="text-h5">Terms and Conditions</v-card-title>
-      <HtmlDisplay :url="url" />
+      <HtmlDisplay class="pt-4 px-4" :url="url" />
       <v-card-actions class="pt-0">
         <v-checkbox
           v-model="isInAgreement"
@@ -29,6 +29,7 @@
 import { useConfigStore } from '@/stores/config'
 import { computed, ref } from 'vue'
 import HtmlDisplay from '@/components/general/HtmlDisplay.vue'
+import { getResourcesStaticUrl } from '@/lib/fews-config'
 
 const showTermsDialog = defineModel({ default: false })
 const isInAgreement = ref(false)
@@ -39,7 +40,9 @@ const url = computed(() => {
   const matchingComponent = configStore
     .getComponentsByType('HtmlDisplay')
     ?.find((c) => c.path === termsPath)
-  return matchingComponent?.url
+
+  const url = matchingComponent?.url
+  return url ? getResourcesStaticUrl(url) : url
 })
 
 function onAgreeClick() {

--- a/src/components/general/HtmlDisplay.vue
+++ b/src/components/general/HtmlDisplay.vue
@@ -1,10 +1,9 @@
 <template>
-  <div v-if="htmlText" class="html-content pa-4" v-html="htmlText"></div>
+  <div v-if="htmlText" class="html-content" v-html="htmlText"></div>
   <v-alert v-else class="ma-10">Resource not found</v-alert>
 </template>
 
 <script setup lang="ts">
-import { getResourcesStaticUrl } from '@/lib/fews-config'
 import { computedAsync } from '@vueuse/core'
 
 interface Props {
@@ -16,10 +15,8 @@ const props = defineProps<Props>()
 const htmlText = computedAsync(async () => {
   if (!props.url) return
 
-  const staticUrl = getResourcesStaticUrl(props.url)
-
   try {
-    const response = await fetch(staticUrl)
+    const response = await fetch(props.url)
     const text = await response.text()
     if (response.ok) {
       // Remove style since this leaks into our global styles

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -31,7 +31,8 @@ const DataDownloadDisplayView = () =>
   import('../views/DataDownloadDisplayView.vue')
 const TimeSeriesDisplay = () =>
   import('../components/timeseries/TimeSeriesDisplay.vue')
-const HtmlDisplay = () => import('../views/HtmlDisplayView.vue')
+const HtmlDisplayView = () => import('../views/HtmlDisplayView.vue')
+const ReportsDisplayView = () => import('../views/ReportsDisplayView.vue')
 const Empty = () => import('../views/Empty.vue')
 
 const routesBase: Readonly<RouteRecordRaw[]> = [
@@ -172,6 +173,13 @@ export const dynamicRoutes: Readonly<RouteRecordRaw[]> = [
         meta: { sidebar: true },
       },
       {
+        path: '/topology/node/:nodeId*/reports/',
+        name: 'TopologyReports',
+        component: ReportsDisplayView,
+        props: true,
+        meta: { sidebar: true },
+      },
+      {
         path: '/topology/node/:nodeId*/map/:layerName?',
         name: 'TopologySpatialDisplay',
         component: SpatialDisplay,
@@ -199,7 +207,7 @@ export const dynamicRoutes: Readonly<RouteRecordRaw[]> = [
   {
     path: '/resources/:path?',
     name: 'HtmlDisplay',
-    component: HtmlDisplay,
+    component: HtmlDisplayView,
     props: true,
   },
   {

--- a/src/services/useReports/index.ts
+++ b/src/services/useReports/index.ts
@@ -1,0 +1,53 @@
+import { createTransformRequestFn } from '@/lib/requests/transformRequest'
+import { PiWebserviceProvider, type Report } from '@deltares/fews-pi-requests'
+import type { MaybeRefOrGetter, Ref, ShallowRef } from 'vue'
+import { ref, shallowRef, toValue, watchEffect } from 'vue'
+
+export interface UseReportsReturn {
+  error: Ref<string | undefined>
+  reports: ShallowRef<Report[] | undefined>
+  isReady: Ref<boolean>
+  isLoading: Ref<boolean>
+}
+
+export function useReports(
+  baseUrl: string,
+  moduleInstanceIds: MaybeRefOrGetter<string[]>,
+): UseReportsReturn {
+  const reports = shallowRef<Report[]>()
+  const isReady = ref(false)
+  const isLoading = ref(false)
+  const error = shallowRef<string>()
+
+  async function loadReports() {
+    const _moduleInstanceIds = toValue(moduleInstanceIds)
+    if (_moduleInstanceIds.length === 0) return
+
+    isLoading.value = true
+    isReady.value = false
+    try {
+      const provider = new PiWebserviceProvider(baseUrl, {
+        transformRequestFn: createTransformRequestFn(),
+      })
+      const response = await provider.getReports({
+        moduleInstanceIds: _moduleInstanceIds,
+      })
+      reports.value = response.reports
+    } catch {
+      error.value = 'Error loading reports'
+      reports.value = undefined
+    } finally {
+      isLoading.value = false
+      isReady.value = true
+    }
+  }
+
+  watchEffect(loadReports)
+
+  return {
+    reports,
+    isReady,
+    isLoading,
+    error,
+  }
+}

--- a/src/views/HtmlDisplayView.vue
+++ b/src/views/HtmlDisplayView.vue
@@ -1,9 +1,10 @@
 <template>
-  <HtmlDisplay :url="url" />
+  <HtmlDisplay class="pt-4 px-4" :url="url" />
 </template>
 
 <script setup lang="ts">
 import HtmlDisplay from '@/components/general/HtmlDisplay.vue'
+import { getResourcesStaticUrl } from '@/lib/fews-config'
 import { useConfigStore } from '@/stores/config'
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
@@ -15,7 +16,8 @@ const url = computed(() => {
   const matchingComponent = configStore
     .getComponentsByType('HtmlDisplay')
     ?.find((c) => c.path === route.params.path)
-  console.log(matchingComponent)
-  return matchingComponent?.url
+
+  const url = matchingComponent?.url
+  return url ? getResourcesStaticUrl(url) : url
 })
 </script>

--- a/src/views/ReportsDisplayView.vue
+++ b/src/views/ReportsDisplayView.vue
@@ -22,7 +22,7 @@
         :item-title="(item) => reportItemToTitle(item)"
         :item-value="(item) => reportItemToId(item)"
         hide-details
-        label="Run"
+        label="Analysis time"
         class="pe-2 flex-0-0"
       />
     </v-toolbar>

--- a/src/views/ReportsDisplayView.vue
+++ b/src/views/ReportsDisplayView.vue
@@ -13,7 +13,7 @@
         :item-value="(item) => item.moduleInstanceId"
         hide-details
         label="Report"
-        class="px-4"
+        class="px-2"
       />
       <v-select
         v-model="selectedReportItem"

--- a/src/views/ReportsDisplayView.vue
+++ b/src/views/ReportsDisplayView.vue
@@ -26,7 +26,7 @@
         class="pe-2 flex-0-0"
       />
     </v-toolbar>
-    <iframe :src="url" class="html-content" />
+    <iframe :key="url" :src="url" class="html-content" />
   </div>
   <v-alert v-else class="ma-10">No reports available</v-alert>
 </template>

--- a/src/views/ReportsDisplayView.vue
+++ b/src/views/ReportsDisplayView.vue
@@ -1,8 +1,9 @@
 <template>
-  <div v-if="reports?.length" class="d-flex flex-column h-100 px-4 pt-4">
+  <div v-if="reports?.length" class="d-flex flex-column h-100">
     <v-toolbar
       class="py-1"
       :title="reports.length === 1 ? reports[0].moduleInstanceId : undefined"
+      density="compact"
     >
       <v-select
         v-if="reports.length > 1"
@@ -14,6 +15,8 @@
         hide-details
         label="Report"
         class="px-2"
+        variant="solo-filled"
+        density="compact"
       />
       <v-select
         v-model="selectedReportItem"
@@ -24,6 +27,8 @@
         hide-details
         label="Analysis time"
         class="pe-2 flex-0-0"
+        variant="solo-filled"
+        density="compact"
       />
     </v-toolbar>
     <iframe :key="url" :src="url" class="html-content" />

--- a/src/views/ReportsDisplayView.vue
+++ b/src/views/ReportsDisplayView.vue
@@ -1,0 +1,111 @@
+<template>
+  <div v-if="reports?.length" class="d-flex flex-column h-100 px-4 pt-4">
+    <v-toolbar
+      class="py-1"
+      :title="reports.length === 1 ? reports[0].moduleInstanceId : undefined"
+    >
+      <v-select
+        v-if="reports.length > 1"
+        v-model="selectedReport"
+        :items="reports"
+        return-object
+        :item-title="(item) => item.moduleInstanceId"
+        :item-value="(item) => item.moduleInstanceId"
+        hide-details
+        label="Report"
+        class="px-4"
+      />
+      <v-select
+        v-model="selectedReportItem"
+        :items="reportItems"
+        return-object
+        :item-title="(item) => reportItemToTitle(item)"
+        :item-value="(item) => reportItemToId(item)"
+        hide-details
+        label="Run"
+        class="pe-2 flex-0-0"
+      />
+    </v-toolbar>
+    <iframe :src="url" class="html-content" />
+  </div>
+  <v-alert v-else class="ma-10">No reports available</v-alert>
+</template>
+
+<script setup lang="ts">
+import { useReports } from '@/services/useReports'
+import {
+  PiWebserviceProvider,
+  type ReportItem,
+  type Report,
+  type TopologyNode,
+} from '@deltares/fews-pi-requests'
+import { computed, ref, watch } from 'vue'
+import { configManager } from '@/services/application-config'
+import { filterToParams } from '@deltares/fews-wms-requests'
+
+interface Props {
+  topologyNode?: TopologyNode
+}
+
+const props = defineProps<Props>()
+
+const moduleInstanceIds = computed(() => {
+  return (
+    props.topologyNode?.reportDisplay?.reports.map((r) => r.moduleInstanceId) ??
+    []
+  )
+})
+
+const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
+const { reports } = useReports(baseUrl, moduleInstanceIds)
+
+const selectedReport = ref<Report>()
+const reportItems = computed(() => {
+  return selectedReport.value?.items ?? []
+})
+
+const selectedReportItem = ref<ReportItem>()
+watch(reports, () => {
+  if (reports.value?.length) {
+    selectedReport.value =
+      reports.value.find((r) => r.items.find((i) => i.isCurrent)) ??
+      reports.value[0]
+  }
+})
+
+watch(selectedReport, () => {
+  const items = selectedReport.value?.items
+  if (!items) return
+
+  selectedReportItem.value = items.find((i) => i.isCurrent) ?? items[0]
+})
+
+const url = computed(() => {
+  if (!selectedReportItem.value) return undefined
+
+  const queryParameters = filterToParams({
+    moduleInstanceId: selectedReportItem.value.moduleInstanceId,
+    taskRunId: selectedReportItem.value.taskRunId,
+    reportId: selectedReportItem.value.reportId,
+  })
+  const provider = new PiWebserviceProvider(baseUrl)
+  return `${baseUrl}${provider.API_ENDPOINT}/report${queryParameters}`
+})
+
+function reportItemToId(item: ReportItem) {
+  return `${item.moduleInstanceId} - ${item.taskRunId} - ${item.reportId}`
+}
+
+function reportItemToTitle(item: ReportItem) {
+  return `${item.timeZero} - ${item.reportId}`
+}
+</script>
+
+<style scoped>
+.html-content {
+  height: 100%;
+  width: 100%;
+  border: none;
+  overflow-y: auto;
+}
+</style>

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -153,7 +153,7 @@ interface Props {
 }
 
 interface DisplayTab {
-  type: string
+  type: 'charts' | 'map' | 'reports'
   id: string
   title: string
   href?: string
@@ -422,6 +422,20 @@ function displayTabsForNode(leafNode: TopologyNode, parentNodeId?: string) {
         },
       },
       icon: 'mdi-download',
+    })
+  }
+  if (leafNode.reportDisplay?.reports.length) {
+    _displayTabs.push({
+      type: 'reports',
+      id: timeseriesTabId,
+      title: 'Reports',
+      to: {
+        name: 'TopologyReports',
+        params: {
+          nodeId: parentNodeId ? [parentNodeId, leafNode.id] : leafNode.id,
+        },
+      },
+      icon: 'mdi-file-document',
     })
   }
   return _displayTabs

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -368,6 +368,7 @@ function updateItems(): void {
 function displayTabsForNode(leafNode: TopologyNode, parentNodeId?: string) {
   const activeNodeId = leafNode.id
   const timeseriesTabId = `${activeNodeId}-timeseries`
+  const reportsTabId = `${activeNodeId}-reports`
   const spatialTabId = `${activeNodeId}-spatial`
   const _displayTabs: DisplayTab[] = []
   if (
@@ -427,7 +428,7 @@ function displayTabsForNode(leafNode: TopologyNode, parentNodeId?: string) {
   if (leafNode.reportDisplay?.reports.length) {
     _displayTabs.push({
       type: 'reports',
-      id: timeseriesTabId,
+      id: reportsTabId,
       title: 'Reports',
       to: {
         name: 'TopologyReports',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,6 +30,7 @@ export default defineConfig(({ mode }) => {
           `worker-src blob:`, // maplibre-gl
           `img-src 'self' data: blob: ${env.VITE_FEWS_WEBSERVICES_URL}`, // FEWS webservices
           `connect-src 'self' https://basemaps.cartocdn.com https://*.basemaps.cartocdn.com https://login.microsoftonline.com ${env.VITE_FEWS_WEBSERVICES_URL}`, // FEWS webservices, Authentication, Basemaps
+          `frame-src 'self' ${env.VITE_FEWS_WEBSERVICES_URL}`,
         ].join('; '),
       },
     },


### PR DESCRIPTION
### Description
Adds a reports tab when a `moduleInstanceId` is set for a given topology node.
The reports tab shows the given reports, either html or pdf, for the current node.

### Screenshots
![image](https://github.com/user-attachments/assets/767870e1-8182-499d-96c3-ab12f43dc080)
![image](https://github.com/user-attachments/assets/3896a0fa-a2b4-4ab7-be27-b5373d5d29de)
![image](https://github.com/user-attachments/assets/b2352ff7-2ae4-43f3-bc5b-14954def63b7)

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [ ] Update documentation.
- [ ] Update tests.
