### PR TITLE
Show ssd's linked to topology

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@deltares/fews-pi-requests": "^1.2.7",
         "@deltares/fews-ssd-requests": "^1.0.1",
-        "@deltares/fews-ssd-webcomponent": "^1.0.1",
+        "@deltares/fews-ssd-webcomponent": "^1.0.2",
         "@deltares/fews-web-oc-charts": "^3.0.3-beta.6",
         "@deltares/fews-wms-requests": "^1.0.2",
         "@indoorequal/vue-maplibre-gl": "^7.5.0",
@@ -145,9 +145,9 @@
       }
     },
     "node_modules/@deltares/fews-ssd-webcomponent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@deltares/fews-ssd-webcomponent/-/fews-ssd-webcomponent-1.0.1.tgz",
-      "integrity": "sha512-/1OWfCegJZ2BObCwaADZweQPDimJ4SQs/GyzpymWVKQ56F6zv/WVDgLEBgIOi0qJ67KHrvAHKzCIxummgz8lqg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@deltares/fews-ssd-webcomponent/-/fews-ssd-webcomponent-1.0.2.tgz",
+      "integrity": "sha512-D1V8dLJOwdmti98yGfmDZzi9L2v7VTvTqqWS1D6GOYFi8kCHTVJZUyAAOPLN9vW0NrGbPJFA/uHjUtC2B/r1fg==",
       "dependencies": {
         "@deltares/fews-ssd-requests": "^1.0.1",
         "@stencil/core": "^2.17.4"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@deltares/fews-pi-requests": "^1.2.7",
     "@deltares/fews-ssd-requests": "^1.0.1",
-    "@deltares/fews-ssd-webcomponent": "^1.0.1",
+    "@deltares/fews-ssd-webcomponent": "^1.0.2",
     "@deltares/fews-web-oc-charts": "^3.0.3-beta.6",
     "@deltares/fews-wms-requests": "^1.0.2",
     "@indoorequal/vue-maplibre-gl": "^7.5.0",

--- a/src/components/ssd/SchematicStatusDisplay.vue
+++ b/src/components/ssd/SchematicStatusDisplay.vue
@@ -1,0 +1,238 @@
+<template>
+  <div class="container">
+    <div
+      class="child-container"
+      :class="{ 'd-none': hideSSD }"
+      ref="ssdContainer"
+    >
+      <SsdComponent :src="src" @action="onAction" ref="ssdComponent" />
+      <DateTimeSlider
+        v-model:selectedDate="selectedDateSlider"
+        :dates="dates"
+        :hide-speed-controls="mobile"
+      />
+    </div>
+    <div class="child-container" :class="{ mobile, 'd-none': objectId === '' }">
+      <router-view @close="closeTimeSeriesDisplay"></router-view>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type {
+  SsdActionResult,
+  SsdActionRequest,
+} from '@deltares/fews-ssd-requests'
+import debounce from 'lodash-es/debounce'
+import { ref, computed, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+import { useAlertsStore } from '@/stores/alerts.ts'
+
+import { configManager } from '@/services/application-config/index.ts'
+
+import { useSsd } from '@/services/useSsd/index.ts'
+
+import DateTimeSlider from '@/components/general/DateTimeSlider.vue'
+import SsdComponent from '@/components/ssd/SsdComponent.vue'
+import { useDisplay } from 'vuetify'
+import { useElementSize } from '@vueuse/core'
+
+interface Props {
+  groupId?: string
+  panelId?: string
+  objectId?: string
+}
+
+interface SsdActionEventPayload {
+  objectId: string
+  panelId: string
+  results: SsdActionResult[]
+}
+
+const sliderDebounceInterval = 500
+
+const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
+const alertsStore = useAlertsStore()
+const route = useRoute()
+const router = useRouter()
+
+const props = withDefaults(defineProps<Props>(), {
+  groupId: '',
+  panelId: '',
+  objectId: '',
+})
+
+const ssdComponent = ref<InstanceType<typeof SsdComponent> | null>(null)
+const ssdContainer = ref<HTMLElement | null>(null)
+
+const selectedDate = ref<Date>(new Date())
+const selectedDateSlider = ref<Date>(selectedDate.value)
+
+const { mobile } = useDisplay()
+
+const selectedDateString = computed(() => {
+  if (selectedDate.value === undefined) return ''
+  const dateString = selectedDate.value.toISOString()
+  return dateString.substring(0, 19) + 'Z'
+})
+
+// Debounce the selected date from the slider input, so we do not send hundreds of requests when
+// dragging the slider around.
+watch(
+  selectedDateSlider,
+  debounce(
+    () => {
+      selectedDate.value = selectedDateSlider.value
+    },
+    sliderDebounceInterval,
+    { leading: true, trailing: true },
+  ),
+)
+
+const { capabilities, src, dates } = useSsd(
+  baseUrl,
+  () => props.groupId,
+  () => props.panelId,
+  selectedDateString,
+)
+
+const hideSSD = computed(() => {
+  return mobile.value && props.objectId !== ''
+})
+
+const ssdContainerSize = useElementSize(ssdContainer)
+watch(ssdContainerSize.width, () => {
+  if (ssdComponent.value) {
+    ssdComponent.value.resize()
+  }
+})
+
+function onAction(event: CustomEvent<SsdActionEventPayload>): void {
+  const { panelId, objectId, results } = event.detail
+  const now = new Date()
+  if (results.length === 0) {
+    alertsStore.addAlert({
+      id: `undefined-action-${now.toISOString()}`,
+      type: 'error',
+      message: 'No left click actions defined for this object',
+      active: true,
+    })
+    return
+  }
+
+  switch (results[0].type) {
+    case 'PDF':
+      window.open(new URL(results[0].requests[0].request))
+      break
+    case 'SSD':
+      switchPanel(results[0].requests[0])
+      break
+    case 'PI':
+      openTimeSeriesDisplay(panelId, objectId)
+      break
+    default:
+      alertsStore.addAlert({
+        id: `action-${results[0].type}-${now.toISOString()}`,
+        type: 'error',
+        message: `Action '${results[0].type}' not supported yet.`,
+        active: true,
+      })
+  }
+}
+
+function switchPanel(request: SsdActionRequest): void {
+  if (!capabilities.value) return
+
+  // We want to use the URL web API to parse the query parameters of the relative URL specified in
+  // the request; we are not actually using it as a URL. Hence, we use a random base URL.
+  const url = new URL(request.request, 'https://www.example.com')
+  const panelId = url.searchParams.get('ssd')
+
+  if (!panelId) return
+
+  // Find the display group that contains this panel.
+  const group = capabilities.value.displayGroups.find((cur) => {
+    return cur.displayPanels.some((panel) => panel.name === panelId)
+  })
+  const groupId = group?.name
+
+  if (!groupId) return
+
+  const currentRoute = router.currentRoute.value
+  const parentRoute = router
+    .getRoutes()
+    .find(
+      (route) =>
+        route.children &&
+        route.children.some((child) => child.name === currentRoute.name),
+    )
+  const targetRouteName = parentRoute?.name ?? currentRoute.name
+  if (!targetRouteName) return
+  router.push({
+    name: targetRouteName,
+    params: { groupId, panelId },
+    query: route.query,
+  })
+}
+
+function openTimeSeriesDisplay(panelId: string, objectId: string) {
+  const currentRoute = router.currentRoute.value
+  const routeConfig = router
+    .getRoutes()
+    .find((route) => route.name === currentRoute.name)
+  const childRoute = routeConfig?.children?.find((route) =>
+    route.name?.toString().endsWith('SSDTimeSeriesDisplay'),
+  )
+  router
+    .push({
+      name: childRoute?.name,
+      params: { objectId: objectId, panelId: panelId, groupId: props.groupId },
+    })
+    .then(() => {
+      ssdComponent.value?.resize()
+    })
+}
+
+function closeTimeSeriesDisplay(): void {
+  const currentRoute = router.currentRoute.value
+  const parentRoute = router
+    .getRoutes()
+    .find(
+      (route) =>
+        route.children &&
+        route.children.some((child) => child.name === currentRoute.name),
+    )
+  if (!parentRoute) return
+  router
+    .push({
+      name: parentRoute.name,
+      params: { groupId: props.groupId, panelId: props.panelId },
+    })
+    .then(() => {
+      ssdComponent.value?.resize()
+    })
+}
+</script>
+
+<style scoped>
+.container {
+  display: flex;
+  width: 100%;
+  height: 100%;
+}
+
+.child-container {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 50%;
+  max-width: 100%;
+  flex: 1 1 0px;
+}
+
+.child-container.mobile {
+  height: 100%;
+  width: 100%;
+}
+</style>

--- a/src/components/ssd/SchematicStatusDisplay.vue
+++ b/src/components/ssd/SchematicStatusDisplay.vue
@@ -92,7 +92,6 @@ watch(
 
 const { capabilities, src, dates } = useSsd(
   baseUrl,
-  () => props.groupId,
   () => props.panelId,
   selectedDateString,
 )

--- a/src/components/ssd/SsdComponent.vue
+++ b/src/components/ssd/SsdComponent.vue
@@ -187,7 +187,7 @@ function resize(): void {
 
 function setAspectRatio(): void {
   const sizes = getSvgContainerSizes()
-  if (sizes) {
+  if (sizes.length) {
     // check if sizes is empty
     aspectRatio = +sizes[2] / +sizes[3]
     return

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -182,7 +182,7 @@ export const dynamicRoutes: Readonly<RouteRecordRaw[]> = [
         meta: { sidebar: true },
       },
       {
-        path: '/topology/node/:nodeId*/ssd/',
+        path: '/topology/node/:nodeId*/ssd/:panelId?',
         name: 'TopologySchematicStatusDisplay',
         component: SchematicStatusDisplay,
         props: true,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -18,6 +18,8 @@ const SystemMonitorDisplayView = () =>
   import('../views/SystemMonitorDisplayView.vue')
 const SchematicStatusDisplayView = () =>
   import('../views/SchematicStatusDisplayView.vue')
+const SchematicStatusDisplay = () =>
+  import('../components/ssd/SchematicStatusDisplay.vue')
 const SSDTimeSeriesDisplay = () =>
   import('../components/ssd/SsdTimeSeriesDisplay.vue')
 const SpatialDisplayView = () => import('../views/SpatialDisplayView.vue')
@@ -176,6 +178,13 @@ export const dynamicRoutes: Readonly<RouteRecordRaw[]> = [
         path: '/topology/node/:nodeId*/reports/',
         name: 'TopologyReports',
         component: ReportsDisplayView,
+        props: true,
+        meta: { sidebar: true },
+      },
+      {
+        path: '/topology/node/:nodeId*/ssd/',
+        name: 'TopologySchematicStatusDisplay',
+        component: SchematicStatusDisplay,
         props: true,
         meta: { sidebar: true },
       },

--- a/src/services/useSsd/index.ts
+++ b/src/services/useSsd/index.ts
@@ -2,7 +2,6 @@ import {
   datesFromPeriod,
   SsdWebserviceProvider,
   type SsdGetCapabilitiesResponse,
-  type SsdDisplayGroup,
   type SsdDisplayPanel,
 } from '@deltares/fews-ssd-requests'
 import { ref, shallowRef, toValue, watchEffect } from 'vue'

--- a/src/views/SchematicStatusDisplayView.vue
+++ b/src/views/SchematicStatusDisplayView.vue
@@ -101,7 +101,6 @@ watch(() => props.panelId, onPanelIdChange)
 
 const { capabilities } = useSsd(
   baseUrl,
-  () => props.groupId,
   () => props.panelId,
   selectedDateString,
 )

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -450,7 +450,6 @@ function displayTabsForNode(leafNode: TopologyNode, parentNodeId?: string) {
         name: 'TopologySchematicStatusDisplay',
         params: {
           nodeId: parentNodeId ? [parentNodeId, leafNode.id] : leafNode.id,
-          groupId: 'SchematicSystemDisplay',
           panelId: 'coastal_flooding',
         },
       },

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -450,6 +450,8 @@ function displayTabsForNode(leafNode: TopologyNode, parentNodeId?: string) {
         name: 'TopologySchematicStatusDisplay',
         params: {
           nodeId: parentNodeId ? [parentNodeId, leafNode.id] : leafNode.id,
+          groupId: 'SchematicSystemDisplay',
+          panelId: 'coastal_flooding',
         },
       },
       icon: 'mdi-view-dashboard',

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -440,17 +440,16 @@ function displayTabsForNode(leafNode: TopologyNode, parentNodeId?: string) {
       icon: 'mdi-file-document',
     })
   }
-  // TODO: Use topology setting
-  if (true) {
+  if (leafNode.scadaPanelId !== undefined) {
     _displayTabs.push({
       type: 'schematic-status-display',
       id: ssdTabId,
-      title: 'SSD',
+      title: 'Schematic',
       to: {
         name: 'TopologySchematicStatusDisplay',
         params: {
           nodeId: parentNodeId ? [parentNodeId, leafNode.id] : leafNode.id,
-          panelId: 'coastal_flooding',
+          panelId: leafNode.scadaPanelId,
         },
       },
       icon: 'mdi-view-dashboard',

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -153,7 +153,7 @@ interface Props {
 }
 
 interface DisplayTab {
-  type: 'charts' | 'map' | 'reports'
+  type: 'charts' | 'map' | 'reports' | 'schematic-status-display'
   id: string
   title: string
   href?: string
@@ -370,6 +370,7 @@ function displayTabsForNode(leafNode: TopologyNode, parentNodeId?: string) {
   const timeseriesTabId = `${activeNodeId}-timeseries`
   const reportsTabId = `${activeNodeId}-reports`
   const spatialTabId = `${activeNodeId}-spatial`
+  const ssdTabId = `${activeNodeId}-ssd`
   const _displayTabs: DisplayTab[] = []
   if (
     leafNode.gridDisplaySelection !== undefined ||
@@ -437,6 +438,21 @@ function displayTabsForNode(leafNode: TopologyNode, parentNodeId?: string) {
         },
       },
       icon: 'mdi-file-document',
+    })
+  }
+  // TODO: Use topology setting
+  if (true) {
+    _displayTabs.push({
+      type: 'schematic-status-display',
+      id: ssdTabId,
+      title: 'SSD',
+      to: {
+        name: 'TopologySchematicStatusDisplay',
+        params: {
+          nodeId: parentNodeId ? [parentNodeId, leafNode.id] : leafNode.id,
+        },
+      },
+      icon: 'mdi-view-dashboard',
     })
   }
   return _displayTabs

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -146,6 +146,7 @@ import { configManager } from '@/services/application-config'
 
 interface Props {
   nodeId?: string | string[]
+  panelId?: string
   layerName?: string
   locationId?: string
   latitude?: string


### PR DESCRIPTION
### Description
Adds a tab for configured SSD's per topology node.

### Screenshots
![image](https://github.com/user-attachments/assets/84eba9fc-70cc-4a0e-9d5e-54006d548311)

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [ ] Update documentation.
- [ ] Update tests.
