### PR TITLE
Limit height of chart time series chart, limit width of vertical profile

### DIFF
--- a/src/components/charts/ElevationChart.vue
+++ b/src/components/charts/ElevationChart.vue
@@ -398,6 +398,7 @@ onBeforeUnmount(() => {
   flex-direction: column;
   flex: 1 1 80%;
   height: 100%;
+  max-width: 600px;
 }
 
 .v-chip--outlined {

--- a/src/components/charts/TimeSeriesChart.vue
+++ b/src/components/charts/TimeSeriesChart.vue
@@ -505,7 +505,7 @@ onBeforeUnmount(() => {
   position: relative;
   flex-direction: column;
   flex: 1 1 80%;
-  height: 100%;
+  max-height: 800px;
 }
 
 .v-chip--outlined {


### PR DESCRIPTION
### Description

Limit the height of time series chart. For large screen a single chart will no longer fill the complete height of the panel.
Limit the width of vertical profile chart. For large screen single chart will be no longer fill the complete width of the panel.
