### PR TITLE
Fix for HtmlDisplay if more than one <style> in Html Document

### DIFF
--- a/src/components/general/HtmlDisplay.vue
+++ b/src/components/general/HtmlDisplay.vue
@@ -20,7 +20,7 @@ const htmlText = computedAsync(async () => {
     const text = await response.text()
     if (response.ok) {
       // Remove style since this leaks into our global styles
-      const textWithoutStyle = text.replaceAll(/<style>(.|\n)*<\/style>/g, '')
+      const textWithoutStyle = text.replaceAll(/<style>(.|\n)*?<\/style>/g, '')
       return textWithoutStyle
     }
   } catch (error) {


### PR DESCRIPTION
### Description

If the WebOC tries to open a html file which has more that one <style> element, it does not load the file.

