### PR TITLE
Remove information panel layer name capitalization

### DIFF
--- a/src/components/wms/InformationPanel.vue
+++ b/src/components/wms/InformationPanel.vue
@@ -14,7 +14,7 @@
       v-if="showLayer"
     >
       <template v-slot:activator="{ props }">
-        <v-btn variant="plain" v-bind="props" class="pe-0 text-capitalize">
+        <v-btn variant="plain" v-bind="props" class="pe-0 text-none">
           <span
             class="me-2"
             :class="{ 'text-decoration-line-through': props.completelyMissing }"


### PR DESCRIPTION
### Description

Removes the information panel layer name capitalization so PH becomes pH.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
