### PR TITLE
Remove report id from report selection and add current subtitle

### DIFF
--- a/src/views/ReportsDisplayView.vue
+++ b/src/views/ReportsDisplayView.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="reports?.length" class="d-flex flex-column h-100 w-100">
-    <v-toolbar class="py-1" density="compact">
+    <v-toolbar density="compact">
       <template v-if="reports.length === 1">
         <div class="ml-5">{{ reportToTitle(reports[0]) }}</div>
         <v-spacer />
@@ -106,7 +106,7 @@ function reportItemToId(item: ReportItem) {
 }
 
 function reportItemToTitle(item: ReportItem) {
-  return `${item.timeZero} - ${item.reportId}`
+  return `${item.timeZero}`
 }
 
 function reportToTitle(item: Report) {

--- a/src/views/ReportsDisplayView.vue
+++ b/src/views/ReportsDisplayView.vue
@@ -25,6 +25,9 @@
         return-object
         :item-title="(item) => reportItemToTitle(item)"
         :item-value="(item) => reportItemToId(item)"
+        :item-props="
+          (item) => ({ subtitle: item.isCurrent ? 'Current' : undefined })
+        "
         hide-details
         label="Analysis time"
         class="pe-2 flex-0-0"


### PR DESCRIPTION
### Description

Makes the reports toolbar the same size as the top bar, removes report id as it was confusing and adds current subtitle to the current report.

### Screenshots

![image](https://github.com/user-attachments/assets/35fb2397-6eb7-4531-85fe-c8a391e55891)

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
