### PR TITLE
Make series only editable if an editRequest is present in the request

### DIFF
--- a/src/components/timeseries/TimeSeriesComponent.vue
+++ b/src/components/timeseries/TimeSeriesComponent.vue
@@ -207,6 +207,13 @@ watch(
     const series = newSubplots
       .flatMap((subplot) => subplot.series)
       .filter((series) => series.visibleInTable)
+
+    series.forEach((s) => {
+      s.editable = props.config.requests.some(
+        (request) => request.key === s.id && request.editRequest,
+      )
+    })
+
     tableConfig.value = {
       title: props.config.title,
       series,

--- a/src/lib/charts/types/ChartSeries.ts
+++ b/src/lib/charts/types/ChartSeries.ts
@@ -15,4 +15,5 @@ export interface ChartSeries {
   options: ChartSeriesOptions
   unit: string
   style: CSS.SvgPropertiesHyphen
+  editable?: boolean
 }

--- a/src/lib/table/createTableHeaders.ts
+++ b/src/lib/table/createTableHeaders.ts
@@ -19,7 +19,7 @@ export function createTableHeaders(
         key: chartSeries.id,
         title: formatHeader(chartSeries),
         color: chartSeries.style.stroke?.toString(),
-        editable: true,
+        editable: chartSeries.editable ?? false,
       })
     }
   })


### PR DESCRIPTION
### Description

Check if time series are editable by the presence of `editRequest` property, disable editing otherwise.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [ ] Update documentation.
- [ ] Update tests.
