### PR TITLE
Remove alerts instead of deactivating them

### DIFF
--- a/src/components/ssd/SchematicStatusDisplay.vue
+++ b/src/components/ssd/SchematicStatusDisplay.vue
@@ -115,7 +115,6 @@ function onAction(event: CustomEvent<SsdActionEventPayload>): void {
       id: `undefined-action-${now.toISOString()}`,
       type: 'error',
       message: 'No left click actions defined for this object',
-      active: true,
     })
     return
   }
@@ -135,7 +134,6 @@ function onAction(event: CustomEvent<SsdActionEventPayload>): void {
         id: `action-${results[0].type}-${now.toISOString()}`,
         type: 'error',
         message: `Action '${results[0].type}' not supported yet.`,
-        active: true,
       })
   }
 }

--- a/src/components/workflows/WorkflowsControl.vue
+++ b/src/components/workflows/WorkflowsControl.vue
@@ -435,7 +435,6 @@ function showErrorMessage(message: string) {
     id: `workflow-error-${userId.value}`,
     type: 'error',
     message,
-    active: true,
   })
 }
 
@@ -444,7 +443,6 @@ function showStartMessage(message: string) {
     id: `workflow-start-${userId.value}`,
     type: 'success',
     message,
-    active: true,
   })
 }
 
@@ -453,7 +451,6 @@ function showSuccessMessage(message: string) {
     id: `workflow-success-${userId.value}`,
     type: 'success',
     message,
-    active: true,
   })
 }
 

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -147,9 +147,9 @@
       <Suspense>
         <router-view></router-view>
       </Suspense>
-      <div class="alerts__container" v-if="alertsStore.hasActiveAlerts">
+      <div class="alerts__container" v-if="alertsStore.hasAlerts">
         <v-alert
-          v-for="alert in alertsStore.activeAlerts"
+          v-for="alert in alertsStore.alerts"
           :type="alert.type"
           closable
           density="compact"
@@ -197,6 +197,17 @@ const showHash = ref(false)
 const logoSrc = ref('')
 const appBarStyle = ref<StyleValue>()
 const appBarColor = ref<string>('')
+
+alertsStore.addAlert({
+  id: crypto.randomUUID(),
+  type: 'success',
+  message: 'hallo dit is een bericht',
+})
+alertsStore.addAlert({
+  id: crypto.randomUUID(),
+  type: 'success',
+  message: 'hallo dit is een bericht',
+})
 
 function updateAppBarColor() {
   appBarColor.value = getComputedStyle(document.body).getPropertyValue(
@@ -279,7 +290,7 @@ const shouldRenderInfoMenu = computed(() => {
 })
 
 function onCloseAlert(alert: Alert) {
-  alertsStore.deactiveAlert(alert.id)
+  alertsStore.removeAlert(alert.id)
 }
 
 const useRail = computed(

--- a/src/stores/alerts.ts
+++ b/src/stores/alerts.ts
@@ -6,7 +6,6 @@ export interface Alert {
   id: string
   type: AlertType
   message: string
-  active: boolean
 }
 
 interface AlertState {
@@ -22,17 +21,13 @@ const useAlertsStore = defineStore('alerts', {
     addAlert(alert: Alert) {
       this.alerts.push(alert)
     },
-    deactiveAlert(id: string) {
-      const alert = this.alerts.find((alert) => alert.id === id)
-      if (alert) {
-        alert.active = false
-      }
+    removeAlert(id: string) {
+      this.alerts = this.alerts.filter((alert) => alert.id !== id)
     },
   },
 
   getters: {
-    activeAlerts: (state) => state.alerts.filter((alert) => alert.active),
-    hasActiveAlerts: (state) => state.alerts.some((alert) => alert.active),
+    hasAlerts: (state) => state.alerts.length > 0,
   },
 })
 


### PR DESCRIPTION
### Description

Closing alert messages was a bit buggy; multiple items would be closed or all alerts would be hidden upon closing a single alert. Issues stemmed from the alerts state not being deeply reactive. We now simplified the alerts store by removing the `active` property, which was only used to "remove" alerts.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [ ] Update documentation.
- [ ] Update tests.
