### PR TITLE
Fix issue with image placement when maps show multiple Earths

### DIFF
--- a/src/components/wms/AnimatedRasterLayer.vue
+++ b/src/components/wms/AnimatedRasterLayer.vue
@@ -115,13 +115,16 @@ function getImageSourceOptions(): any {
   const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
   const time = props.layer.time.toISOString()
   let bounds = map.getBounds()
-  let { width, height}  = map.getCanvas()
+  let { width, height } = map.getCanvas()
 
   // Check if we have a multiple Earths on the map
   // Then reduce the bounds and image width to contain only one Earth
   if (bounds.getEast() - bounds.getWest() > 360) {
-    width = width  * 360 / ( bounds.getEast() - bounds.getWest())
-    bounds = new LngLatBounds(new LngLat(-180, bounds.getSouth()), new LngLat(180, bounds.getNorth()))
+    width = (width * 360) / (bounds.getEast() - bounds.getWest())
+    bounds = new LngLatBounds(
+      new LngLat(-180, bounds.getSouth()),
+      new LngLat(180, bounds.getNorth()),
+    )
   }
 
   const getMapUrl = new URL(`${baseUrl}/wms`)


### PR DESCRIPTION
### Description

Fix for issue where WMS layer stretched and not a the right coordinates when the maps has multiple Earths.

### Screenshots (if applicable)

If there are any visual changes, please attach screenshots here.

### Checklist
- [ ] Make the title short and concise
- [ ] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [ ] Update documentation.
- [ ] Update tests.
