### PR TITLE
Improvements location and colourbar labels

### DIFF
--- a/src/components/wms/ColourBar.vue
+++ b/src/components/wms/ColourBar.vue
@@ -109,15 +109,20 @@ function updateColourBar() {
   fill: white;
   text-rendering: optimizeLegibility;
   text-shadow:
-    black 0px 0px 2px,
-    black 0px 0px 4px,
-    black 0px 0px 6px;
+    -1px 0 1px rgba(0, 0, 0, 0.6),
+    1px 0 1px rgba(0, 0, 0, 0.6),
+    0 1px 1px rgba(0, 0, 0, 0.6),
+    0 -1px 1px rgba(0, 0, 0, 0.6);
 }
 
 .map__colour-bar :deep(.axis .tick line) {
   stroke: white;
-  filter: drop-shadow(0px 0px 2px black) drop-shadow(0px 0px 4px black)
-    drop-shadow(0px 0px 6px black);
+  stroke-width: 1px;
+  filter: drop-shadow(-1px 0 0.5px rgba(0, 0, 0, 0.3))
+    drop-shadow(1px 0 0.5px rgba(0, 0, 0, 0.3))
+    drop-shadow(0 1px 0.5px rgba(0, 0, 0, 0.3))
+    drop-shadow(0 -1px 0.5px rgba(0, 0, 0, 0.3));
+  shape-rendering: crispEdges;
 }
 
 .map__colour-bar :deep(.grid) {

--- a/src/components/wms/LocationsLayer.vue
+++ b/src/components/wms/LocationsLayer.vue
@@ -124,6 +124,9 @@ const layoutTextSpecification = {
 const paintTextSpecification = computed(() => {
   return {
     'text-color': isDark.value ? 'rgb(255,255,255)' : 'rgb(0,0,0)',
+    'text-halo-color': isDark.value ? 'rgb(0,0,0)' : 'rgb(255,255,255)',
+    'text-halo-width': 1,
+    'text-halo-blur': 1,
   }
 })
 


### PR DESCRIPTION
### Description

A shadow has been added to the location labels, to improve readibility. For consistency (and improved readibility), the shadows of the colour bar are changed to look the same as those of the location labels.

### Screenshots

Location label before (no shadow around text):
![location_labels_before](https://github.com/user-attachments/assets/cc662b0e-8cde-4be9-994d-68cf9f0dd71e)

Location label after (with shadow around text):
![location_labels_after](https://github.com/user-attachments/assets/fa170fd1-7c6f-4acd-b338-dacdb4c8158f)

Colourbar before (note the amount of blur):
![colourbar_before](https://github.com/user-attachments/assets/e7664381-2680-46c4-9c31-706d4bd188d4)

Colourbar after (blur is reduced. The shadow around the text and tick is more crisp):
![colourbar_after](https://github.com/user-attachments/assets/e41b7a05-d3ac-47f7-831d-7e5b85c3157e)
