### PR TITLE
Do no show node url in app bar

### DIFF
--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -14,16 +14,6 @@
       v-model:nodeButtons="nodesStore.nodeButtons"
       variant="tonal"
     />
-    <!-- TODO: Should this be a display tab maybe? -->
-    <v-btn
-      v-if="externalLink"
-      :href="externalLink"
-      target="_blank"
-      variant="text"
-      class="text-capitalize"
-    >
-      <v-icon>mdi-open-in-new</v-icon>Link
-    </v-btn>
   </Teleport>
   <Teleport to="#app-bar-content-center">
     <v-toolbar-items v-if="displayTabs.length > 1">


### PR DESCRIPTION
### Description

The WebOC will only show a node url as a link in the topology tree. Nodes which have additional properties will not display a link. 