### PR TITLE
Synchronize zoom between timeseriescharts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@deltares/fews-pi-requests": "^1.2.4",
         "@deltares/fews-ssd-requests": "^1.0.1",
         "@deltares/fews-ssd-webcomponent": "^1.0.1",
-        "@deltares/fews-web-oc-charts": "^3.0.3-beta.3",
+        "@deltares/fews-web-oc-charts": "^3.0.3-beta.6",
         "@deltares/fews-wms-requests": "^1.0.2",
         "@indoorequal/vue-maplibre-gl": "^7.5.0",
         "@jsonforms/core": "^3.4.0",
@@ -153,9 +153,10 @@
       }
     },
     "node_modules/@deltares/fews-web-oc-charts": {
-      "version": "3.0.3-beta.3",
-      "resolved": "https://registry.npmjs.org/@deltares/fews-web-oc-charts/-/fews-web-oc-charts-3.0.3-beta.3.tgz",
-      "integrity": "sha512-5q602JUVYlVWRwWiWULIdxNNPdw289RKyhkqfFH8JGeHcmA3GLByHy81Td9830EVfH98jVsbSrM50DKkSt7fuw==",
+      "version": "3.0.3-beta.6",
+      "resolved": "https://registry.npmjs.org/@deltares/fews-web-oc-charts/-/fews-web-oc-charts-3.0.3-beta.6.tgz",
+      "integrity": "sha512-41zhrcODwnD42+tXrGclomQzIs+Rk/MQJkwifkAglXOt2WS48ftEVfrR7Hf2D0yawaNYW1snxdyPKSQUDzu5JQ==",
+      "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.0",
         "d3": "^7.8.5",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@deltares/fews-pi-requests": "^1.2.4",
     "@deltares/fews-ssd-requests": "^1.0.1",
     "@deltares/fews-ssd-webcomponent": "^1.0.1",
-    "@deltares/fews-web-oc-charts": "^3.0.3-beta.3",
+    "@deltares/fews-web-oc-charts": "^3.0.3-beta.6",
     "@deltares/fews-wms-requests": "^1.0.2",
     "@indoorequal/vue-maplibre-gl": "^7.5.0",
     "@jsonforms/core": "^3.4.0",

--- a/src/components/charts/ElevationChart.vue
+++ b/src/components/charts/ElevationChart.vue
@@ -75,6 +75,7 @@ interface Props {
   config?: ChartConfig
   series?: Record<string, Series>
   isLoading?: boolean
+  zoomHandler?: ZoomHandler
 }
 
 interface Tag {
@@ -147,7 +148,7 @@ onMounted(() => {
       axisOptions,
     )
     const mouseOver = new VerticalMouseOver()
-    const zoom = new ZoomHandler(WheelMode.NONE)
+    const zoom = props.zoomHandler ?? new ZoomHandler(WheelMode.NONE)
 
     axis.accept(zoom)
     axis.accept(mouseOver)

--- a/src/components/charts/TimeSeriesChart.vue
+++ b/src/components/charts/TimeSeriesChart.vue
@@ -86,6 +86,7 @@ interface Props {
   series?: Record<string, Series>
   currentTime?: Date
   isLoading?: boolean
+  zoomHandler?: ZoomHandler
 }
 
 interface Tag {
@@ -161,7 +162,7 @@ onMounted(() => {
       merge(axisOptions, { x: props.config?.xAxis, y: props.config?.yAxis }),
     )
     const mouseOver = new MouseOver()
-    const zoom = new ZoomHandler(WheelMode.NONE)
+    const zoom = props.zoomHandler ?? new ZoomHandler(WheelMode.NONE)
     axisTime.value = new CurrentTime({
       x: {
         axisIndex: 0,

--- a/src/components/timeseries/TimeSeriesComponent.vue
+++ b/src/components/timeseries/TimeSeriesComponent.vue
@@ -12,7 +12,7 @@
           :key="`${subplot.title}-${i}`"
           :currentTime="props.currentTime"
           :isLoading="isLoading(subplot, loadingSeriesIds)"
-          :zoomHandler="zoomHandler"
+          :zoomHandler="sharedZoomHandler"
         >
         </TimeSeriesChart>
       </KeepAlive>
@@ -43,6 +43,7 @@
           :key="`${subplot.title}-${i}`"
           :style="`min-width: ${xs ? 100 : 50}%`"
           :isLoading="isLoading(subplot, elevationLoadingSeriesIds)"
+          :zoomHandler="sharedVerticalZoomHandler"
         >
         </ElevationChart>
       </KeepAlive>
@@ -85,7 +86,7 @@ import type { TimeSeriesEvent } from '@deltares/fews-pi-requests'
 import { useDisplay } from 'vuetify'
 import { onBeforeRouteUpdate, onBeforeRouteLeave } from 'vue-router'
 import { until } from '@vueuse/core'
-import { WheelMode, ZoomHandler } from '@deltares/fews-web-oc-charts'
+import { ZoomHandler, ZoomMode } from '@deltares/fews-web-oc-charts'
 
 interface Props {
   config?: DisplayConfig
@@ -129,7 +130,12 @@ const lastUpdated = ref<Date>(new Date())
 const isEditing = ref(false)
 const confirmationDialog = ref(false)
 const { xs } = useDisplay()
-const zoomHandler = new ZoomHandler(WheelMode.NONE)
+const sharedZoomHandler = new ZoomHandler({
+  sharedZoomMode: ZoomMode.X,
+})
+const sharedVerticalZoomHandler = new ZoomHandler({
+  sharedZoomMode: ZoomMode.Y,
+})
 
 const options = computed<UseTimeSeriesOptions>(() => {
   return {

--- a/src/components/timeseries/TimeSeriesComponent.vue
+++ b/src/components/timeseries/TimeSeriesComponent.vue
@@ -12,6 +12,7 @@
           :key="`${subplot.title}-${i}`"
           :currentTime="props.currentTime"
           :isLoading="isLoading(subplot, loadingSeriesIds)"
+          :zoomHandler="zoomHandler"
         >
         </TimeSeriesChart>
       </KeepAlive>
@@ -84,6 +85,7 @@ import type { TimeSeriesEvent } from '@deltares/fews-pi-requests'
 import { useDisplay } from 'vuetify'
 import { onBeforeRouteUpdate, onBeforeRouteLeave } from 'vue-router'
 import { until } from '@vueuse/core'
+import { WheelMode, ZoomHandler } from '@deltares/fews-web-oc-charts'
 
 interface Props {
   config?: DisplayConfig
@@ -127,6 +129,7 @@ const lastUpdated = ref<Date>(new Date())
 const isEditing = ref(false)
 const confirmationDialog = ref(false)
 const { xs } = useDisplay()
+const zoomHandler = new ZoomHandler(WheelMode.NONE)
 
 const options = computed<UseTimeSeriesOptions>(() => {
   return {


### PR DESCRIPTION
### Description

When multiple time series charts are visible, zooming the horizontal time axis in one time series chart will be reflected in the other time series charts.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [ ] Update documentation.
- [ ] Update tests.
