### PR TITLE
Fix: topology node acts as link for leaf nodes with only a url

### DIFF
--- a/src/components/general/TreeMenuItem.vue
+++ b/src/components/general/TreeMenuItem.vue
@@ -25,13 +25,13 @@
         ></TreeMenuItem>
       </v-list-group>
     </template>
-    <v-list-item
-      v-else
-      :to="item.to"
-      :href="item.href"
-      :target="item.href ? '_blank' : undefined"
-      :active="props.active === item.id"
-    >
+    <v-list-item v-else-if="item.href" :href="item.href" target="_blank">
+      <v-list-item-title>{{ item.name }}</v-list-item-title>
+      <template v-slot:append>
+        <v-icon size="xsmall">mdi-open-in-new</v-icon>
+      </template>
+    </v-list-item>
+    <v-list-item v-else :to="item.to" :active="props.active === item.id">
       <v-list-item-title>{{ item.name }}</v-list-item-title>
       <template v-slot:append>
         <v-icon v-if="item.icon" size="xsmall">{{ item.icon }}</v-icon>


### PR DESCRIPTION
### Description

The menu item in the topology tree acts as link for a leaf node with only a configured url.

### Screenshots (if applicable)

![topology-url](https://github.com/user-attachments/assets/ca9a31e5-371b-4af3-b8fa-5c49aca3fdd4)

### Checklist
- [ ] Make the title short and concise
- [ ] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [ ] Update documentation.
- [ ] Update tests.
