### PR TITLE
Remove min zoom setting on map

### DIFF
--- a/src/components/map/MapComponent.vue
+++ b/src/components/map/MapComponent.vue
@@ -1,7 +1,6 @@
 <template>
   <mgl-map
     ref="map"
-    :min-zoom="2"
     :interactive="true"
     :trackResize="true"
     :drag-pan="true"


### PR DESCRIPTION
### Description

Minimum zoom level of 2 is unset. 

### Screenshots (if applicable)

If there are any visual changes, please attach screenshots here.

### Link to documentation (if applicable)

Add link to public Github pages (only documentation about configuration)

### Checklist
- [ ] Make the title short and concise
- [ ] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [ ] Update documentation.
- [ ] Update tests.
