### PR TITLE
Add satellite background style

### DIFF
--- a/src/assets/DefaultUserSettings.json
+++ b/src/assets/DefaultUserSettings.json
@@ -99,6 +99,10 @@
       {
         "value": "carto-dark-matter",
         "icon": "mdi-weather-night"
+      },
+      {
+        "value": "esri-relief",
+        "icon": "mdi-terrain"
       }
     ],
     "group": "Map"

--- a/src/assets/base-layers.json
+++ b/src/assets/base-layers.json
@@ -52,6 +52,12 @@
           "attribution": "Tiles &copy; Esri, DigitalGlobe, GeoEye, Earthstar Geographics, CNES/Airbus DS, USDA, USGS, AEX, Getmapping, Aerogrid, IGN, IGP, swisstopo, and the GIS User Community"
         }
       ]
+    },
+    {
+      "id": "esri-relief",
+      "name": "ESRI World Relief Map",
+      "type": "vector",
+      "style": "/baselayers/esri/style.json"
     }
   ]
 }

--- a/src/components/wms/AnimatedRasterLayer.vue
+++ b/src/components/wms/AnimatedRasterLayer.vue
@@ -16,6 +16,7 @@ import {
 import { configManager } from '@/services/application-config'
 import { useMap } from '@indoorequal/vue-maplibre-gl'
 import { point } from '@turf/helpers'
+import { getLayerId, getSourceId, isCustomLayer } from '@/lib/map'
 
 export interface AnimatedRasterLayerOptions {
   name: string
@@ -182,7 +183,11 @@ function createSource() {
       'raster-fade-duration': 0,
     },
   }
-  map.addLayer(rasterLayer, 'boundary_country_outline')
+  const beforeId = map
+    ?.getStyle()
+    .layers.map((l) => l.id)
+    .find(isCustomLayer)
+  map.addLayer(rasterLayer, beforeId)
 
   setDefaultZoom()
 }

--- a/src/components/wms/AnimatedStreamlineRasterLayer.vue
+++ b/src/components/wms/AnimatedStreamlineRasterLayer.vue
@@ -15,6 +15,7 @@ import {
 import { configManager } from '@/services/application-config'
 import { type AnimatedRasterLayerOptions } from '@/components/wms/AnimatedRasterLayer.vue'
 import type { MapLayerMouseEvent, MapLayerTouchEvent } from 'maplibre-gl'
+import { getLayerId, isCustomLayer } from '@/lib/map'
 
 type StreamlineLayerOptionsFews = Layer['animatedVectors']
 
@@ -118,7 +119,11 @@ function addLayer(): void {
     )
   })
 
-  map?.addLayer(layer, 'boundary_country_outline')
+  const beforeId = map
+    ?.getStyle()
+    .layers.map((l) => l.id)
+    .find(isCustomLayer)
+  map?.addLayer(layer, beforeId)
   map?.on('dblclick', onDoubleClick)
 }
 

--- a/src/services/useBaseLayers/index.ts
+++ b/src/services/useBaseLayers/index.ts
@@ -4,6 +4,7 @@ import Basemaps from '@/assets/base-layers.json'
 import { MglDefaults } from '@indoorequal/vue-maplibre-gl'
 import { useDark } from '@vueuse/core'
 import { StyleSpecification } from 'maplibre-gl'
+import { getResourcesStaticUrl } from '@/lib/fews-config'
 
 export interface UseBaseLayersReturn {
   baseLayerStyle: ShallowRef<string | StyleSpecification>
@@ -39,6 +40,14 @@ export function useBaseLayers(
       }
     } else if (layerDefinition?.style) {
       baseLayerStyle.value = layerDefinition?.style
+    }
+
+    if (
+      baseLayerStyle.value &&
+      typeof baseLayerStyle.value === 'string' &&
+      baseLayerStyle.value.startsWith('/')
+    ) {
+      baseLayerStyle.value = getResourcesStaticUrl(baseLayerStyle.value)
     }
   })
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,7 +40,7 @@ export default defineConfig(({ mode }) => {
           `style-src 'self' 'unsafe-inline'`, // vuetify
           `worker-src blob:`, // maplibre-gl
           `img-src 'self' data: blob: ${env.VITE_FEWS_WEBSERVICES_URL}`, // FEWS webservices
-          `connect-src 'self' https://basemaps.cartocdn.com https://*.basemaps.cartocdn.com https://login.microsoftonline.com ${env.VITE_FEWS_WEBSERVICES_URL}`, // FEWS webservices, Authentication, Basemaps
+          `connect-src 'self' https://basemaps.cartocdn.com https://*.basemaps.cartocdn.com https://tiles.arcgis.com https://login.microsoftonline.com ${env.VITE_FEWS_WEBSERVICES_URL}`, // FEWS webservices, Authentication, Basemaps
           `frame-src 'self' ${env.VITE_FEWS_WEBSERVICES_URL}`,
         ].join('; '),
       },


### PR DESCRIPTION
### Description

Depends on #1079 
Adds the esri style.json from the static resources.
How would we want to configure this in the future?

The currently configured layer is not a satellite layer and also becomes blurry when zooming in as the endpoint starts  returning 404's for our requests.

### Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/cbc22285-787e-41ab-bc0a-c23a80b8fbc7)

Zoomed in:
![image](https://github.com/user-attachments/assets/afd279b7-5492-496a-871f-5cb949b76091)


### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
