### PR TITLE
Fetch WMS with downsampled resolution for animated vectors

### DIFF
--- a/src/components/wms/AnimatedStreamlineRasterLayer.vue
+++ b/src/components/wms/AnimatedStreamlineRasterLayer.vue
@@ -131,6 +131,7 @@ function addLayer(): void {
   const options: WMSStreamlineLayerOptions = {
     ...mergeOptions(props.layerOptions, props.streamlineOptions),
     transformRequest: createTransformRequestFn(),
+    downsampleFactorWMS: 2,
   }
 
   // Create and initialise new streamline layer.


### PR DESCRIPTION
## Pull Request Template

### Description

The GeoTIFF WMS backend produces relatively large files, but this resolution does not contribute to the visual effect. We now fetch these GeoTIFFs with 2x downsampled resolution (4x fewer pixels), resulting in much faster fetches for (almost) the same result.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes.
