### PR TITLE
Refresh timeseries automatically every 30s

### DIFF
--- a/src/components/charts/TimeSeriesChart.vue
+++ b/src/components/charts/TimeSeriesChart.vue
@@ -147,7 +147,7 @@ watch(
   (newValue) => {
     if (axisTime.value) {
       axisTime.value.setDateTime(newValue)
-      onValueChange()
+      axisTime.value.redraw()
     }
   },
 )

--- a/src/components/charts/TimeSeriesChart.vue
+++ b/src/components/charts/TimeSeriesChart.vue
@@ -384,10 +384,10 @@ watch(
     ),
   (newValue, oldValue) => {
     const newSeriesIds = difference(newValue, oldValue)
-    const requiredSeriesIds = props.config?.series.filter((s) =>
+    const requiredSeries = props.config?.series.filter((s) =>
       newSeriesIds.map((id) => id.split('-')[0]).includes(s.id),
     )
-    if (requiredSeriesIds.length > 0) {
+    if (requiredSeries.length > 0) {
       onValueChange()
     }
   },

--- a/src/components/charts/TimeSeriesChart.vue
+++ b/src/components/charts/TimeSeriesChart.vue
@@ -9,8 +9,7 @@
       :settings="settings.legend"
       @toggle-line="toggleLine"
     />
-    <LoadingOverlay v-if="isLoading" :offsets="margin" />
-    <div ref="chartContainer" class="chart-container" v-show="!isLoading"></div>
+    <div ref="chartContainer" class="chart-container"></div>
   </div>
 </template>
 
@@ -34,7 +33,6 @@ import {
   MouseOver,
   VerticalMouseOver,
 } from '@deltares/fews-web-oc-charts'
-import LoadingOverlay from '@/components/charts/LoadingOverlay.vue'
 import ChartLegend from '@/components/charts/ChartLegend.vue'
 import type { ChartConfig } from '../../lib/charts/types/ChartConfig.js'
 import type { ChartSeries } from '../../lib/charts/types/ChartSeries.js'

--- a/src/components/charts/TimeSeriesChart.vue
+++ b/src/components/charts/TimeSeriesChart.vue
@@ -417,8 +417,10 @@ watch(props.config, onValueChange)
 watch(
   () => props.isLoading,
   (newValue, oldValue) => {
-    if (!newValue && oldValue) {
-      hasLoadedOnce.value = hasLoadedOnce.value || true
+    // isLoading changes every time the data is requested again.
+    // We need to keep track of the first time the data has been loaded, in order to fully draw the chart once
+    if (!newValue) {
+      hasLoadedOnce.value = true
     }
   },
 )

--- a/src/components/charts/TimeSeriesChart.vue
+++ b/src/components/charts/TimeSeriesChart.vue
@@ -63,6 +63,7 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
   config: () => {
     return {
+      id: '',
       title: '',
       series: [],
     }

--- a/src/components/timeseries/TimeSeriesComponent.vue
+++ b/src/components/timeseries/TimeSeriesComponent.vue
@@ -7,10 +7,10 @@
     >
       <KeepAlive>
         <TimeSeriesChart
-          v-for="(subplot, i) in subplots"
+          v-for="subplot in subplots"
           :config="subplot"
           :series="series"
-          :key="`${subplot.title}-${i}`"
+          :key="subplot.id"
           :currentTime="selectedDate"
           :isLoading="isLoading(subplot, loadingSeriesIds)"
           :zoomHandler="sharedZoomHandler"
@@ -26,11 +26,11 @@
     >
       <KeepAlive>
         <TimeSeriesChart
-          v-for="(subplot, i) in elevationChartSubplots"
+          v-for="subplot in elevationChartSubplots"
           verticalProfile
           :config="subplot"
           :series="elevationChartSeries"
-          :key="`${subplot.title}-${i}`"
+          :key="subplot.id"
           :style="`min-width: ${xs ? 100 : 50}%`"
           :isLoading="isLoading(subplot, elevationLoadingSeriesIds)"
           :zoomHandler="sharedVerticalZoomHandler"
@@ -231,7 +231,7 @@ const elevationChartSubplots = computed(() => {
   }
 })
 
-const tableConfig = ref<ChartConfig>({ title: '', series: [] })
+const tableConfig = ref<ChartConfig>({ id: '', title: '', series: [] })
 
 watch(
   () => props.config.subplots,
@@ -247,6 +247,7 @@ watch(
     })
 
     tableConfig.value = {
+      id: 'table',
       title: props.config.title,
       series,
     }

--- a/src/lib/charts/timeSeriesDisplayToChartConfig.ts
+++ b/src/lib/charts/timeSeriesDisplayToChartConfig.ts
@@ -19,7 +19,6 @@ import {
 
 export function timeSeriesDisplayToChartConfig(
   subplot: TimeSeriesDisplaySubplot,
-  title: string,
   domain?: [Date, Date],
 ): ChartConfig {
   const xAxis = subplot.xAxis ? xAxisFromPlotItemXAxis(subplot.xAxis) : []
@@ -34,8 +33,10 @@ export function timeSeriesDisplayToChartConfig(
     }
   }
 
+  const subplotId = subplot.items.map(plot => plot.request).toString()
   const config: ChartConfig = {
-    title: title,
+    id: subplotId,
+    title: "",
     xAxis,
     yAxis: yAxisFromSubplot(subplot),
     series: [],

--- a/src/lib/charts/timeSeriesDisplayToChartConfig.ts
+++ b/src/lib/charts/timeSeriesDisplayToChartConfig.ts
@@ -33,10 +33,10 @@ export function timeSeriesDisplayToChartConfig(
     }
   }
 
-  const subplotId = subplot.items.map(plot => plot.request).toString()
+  const subplotId = subplot.items.map((plot) => plot.request).toString()
   const config: ChartConfig = {
     id: subplotId,
-    title: "",
+    title: '',
     xAxis,
     yAxis: yAxisFromSubplot(subplot),
     series: [],

--- a/src/lib/charts/types/ChartConfig.ts
+++ b/src/lib/charts/types/ChartConfig.ts
@@ -3,6 +3,7 @@ import { ThresholdLine } from './ThresholdLine'
 import { AxisOptions } from '@deltares/fews-web-oc-charts'
 
 export interface ChartConfig {
+  id: string
   title: string
   xAxis?: AxisOptions[]
   yAxis?: AxisOptions[]

--- a/src/services/useDisplayConfig/index.ts
+++ b/src/services/useDisplayConfig/index.ts
@@ -60,7 +60,7 @@ function actionsResponseToDisplayConfig(
 
     const subplots =
       result.config.timeSeriesDisplay.subplots?.map((subPlot) => {
-        return timeSeriesDisplayToChartConfig(subPlot, title, configPeriod)
+        return timeSeriesDisplayToChartConfig(subPlot, configPeriod)
       }) ?? []
     const display: DisplayConfig = {
       id: title,

--- a/src/services/useSsdPi/index.ts
+++ b/src/services/useSsdPi/index.ts
@@ -64,7 +64,7 @@ export function useSsdPi(
         subplots = result.config.timeSeriesDisplay.subplots?.map((subPlot) => {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
-          return timeSeriesDisplayToChartConfig(subPlot, title)
+          return timeSeriesDisplayToChartConfig(subPlot)
         })
       }
       const display: DisplayConfig = {

--- a/src/services/useTimeSeries/index.ts
+++ b/src/services/useTimeSeries/index.ts
@@ -65,6 +65,10 @@ export function useTimeSeries(
   const isLoading = computed(() => debouncedLoadingSeriesIds.value.length > 0)
 
   watch([lastUpdated, selectedTime ?? ref(), requests, options], () => {
+    loadTimeSeries()
+  })
+
+  function loadTimeSeries() {
     controller.abort('Timeseries request triggered again before finishing.')
     controller = new AbortController()
     const piProvider = new PiWebserviceProvider(baseUrl, {
@@ -113,8 +117,8 @@ export function useTimeSeries(
           })
           const timeStepPerPixel = Math.round(
             Interval.fromDateTimes(startTime, endTime).length() /
-              window.outerWidth /
-              2,
+            window.outerWidth /
+            2,
           )
           url.searchParams.set('thinning', `${timeStepPerPixel}`)
         }
@@ -190,7 +194,7 @@ export function useTimeSeries(
         delete series.value[seriesId]
       }
     }
-  })
+  }
 
   onUnmounted(() => {
     controller.abort('useTimeSeries unmounted.')

--- a/src/services/useTimeSeries/index.ts
+++ b/src/services/useTimeSeries/index.ts
@@ -143,7 +143,10 @@ export function useTimeSeries(
               ? `${request.key}[${index}]`
               : (request.key ?? '')
             updatedSeriesIds.push(resourceId)
-            const resource = new SeriesUrlRequest('fews-pi', `dummyUrl-for-resource-${resourceId}`)
+            const resource = new SeriesUrlRequest(
+              'fews-pi',
+              `dummyUrl-for-resource-${resourceId}`,
+            )
             const _series = new Series(resource)
             const header = timeSeries.header
             if (header !== undefined) {

--- a/src/services/useTimeSeries/index.ts
+++ b/src/services/useTimeSeries/index.ts
@@ -214,7 +214,7 @@ export function useTimeSeries(
     controller.abort('useTimeSeries unmounted.')
   })
 
-  const shell = {
+  return {
     series,
     isReady,
     isLoading,
@@ -222,8 +222,6 @@ export function useTimeSeries(
     error,
     interval
   }
-
-  return shell
 }
 
 export async function postTimeSeriesEdit(

--- a/src/services/useTimeSeries/index.ts
+++ b/src/services/useTimeSeries/index.ts
@@ -15,7 +15,6 @@ import { createTransformRequestFn } from '@/lib/requests/transformRequest'
 import { difference } from 'lodash-es'
 import { SeriesData } from '@/lib/timeseries/types/SeriesData'
 import { convertFewsPiDateTimeToJsDate } from '@/lib/date'
-import { debouncedRef } from '@vueuse/core'
 import { type Pausable, useIntervalFn } from '@vueuse/core'
 
 export interface UseTimeSeriesReturn {
@@ -65,8 +64,7 @@ export function useTimeSeries(
   const error = shallowRef<any | undefined>(undefined)
   const MAX_SERIES = 20
   const loadingSeriesIds = ref<string[]>([])
-  const debouncedLoadingSeriesIds = debouncedRef(loadingSeriesIds, 100)
-  const isLoading = computed(() => debouncedLoadingSeriesIds.value.length > 0)
+  const isLoading = computed(() => loadingSeriesIds.value.length > 0)
 
   watch([lastUpdated, selectedTime ?? ref(), requests, options], () => {
     loadTimeSeries()
@@ -216,7 +214,7 @@ export function useTimeSeries(
     series,
     isReady,
     isLoading,
-    loadingSeriesIds: debouncedLoadingSeriesIds,
+    loadingSeriesIds,
     error,
     interval,
   }

--- a/src/services/useTimeSeries/index.ts
+++ b/src/services/useTimeSeries/index.ts
@@ -29,7 +29,6 @@ export interface UseTimeSeriesReturn {
 
 const TIMESERIES_POLLING_INTERVAL = 1000 * 30
 
-
 export interface UseTimeSeriesOptions {
   startTime?: Date | null
   endTime?: Date | null
@@ -122,8 +121,8 @@ export function useTimeSeries(
           })
           const timeStepPerPixel = Math.round(
             Interval.fromDateTimes(startTime, endTime).length() /
-            window.outerWidth /
-            2,
+              window.outerWidth /
+              2,
           )
           url.searchParams.set('thinning', `${timeStepPerPixel}`)
         }
@@ -201,14 +200,10 @@ export function useTimeSeries(
     }
   }
 
-  const interval = useIntervalFn(
-    loadTimeSeries,
-    TIMESERIES_POLLING_INTERVAL,
-    {
-      immediate: true,
-      immediateCallback: true,
-    },
-  )
+  const interval = useIntervalFn(loadTimeSeries, TIMESERIES_POLLING_INTERVAL, {
+    immediate: true,
+    immediateCallback: true,
+  })
 
   onUnmounted(() => {
     controller.abort('useTimeSeries unmounted.')
@@ -220,7 +215,7 @@ export function useTimeSeries(
     isLoading,
     loadingSeriesIds: debouncedLoadingSeriesIds,
     error,
-    interval
+    interval,
   }
 }
 

--- a/src/services/useTimeSeries/index.ts
+++ b/src/services/useTimeSeries/index.ts
@@ -143,7 +143,7 @@ export function useTimeSeries(
               ? `${request.key}[${index}]`
               : (request.key ?? '')
             updatedSeriesIds.push(resourceId)
-            const resource = new SeriesUrlRequest('fews-pi', 'dummyUrl')
+            const resource = new SeriesUrlRequest('fews-pi', `dummyUrl-for-resource-${resourceId}`)
             const _series = new Series(resource)
             const header = timeSeries.header
             if (header !== undefined) {


### PR DESCRIPTION
### Description

Performs a timeseries request every 30 seconds if a chart is open, to keep the data up-to-date. The chart is prevented from being redrawn completely, because a redraw would reset the zoom and would create a noticeable/visible 'flicker' of the chart.