### PR TITLE
Remove special SSD dashboard panel treatment

### DIFF
--- a/src/components/general/DashboardDisplay.vue
+++ b/src/components/general/DashboardDisplay.vue
@@ -4,9 +4,8 @@
       <v-card
         v-if="panel.component"
         :style="{ gridArea: panel.id }"
-        class="dashboard-card"
+        class="d-flex flex-column"
         density="compact"
-        :flat="panel.id.includes('ssd')"
       >
         <component
           class="overflow-auto"
@@ -91,11 +90,5 @@ watch(
   );
   height: 100%;
   width: 100%;
-}
-
-.dashboard-card {
-  display: flex;
-  flex-direction: column;
-  background-color: transparent;
 }
 </style>


### PR DESCRIPTION
### Description

Removes the transparency of ssd dashboard panels.
Does cause small black strips to show up in dark mode.

### Screenshots (if applicable)
# Before:
![image](https://github.com/user-attachments/assets/664e5663-6bf4-4df0-ae68-2d44a8a4d5e0)
![image](https://github.com/user-attachments/assets/fa6337cb-37c6-4106-9332-d607e42220e9)
# After:
![image](https://github.com/user-attachments/assets/4b045b53-160b-4265-8baa-cf6fa276cef7)
![image](https://github.com/user-attachments/assets/3420a2a4-2957-48e5-a8ae-3ab21f644a56)

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
