### PR TITLE
Fix range not updating legend when layer capabilities has no styles

### DIFF
--- a/src/components/spatialdisplay/SpatialDisplayComponent.vue
+++ b/src/components/spatialdisplay/SpatialDisplayComponent.vue
@@ -297,7 +297,10 @@ watch(
           () => settings.useDisplayUnits,
           range,
           style,
-          () => props.layerCapabilities?.styles ?? [],
+          () =>
+            props.layerCapabilities
+              ? (props.layerCapabilities.styles ?? [style])
+              : undefined,
         )
 
         watch(newLegendGraphic, () => {

--- a/src/services/useWms/index.ts
+++ b/src/services/useWms/index.ts
@@ -94,9 +94,9 @@ export function useWmsLegend(
   baseUrl: string,
   layerName: MaybeRefOrGetter<string>,
   useDisplayUnits: MaybeRefOrGetter<boolean>,
-  colorScaleRange?: MaybeRefOrGetter<string | undefined>,
-  style?: MaybeRefOrGetter<Style>,
-  activeStyles?: MaybeRefOrGetter<Style[]>,
+  colorScaleRange: MaybeRefOrGetter<string | undefined>,
+  style: MaybeRefOrGetter<Style | undefined>,
+  activeStyles: MaybeRefOrGetter<Style[] | undefined>,
 ): Ref<GetLegendGraphicResponse | undefined> {
   const legendGraphic = ref<GetLegendGraphicResponse>()
 


### PR DESCRIPTION
### Description

Use default layer style when layer has no layer capabilities styles to fix range not updating legend.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
