### PR TITLE
Allow for multiple topology displays

### DIFF
--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -40,40 +40,41 @@
             <v-list-item-title v-text="item.title"></v-list-item-title>
           </v-list-item>
         </v-list>
-        <v-menu
-          origin="bottom"
-          width="320"
+        <v-list
           v-else-if="configStore.activeComponents.length > 1"
+          density="compact"
         >
-          <template #activator="{ props }">
-            <v-list-item
-              aria-label="Menu button"
-              v-bind="props"
-              :title="currentItemTitle"
-              class="ma-2 mb-1 px-2"
-              :prepend-icon="
-                activeComponent?.icon ?? toCharacterIcon(currentItemTitle)
-              "
-              append-icon="mdi-chevron-right"
-              rounded
-              variant="tonal"
-            />
-          </template>
-          <v-list density="compact">
-            <v-list-subheader>Switch to</v-list-subheader>
-            <v-list-item
-              v-for="(item, i) in configStore.activeComponents"
-              :key="i"
-              :value="item"
-              :to="item.to"
-            >
-              <template v-slot:prepend>
-                <v-icon :icon="item.icon"></v-icon>
-              </template>
-              <v-list-item-title v-text="item.title"></v-list-item-title>
-            </v-list-item>
-          </v-list>
-        </v-menu>
+          <v-list-subheader>Switch to</v-list-subheader>
+          <v-menu origin="bottom" width="320">
+            <template #activator="{ props }">
+              <v-list-item
+                aria-label="Menu button"
+                v-bind="props"
+                :title="currentItemTitle"
+                class="ma-2 mb-1 px-2"
+                :prepend-icon="
+                  activeComponent?.icon ?? toCharacterIcon(currentItemTitle)
+                "
+                append-icon="mdi-chevron-right"
+                rounded
+                variant="tonal"
+              />
+            </template>
+            <v-list density="compact">
+              <v-list-item
+                v-for="(item, i) in configStore.activeComponents"
+                :key="i"
+                :value="item"
+                :to="item.to"
+              >
+                <template v-slot:prepend>
+                  <v-icon :icon="item.icon"></v-icon>
+                </template>
+                <v-list-item-title v-text="item.title"></v-list-item-title>
+              </v-list-item>
+            </v-list>
+          </v-menu>
+        </v-list>
         <div
           class="d-flex pa-2 bg-surface-light"
           id="web-oc-toolbar-target"

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -233,18 +233,11 @@ watch(
   },
 )
 
-const parentRoute = computed(() => route.matched[0])
-
-const activeComponent = computed(() => {
-  if (parentRoute.value === undefined) return
-  const parentRouteName = parentRoute.value.name?.toString() ?? ''
-  return configStore.getComponentByType(parentRouteName)
-})
-
+const activeComponent = computed(() => configStore.getComponentByRoute(route))
 const currentItemTitle = computed(
   () =>
     activeComponent.value?.title ??
-    (parentRoute.value?.meta?.title as string | undefined) ??
+    (route.matched[0]?.meta?.title as string | undefined) ??
     '',
 )
 

--- a/src/lib/fews-config/types.ts
+++ b/src/lib/fews-config/types.ts
@@ -1,31 +1,68 @@
-import { WebOcGeneralConfig } from '@deltares/fews-pi-requests'
+import type {
+  WebOcSchematicStatusDisplayConfig as WebOcSchematicStatusDisplayConfigUnTyped,
+  WebOcSpatialDisplayConfig as WebOcSpatialDisplayConfigUnTyped,
+  WebOcTopologyDisplayConfig as WebOcTopologyDisplayConfigUnTyped,
+  WebOcSystemMonitorConfig as WebOcSystemMonitorConfigUnTyped,
+  WebOcGeneralConfig,
+} from '@deltares/fews-pi-requests'
+
+// needs to be fixed in Open API schema
+
+export interface WebOcSpatialDisplayConfig
+  extends WebOcSpatialDisplayConfigUnTyped {
+  type: 'SpatialDisplay'
+}
+
+export interface WebOcSchematicStatusDisplayConfig
+  extends WebOcSchematicStatusDisplayConfigUnTyped {
+  type: 'SchematicStatusDisplay'
+}
+
+export interface WebOcTopologyDisplayConfig
+  extends WebOcTopologyDisplayConfigUnTyped {
+  type: 'TopologyDisplay'
+}
+
+export interface WebOcSystemMonitorConfig
+  extends WebOcSystemMonitorConfigUnTyped {
+  type: 'SystemMonitor'
+}
+
+// needs to be added to Open API schema
+interface HtmlDisplayConfig {
+  id: string
+  type: 'HtmlDisplay'
+  icon: string
+  title: string
+  path: string
+  url: string
+  showInNavigationMenu: boolean
+}
 
 export interface WebOcConfiguration {
   general: WebOcGeneralConfig
   webOcComponents: WebOcComponent[]
 }
 
-export interface WebOcComponent {
-  id: string
-  type: ComponentType
-  title?: string
-  icon?: string
-  defaultPath?: any
-  showLeafNodesAsButtons?: boolean
-  path?: string
-  url?: string
-  showInNavigationMenu?: boolean
+export type WebOcComponent =
+  | WebOcSpatialDisplayConfig
+  | WebOcSchematicStatusDisplayConfig
+  | WebOcTopologyDisplayConfig
+  | WebOcSystemMonitorConfig
+  | HtmlDisplayConfig
+
+export function hasDefaultPath(
+  component: WebOcComponent,
+): component is
+  | WebOcSpatialDisplayConfig
+  | WebOcSchematicStatusDisplayConfig
+  | WebOcTopologyDisplayConfig {
+  return (
+    (
+      component as
+        | WebOcSpatialDisplayConfig
+        | WebOcSchematicStatusDisplayConfig
+        | WebOcTopologyDisplayConfig
+    ).defaultPath !== undefined
+  )
 }
-
-export const ComponentTypeEnum = {
-  DataViewer: 'DataViewer',
-  SpatialDisplay: 'SpatialDisplay',
-  SchematicStatusDisplay: 'SchematicStatusDisplay',
-  TimeSeriesDisplay: 'TimeSeriesDisplay',
-  SystemMonitor: 'SystemMonitor',
-  ArchiveDisplay: 'ArchiveDisplay',
-  TopologyDisplay: 'TopologyDisplay',
-} as const
-
-export type ComponentType =
-  (typeof ComponentTypeEnum)[keyof typeof ComponentTypeEnum]

--- a/src/lib/fews-config/types.ts
+++ b/src/lib/fews-config/types.ts
@@ -33,6 +33,7 @@ interface HtmlDisplayConfig {
   id: string
   type: 'HtmlDisplay'
   icon: string
+  iconId: string
   title: string
   path: string
   url: string

--- a/src/lib/topology/displayTabs.ts
+++ b/src/lib/topology/displayTabs.ts
@@ -77,10 +77,15 @@ const displayTabs: DisplayTab[] = [
   },
 ]
 
-export function displayTabsForNode(node: TopologyNode, parentNodeId?: string) {
+export function displayTabsForNode(
+  node: TopologyNode,
+  parentNodeId?: string,
+  topologyId?: string,
+) {
   for (const tab of displayTabs) {
     const params = {
       nodeId: parentNodeId ? [parentNodeId, node.id] : node.id,
+      topologyId,
     }
     switch (tab.type) {
       case 'map':

--- a/src/stores/config.ts
+++ b/src/stores/config.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 import { getFewsConfig } from '../lib/fews-config/index.js'
 import type { WebOcGeneralConfig } from '@deltares/fews-pi-requests'
 import { ComponentTypeEnum, type WebOcComponent } from '@/lib/fews-config/types'
+import { RouteLocation } from 'vue-router'
 
 interface ConfigState {
   version: string
@@ -71,6 +72,27 @@ const useConfigStore = defineStore('config', {
       )
       if (component) component.icon = getMenuIcon(component)
       return component
+    },
+
+    getComponentById(componentId: string) {
+      const component = this.components[componentId]
+      if (component) component.icon = getMenuIcon(component)
+      return component
+    },
+
+    getComponentByRoute(route: RouteLocation) {
+      const rootRoute = route.matched[0]
+      if (rootRoute === undefined) return
+
+      const rootRouteName = rootRoute.name?.toString() ?? ''
+      if (
+        rootRouteName === 'TopologyDisplay' &&
+        route.params.topologyId !== undefined
+      ) {
+        return this.getComponentById(route.params.topologyId as string)
+      }
+
+      return this.getComponentByType(rootRouteName)
     },
 
     getComponentsByType(componentType: string) {

--- a/src/stores/config.ts
+++ b/src/stores/config.ts
@@ -10,8 +10,14 @@ interface ConfigState {
   general: WebOcGeneralConfig
 }
 
+/**
+ * Retrieves the menu icon for a given component configuration.
+ * @param componentConfig - The configuration of the component.
+ * @returns The icon string for the component.
+ */
 function getMenuIcon(componentConfig: WebOcComponent): string {
-  if (componentConfig.icon !== undefined) return componentConfig.icon
+  const configuredIcon = componentConfig.icon ?? componentConfig.iconId
+  if (configuredIcon) return configuredIcon
   switch (componentConfig.type) {
     case 'SpatialDisplay':
       return 'mdi-map'

--- a/src/stores/config.ts
+++ b/src/stores/config.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { getFewsConfig } from '../lib/fews-config/index.js'
-import { WebOcGeneralConfig } from '@deltares/fews-pi-requests'
-import { ComponentTypeEnum, WebOcComponent } from '../lib/fews-config/types.js'
+import type { WebOcGeneralConfig } from '@deltares/fews-pi-requests'
+import { ComponentTypeEnum, type WebOcComponent } from '@/lib/fews-config/types'
 
 interface ConfigState {
   version: string
@@ -27,6 +27,16 @@ function getMenuIcon(componentConfig: WebOcComponent): string {
     default:
       return ''
   }
+}
+
+function getToForComponent(component: WebOcComponent) {
+  if (component.type === ComponentTypeEnum.TopologyDisplay) {
+    return {
+      name: component.type,
+      params: { topologyId: component.id },
+    }
+  }
+  return { name: component.type }
 }
 
 const useConfigStore = defineStore('config', {
@@ -81,7 +91,7 @@ const useConfigStore = defineStore('config', {
         .map((component) => {
           return {
             id: component.id,
-            to: { name: component.type },
+            to: getToForComponent(component),
             title: component.title ?? '',
             icon: getMenuIcon(component),
             showInNavigationMenu: component.showInNavigationMenu,

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -371,19 +371,13 @@ function reroute(to: RouteLocationNormalized) {
         Array.isArray(to.params.nodeId) && to.params.nodeId.length > 1
           ? to.params.nodeId[0]
           : undefined
-      const menuNode = topologyMap.value.get(leafNodeId)
-      const tabs = displayTabsForNode(menuNode as any, parentNodeId)
-      let tabIndex = -1
-      if (activeTab.value) {
-        tabIndex = tabs.findIndex((t) => {
-          return t.type === activeTab.value
-        })
+      const menuNode = topologyMap.value.get(leafNodeId) as TopologyNode
+      const tabs = displayTabsForNode(menuNode, parentNodeId)
+      const tab = tabs.find((t) => t.type === activeTab.value) ?? tabs[0]
+      if (tab) {
+        activeTab.value = tab.type
+        return tab.to
       }
-      if (tabIndex < 0) {
-        tabIndex = 0
-        activeTab.value = tabs.length ? tabs[0].type : ''
-      }
-      return tabs[tabIndex].to
     }
   }
 }

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -387,7 +387,8 @@ function reroute(to: RouteLocationNormalized) {
           ? to.params.nodeId[0]
           : undefined
       const menuNode = topologyMap.value.get(leafNodeId) as TopologyNode
-      const tabs = displayTabsForNode(menuNode, parentNodeId)
+      const topologyId = to.params.topologyId as string
+      const tabs = displayTabsForNode(menuNode, parentNodeId, topologyId)
       const tab = tabs.find((t) => t.type === activeTab.value) ?? tabs[0]
       if (tab) {
         activeTab.value = tab.type

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -234,14 +234,14 @@ watch(
 const topologyComponentConfig = computed(() => {
   const component = props.topologyId
     ? configStore.getComponentById(props.topologyId)
-    : configStore.getComponentsByType('TopologyDisplay')
+    : configStore.getComponentByType('TopologyDisplay')
   return component as WebOcTopologyDisplayConfig | undefined
 })
 
-const topologyDisplayNodes = computed<string[]>(() => {
+const topologyDisplayNodes = computed<string[] | undefined>(() => {
   // FIXME: Update when the types are updated
   // @ts-expect-error
-  return topologyComponentConfig.value?.topologyDisplayNodes ?? []
+  return topologyComponentConfig.value?.topologyDisplayNodes
 })
 
 const showLeafsAsButton = computed(() => {
@@ -257,7 +257,7 @@ const showActiveThresholdCrossingsForFilters = computed(() => {
 
 const nodes = ref<TopologyNode[]>()
 const topologyMap = ref(new Map<string, TopologyNode>())
-const subNodes = computed<TopologyNode[]>(
+const subNodes = computed<TopologyNode[] | undefined>(
   () =>
     topologyDisplayNodes.value?.flatMap((nodeId) => {
       const node = topologyMap.value.get(nodeId)


### PR DESCRIPTION
### Description

Add topologyId to the route and use it to select unique topologyDisplay and its selected subnodes.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
