### PR TITLE
Fix wrong color ranges being sent when display units are switched

### DIFF
--- a/src/components/spatialdisplay/SpatialDisplayComponent.vue
+++ b/src/components/spatialdisplay/SpatialDisplayComponent.vue
@@ -250,10 +250,13 @@ watch(
   { immediate: true },
 )
 
-watch(() => settings.useDisplayUnits, () => {
-  colourScalesStore.clearScales()
-  addScalesForStyles(legendLayerStyles.value ?? [])
-})
+watch(
+  () => settings.useDisplayUnits,
+  () => {
+    colourScalesStore.clearScales()
+    addScalesForStyles(legendLayerStyles.value ?? [])
+  },
+)
 
 function addScalesForStyles(styles: Style[]): void {
   styles.forEach((style) => {

--- a/src/components/spatialdisplay/SpatialDisplayComponent.vue
+++ b/src/components/spatialdisplay/SpatialDisplayComponent.vue
@@ -245,18 +245,27 @@ watch(
 
     currentColourScaleIds.value = styles.map(styleToId)
 
-    styles.forEach((style) => {
-      colourScalesStore.addScale(
-        style,
-        props.layerName,
-        () => props.layerCapabilities?.title,
-        () => settings.useDisplayUnits,
-        () => props.layerCapabilities?.styles ?? [],
-      )
-    })
+    addScalesForStyles(styles)
   },
   { immediate: true },
 )
+
+watch(() => settings.useDisplayUnits, () => {
+  colourScalesStore.clearScales()
+  addScalesForStyles(legendLayerStyles.value ?? [])
+})
+
+function addScalesForStyles(styles: Style[]): void {
+  styles.forEach((style) => {
+    colourScalesStore.addScale(
+      style,
+      props.layerName,
+      () => props.layerCapabilities?.title,
+      settings.useDisplayUnits,
+      () => props.layerCapabilities?.styles ?? [],
+    )
+  })
+}
 
 const selectedCoordinate = computed(() => {
   if (props.latitude === undefined || props.longitude === undefined) return

--- a/src/stores/colourScales.ts
+++ b/src/stores/colourScales.ts
@@ -28,11 +28,16 @@ const useColourScalesStore = defineStore('colourScales', () => {
   const scales = ref<Record<string, ColourScale>>({})
   const processingScaleIds = ref<string[]>([])
 
+  function clearScales() {
+    scales.value = {}
+    processingScaleIds.value = []
+  }
+
   async function addScale(
     style: Style,
     layerName: MaybeRefOrGetter<string>,
     title: MaybeRefOrGetter<string | undefined>,
-    useDisplayUnits: MaybeRefOrGetter<boolean>,
+    useDisplayUnits: boolean,
     activeStyles: MaybeRefOrGetter<Style[]>,
   ) {
     const styleId = styleToId(style)
@@ -47,7 +52,7 @@ const useColourScalesStore = defineStore('colourScales', () => {
     const initialLegendGraphic = await fetchWmsLegend(
       baseUrl,
       toValue(layerName),
-      toValue(useDisplayUnits),
+      useDisplayUnits,
       undefined,
       style,
     )
@@ -94,6 +99,7 @@ const useColourScalesStore = defineStore('colourScales', () => {
   return {
     scales,
     addScale,
+    clearScales,
   }
 })
 


### PR DESCRIPTION
### Description

Fixes grid using wrong color scale ranges when switching units by clearing style ranges when user switches display units

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
