### PR TITLE
Enable automaticSilentRenew on authentication manager

### DIFF
--- a/src/services/authentication/oidcSettings.ts
+++ b/src/services/authentication/oidcSettings.ts
@@ -11,6 +11,7 @@ const oidcSettings: UserManagerSettings = {
   scope: `${import.meta.env.VITE_AUTH_SCOPE}`,
   post_logout_redirect_uri: `${baseUrl}auth/logout`,
   monitorSession: false,
+  automaticSilentRenew: true,
 }
 
 export default oidcSettings


### PR DESCRIPTION
### Description

Automatic token refresh of OIDC authentication manager is now enabled by default.
