### PR TITLE
Set time zero for running tasks

### DIFF
--- a/src/components/general/DateTimeField.vue
+++ b/src/components/general/DateTimeField.vue
@@ -1,0 +1,100 @@
+<template>
+  <div class="d-flex flex-row gc-2">
+    <v-menu :close-on-content-click="false">
+      <template #activator="{ props }">
+        <v-text-field
+          v-bind="props"
+          :model-value="dateString"
+          :label="dateLabel"
+          readonly
+        />
+      </template>
+      <v-date-picker v-model="internalDate" />
+    </v-menu>
+    <v-menu :close-on-content-click="false">
+      <template #activator="{ props }">
+        <v-text-field
+          v-bind="props"
+          :model-value="timeString"
+          :label="timeLabel"
+          readonly
+        />
+      </template>
+      <v-time-picker
+        v-model="internalTime"
+        format="24hr"
+        :use-seconds="false"
+        @update:hour="updateHours"
+        @update:minute="updateMinutes"
+      />
+    </v-menu>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { VTimePicker } from 'vuetify/labs/components'
+
+interface Props {
+  dateLabel?: string
+  timeLabel?: string
+}
+defineProps<Props>()
+const date = defineModel<Date>({ required: true })
+
+// Get/set date and time from the date/time picker components.
+const internalDate = computed<Date>({
+  get: () => date.value,
+  set: (newValue) => {
+    const newDate = new Date(date.value)
+    newDate.setFullYear(newValue.getFullYear())
+    newDate.setMonth(newValue.getMonth())
+    newDate.setDate(newValue.getDate())
+    date.value = newDate
+  },
+})
+const internalTime = computed<string>({
+  get: () => timeString.value,
+  set: (newValue) => {
+    const [hours, minutes] = newValue.split(':').map(parseFloat)
+
+    const newDate = new Date(date.value)
+    newDate.setHours(hours)
+    newDate.setMinutes(minutes)
+    date.value = newDate
+  },
+})
+
+// Get date and time from the text fields.
+const dateString = computed<string>(() => {
+  const year = date.value.getFullYear()
+  const month = date.value.getMonth()
+  const day = date.value.getDate()
+
+  const monthString = (month + 1).toString().padStart(2, '0')
+  const dayString = day.toString().padStart(2, '0')
+  return `${year}-${monthString}-${dayString}`
+})
+
+const timeString = computed<string>(() => {
+  const hours = date.value.getHours()
+  const minutes = date.value.getMinutes()
+
+  const hoursString = hours.toString().padStart(2, '0')
+  const minutesString = minutes.toString().padStart(2, '0')
+  return `${hoursString}:${minutesString}`
+})
+
+function updateHours(hours: number): void {
+  const newDate = new Date(date.value)
+  newDate.setHours(hours)
+  date.value = newDate
+}
+
+function updateMinutes(minutes: number): void {
+  const newDate = new Date(date.value)
+  newDate.setMinutes(minutes)
+  date.value = newDate
+}
+</script>

--- a/src/components/workflows/WorkflowsControl.vue
+++ b/src/components/workflows/WorkflowsControl.vue
@@ -503,7 +503,11 @@ async function startWorkflow() {
 }
 
 function getRunTaskFilter(): PartialRunTaskFilter {
+  // TODO: add an apprioriate description. Also, the userId is a random UUID
+  //       now? Why don't we use the ID of the user currently logged in if we
+  //       have it?
   const description = 'Test run'
+
   const timeZeroString = convertJSDateToFewsPiParameter(timeZero.value)
   return {
     userId: userId.value,

--- a/src/components/workflows/WorkflowsControl.vue
+++ b/src/components/workflows/WorkflowsControl.vue
@@ -67,6 +67,13 @@
           @change="onFormChange"
         />
       </v-container>
+      <v-container v-if="!isProcessDataTask">
+        <DateTimeField
+          v-model="timeZero"
+          date-label="t0 date"
+          time-label="t0 time"
+        />
+      </v-container>
       <v-card-actions>
         <v-spacer></v-spacer>
         <v-btn variant="flat" color="primary" @click="startWorkflow">
@@ -103,6 +110,9 @@ import { generateDefaultUISchema, generateJsonSchema } from './workflowUtils'
 import { useDisplay } from 'vuetify'
 import { LngLat } from 'maplibre-gl'
 import { coordinateToString } from '@/lib/workflows'
+import { convertJSDateToFewsPiParameter } from '@/lib/date'
+
+import DateTimeField from '@/components/general/DateTimeField.vue'
 
 interface Props {
   secondaryWorkflows: SecondaryWorkflowGroupItem[] | null
@@ -140,6 +150,12 @@ const hasProperties = computed<boolean>(() => {
   const numProperties = currentWorkflow.value?.properties?.length ?? 0
   return numProperties > 0
 })
+const isProcessDataTask = computed<boolean>(() => {
+  return data.value['GET_PROCESS_DATA']
+})
+
+const timeZero = ref(new Date())
+
 // Update workflowId, startTime and endTime depending on properties.
 watch(
   currentWorkflow,
@@ -442,7 +458,7 @@ function showSuccessMessage(message: string) {
 }
 
 async function startWorkflow() {
-  const workflowType = data.value['GET_PROCESS_DATA']
+  const workflowType = isProcessDataTask.value
     ? WorkflowType.ProcessData
     : WorkflowType.RunTask
 
@@ -488,9 +504,11 @@ async function startWorkflow() {
 
 function getRunTaskFilter(): PartialRunTaskFilter {
   const description = 'Test run'
+  const timeZeroString = convertJSDateToFewsPiParameter(timeZero.value)
   return {
     userId: userId.value,
     description,
+    timeZero: timeZeroString,
     properties: data.value,
   }
 }

--- a/src/components/workflows/WorkflowsControl.vue
+++ b/src/components/workflows/WorkflowsControl.vue
@@ -55,7 +55,7 @@
           </v-row>
         </v-col>
       </v-container>
-      <v-container class="d-flex workflow-dialog__form" style="">
+      <v-container v-if="hasProperties" class="d-flex workflow-dialog__form">
         <json-forms
           :schema="formSchema"
           :uischema="formUISchema"
@@ -136,6 +136,10 @@ onMounted(() => {
   userId.value = crypto.randomUUID()
 })
 
+const hasProperties = computed<boolean>(() => {
+  const numProperties = currentWorkflow.value?.properties?.length ?? 0
+  return numProperties > 0
+})
 // Update workflowId, startTime and endTime depending on properties.
 watch(
   currentWorkflow,

--- a/src/lib/date/index.ts
+++ b/src/lib/date/index.ts
@@ -53,3 +53,16 @@ export function convertFewsPiDateTimeToJsDate(
     `${fewsDatetime.date}T${fewsDatetime.time}${timeZoneOffsetString}`,
   )
 }
+
+/**
+ * Converts a date to a string suitable for use as a FEWS PI query parameter.
+ *
+ * FEWS PI accepts dates in the format 'YYYY-MM-DDTHH:MM:SSZ', almost an ISO8601
+ * string, but it does not accept milliseconds.
+ *
+ * @param date date to convert.
+ * @returns string suitable for use as a FEWS PI query parameter.
+ */
+export function convertJSDateToFewsPiParameter(date: Date): string {
+  return toISOString(date) + 'Z'
+}

--- a/src/stores/workflows.ts
+++ b/src/stores/workflows.ts
@@ -78,7 +78,7 @@ const useWorkflowsStore = defineStore('workflows', {
         if (this.startTime === null || this.endTime === null) {
           throw new Error('Start time or end time has not been set.')
         }
-        const completeFilter = {
+        const completeFilter: ProcessDataFilter = {
           ...filter,
           workflowId: this.workflowId,
           startTime: this.startTime,
@@ -96,7 +96,7 @@ const useWorkflowsStore = defineStore('workflows', {
           this.numActiveWorkflows--
         }
       } else if (type === WorkflowType.RunTask) {
-        const completeFilter = {
+        const completeFilter: RunTaskFilter = {
           ...filter,
           workflowId: this.workflowId,
         }

--- a/src/stores/workflows.ts
+++ b/src/stores/workflows.ts
@@ -69,11 +69,11 @@ const useWorkflowsStore = defineStore('workflows', {
       options?: StartWorkflowOptions,
     ) {
       if (this.workflowId === null) {
-        throw Error('Workflow ID has not been set.')
+        throw new Error('Workflow ID has not been set.')
       }
       if (type === 'ProcessData' && isPartialProcessDataFilter(filter)) {
         if (this.startTime === null || this.endTime === null) {
-          throw Error('Start time or end time has not been set.')
+          throw new Error('Start time or end time has not been set.')
         }
         const completeFilter = {
           ...filter,

--- a/src/stores/workflows.ts
+++ b/src/stores/workflows.ts
@@ -71,7 +71,10 @@ const useWorkflowsStore = defineStore('workflows', {
       if (this.workflowId === null) {
         throw new Error('Workflow ID has not been set.')
       }
-      if (type === 'ProcessData' && isPartialProcessDataFilter(filter)) {
+      if (
+        type === WorkflowType.ProcessData &&
+        isPartialProcessDataFilter(filter)
+      ) {
         if (this.startTime === null || this.endTime === null) {
           throw new Error('Start time or end time has not been set.')
         }


### PR DESCRIPTION
## Pull Request Template

### Description

This adds a date/time field for setting the t0 to the secondary workflow dialog for running tasks (not for processing data tasks). This time is passed as the `timeZero` query parameter to the `runTask` POST request. By default, the t0 is set to the current time such that the default behaviour is the same as it is now.

### Screenshots (if applicable)

![afbeelding](https://github.com/user-attachments/assets/77fa9cec-c037-445a-bd79-b8b4646e7bb9)

### Link to documentation (if applicable)

N/A

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [ ] Update documentation.
- [ ] Update tests.
