### PR TITLE
Fix: Point Locations not clickable when together with Polygon location

### DIFF
--- a/src/components/wms/LocationsLayer.vue
+++ b/src/components/wms/LocationsLayer.vue
@@ -215,9 +215,9 @@ onBeforeMount(() => {
 onBeforeUnmount(() => {
   if (map) {
     for (const layerId of [
+      locationsFillLayerId,
       locationsCircleLayerId,
       locationsSymbolLayerId,
-      locationsFillLayerId,
     ]) {
       map.off('click', layerId, clickHandler)
       map.off('mouseenter', layerId, setCursorPointer)


### PR DESCRIPTION
### Description
rel: fixes
Point locaitons was not cliackable when a polygon location was also added in the topology node.

