### PR TITLE
Add node information display

### DIFF
--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -123,9 +123,10 @@
       <template #prepend>
         <v-app-bar-nav-icon @click.stop="drawer = !drawer"></v-app-bar-nav-icon>
       </template>
-      <div id="app-bar-content"></div>
+      <div id="app-bar-content-start" />
       <v-spacer />
-      <time-control-menu></time-control-menu>
+      <div id="app-bar-content-end" />
+      <time-control-menu />
       <user-settings-menu />
     </v-app-bar>
     <v-main id="main">

--- a/src/views/InformationDisplayView.vue
+++ b/src/views/InformationDisplayView.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="d-flex h-100 w-100 flex-column">
+    <v-toolbar density="compact" title="Information" class="flex-0-0">
+      <template #append>
+        <v-btn @click="onClose" size="small" variant="text" icon="mdi-close" />
+      </template>
+    </v-toolbar>
+    <v-sheet style="overflow-y: auto">
+      <HtmlDisplay :url />
+    </v-sheet>
+  </div>
+</template>
+
+<script setup lang="ts">
+import HtmlDisplay from '@/components/general/HtmlDisplay.vue'
+import { getResourcesStaticUrl } from '@/lib/fews-config'
+import { TopologyNode } from '@deltares/fews-pi-requests'
+import { computed } from 'vue'
+
+interface Props {
+  topologyNode?: TopologyNode
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits(['close'])
+
+function onClose() {
+  emit('close')
+}
+
+const url = computed(() => {
+  const resource = props.topologyNode?.documentFile
+  if (!resource) return
+
+  return getResourcesStaticUrl(resource)
+})
+</script>

--- a/src/views/InformationDisplayView.vue
+++ b/src/views/InformationDisplayView.vue
@@ -5,14 +5,13 @@
         <v-btn @click="onClose" size="small" variant="text" icon="mdi-close" />
       </template>
     </v-toolbar>
-    <v-sheet style="overflow-y: auto">
-      <HtmlDisplay :url />
+    <v-sheet class="flex-1-1">
+      <iframe :src="url" class="w-100 h-100 ma-0 pa-0 border-none" />
     </v-sheet>
   </div>
 </template>
 
 <script setup lang="ts">
-import HtmlDisplay from '@/components/general/HtmlDisplay.vue'
 import { getResourcesStaticUrl } from '@/lib/fews-config'
 import { TopologyNode } from '@deltares/fews-pi-requests'
 import { computed } from 'vue'

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -128,7 +128,7 @@
     </router-view>
     <div
       v-if="showInformationDisplay"
-      class="information-display"
+      class="w-100 h-100"
       :style="informationDisplayStyle"
     >
       <InformationDisplayView
@@ -231,7 +231,7 @@ const externalLink = ref<string | undefined>('')
 const { mobile } = useDisplay()
 const informationDisplayStyle = computed<StyleValue>(() => {
   return {
-    width: mobile.value ? '100%' : '40%',
+    flex: mobile.value ? undefined : '0 0 33%',
     position: mobile.value ? 'fixed' : undefined,
     'z-index': mobile.value ? 999999 : undefined,
     'border-left': mobile.value ? undefined : '1px solid #e0e0e0',
@@ -608,9 +608,5 @@ function reroute(to: RouteLocationNormalized) {
 <style scoped>
 .v-btn-group {
   color: inherit;
-}
-
-.information-display {
-  height: 100%;
 }
 </style>

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -231,9 +231,10 @@ const externalLink = ref<string | undefined>('')
 const { mobile } = useDisplay()
 const informationDisplayStyle = computed<StyleValue>(() => {
   return {
-    width: mobile.value ? '100%' : '30%',
+    width: mobile.value ? '100%' : '40%',
     position: mobile.value ? 'fixed' : undefined,
     'z-index': mobile.value ? 999999 : undefined,
+    'border-left': mobile.value ? undefined : '1px solid #e0e0e0',
   }
 })
 const showInformationDisplay = ref(false)
@@ -611,6 +612,5 @@ function reroute(to: RouteLocationNormalized) {
 
 .information-display {
   height: 100%;
-  border-left: 1px solid #e0e0e0;
 }
 </style>


### PR DESCRIPTION
### Description

If a documentFile is set in the topology shows an information button opening up an iframe display of the document.

### Screenshots
![image](https://github.com/user-attachments/assets/b9799bfe-c13d-4bdb-b104-af5f53070326)
![image](https://github.com/user-attachments/assets/f1012c16-3f0a-42a1-bfc1-252d0bab301c)
![image](https://github.com/user-attachments/assets/0f60501a-8773-4c51-a6ab-794b597216df)
![image](https://github.com/user-attachments/assets/db09e51b-2afb-4867-a23f-a31e0ddf8070)

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [ ] Update documentation.
- [ ] Update tests.
