### PR TITLE
Keep zoom level the same between layers with the same bounds

### DIFF
--- a/src/components/map/MapComponent.vue
+++ b/src/components/map/MapComponent.vue
@@ -13,6 +13,7 @@
     :touchZoomRotate="false"
     :touchPitch="false"
     :attributionControl="false"
+    :bounds="bounds"
   >
     <mgl-attribution-control position="top-right" :compact="true" />
     <mgl-scale-control position="bottom-right" />
@@ -29,9 +30,15 @@ import {
   MglMap,
   MglScaleControl,
 } from '@indoorequal/vue-maplibre-gl'
-import { type ResourceType, type RequestParameters } from 'maplibre-gl'
+import type { ResourceType, RequestParameters, LngLatBounds } from 'maplibre-gl'
 import { useBaseLayers } from '@/services/useBaseLayers'
 import { useUserSettingsStore } from '@/stores/userSettings'
+
+interface Props {
+  bounds?: LngLatBounds
+}
+
+defineProps<Props>()
 
 const settings = useUserSettingsStore()
 

--- a/src/components/spatialdisplay/SpatialDisplayComponent.vue
+++ b/src/components/spatialdisplay/SpatialDisplayComponent.vue
@@ -1,5 +1,5 @@
 <template>
-  <MapComponent>
+  <MapComponent :bounds="bounds">
     <AnimatedRasterLayer
       v-if="layerKind === LayerKind.Static && showLayer && layerOptions"
       v-model:isLoading="isLoading"
@@ -144,6 +144,7 @@ import debounce from 'lodash-es/debounce'
 import { useUserSettingsStore } from '@/stores/userSettings'
 import {
   LngLat,
+  type LngLatBounds,
   type MapLayerMouseEvent,
   type MapLayerTouchEvent,
 } from 'maplibre-gl'
@@ -452,6 +453,20 @@ function setLayerOptions(): void {
     layerOptions.value = undefined
   }
 }
+
+const bounds = ref<LngLatBounds>()
+watch(
+  () => layerOptions.value?.bbox,
+  (layerBounds) => {
+    if (!layerBounds) return
+
+    const boundsChanged = bounds.value?.toString() !== layerBounds.toString()
+    if (boundsChanged) {
+      bounds.value = layerBounds
+    }
+  },
+  { immediate: true },
+)
 
 function onCoordinateClick(
   event: MapLayerMouseEvent | MapLayerTouchEvent,

--- a/src/components/wms/AnimatedRasterLayer.vue
+++ b/src/components/wms/AnimatedRasterLayer.vue
@@ -3,7 +3,7 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, onMounted, onUnmounted, watch } from 'vue'
+import { onMounted, onUnmounted, watch } from 'vue'
 import { toMercator } from '@turf/projection'
 import {
   ImageSource,
@@ -183,8 +183,6 @@ function createSource() {
     },
   }
   map.addLayer(rasterLayer, 'boundary_country_outline')
-
-  setDefaultZoom()
 }
 
 function updateSource() {
@@ -197,14 +195,6 @@ function getMercatorBboxFromBounds(bounds: LngLatBounds): number[] {
   const sw = toMercator(point(bounds.getSouthWest().toArray()))
   const ne = toMercator(point(bounds.getNorthEast().toArray()))
   return [...sw.geometry.coordinates, ...ne.geometry.coordinates]
-}
-
-function setDefaultZoom() {
-  if (props.layer === undefined || props.layer.bbox === undefined) return
-  const bounds = props.layer.bbox
-  nextTick(() => {
-    map?.fitBounds(bounds)
-  })
 }
 
 function removeLayer() {


### PR DESCRIPTION
### Description

Don't zoom to the layer bounds when the new bounds are the same as the old ones.
Fixes #1077 and #1076 

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
