### PR TITLE
Make button variants and labels opacity more consistent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "vue": "^3.5.13",
         "vue-router": "^4.5.0",
         "vue-slider-component": "^4.1.0-beta.7",
-        "vuetify": "^3.7.2"
+        "vuetify": "^3.7.7"
       },
       "devDependencies": {
         "@mdi/font": "^7.4.47",
@@ -12194,9 +12194,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.7.5.tgz",
-      "integrity": "sha512-5aiSz8WJyGzYe3yfgDbzxsFATwHvKtdvFAaUJEDTx7xRv55s3YiOho/MFhs5iTbmh2VT4ToRgP0imBUP660UOw==",
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.7.7.tgz",
+      "integrity": "sha512-YqKnRo2+BZWQRzfxHVA/5reQo1eLvbS9Z6N+Lvaot/5lpdi7JWooMr/hWoCr7/QPBGRcXArHppqIB+hMfPlsXw==",
       "license": "MIT",
       "engines": {
         "node": "^12.20 || >=14.13"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "vue": "^3.5.13",
     "vue-router": "^4.5.0",
     "vue-slider-component": "^4.1.0-beta.7",
-    "vuetify": "^3.7.2"
+    "vuetify": "^3.7.7"
   },
   "devDependencies": {
     "@mdi/font": "^7.4.47",

--- a/src/components/charts/ElevationChart.vue
+++ b/src/components/charts/ElevationChart.vue
@@ -35,7 +35,6 @@
         v-show="requiresExpand"
         :icon="expanded ? 'mdi-chevron-up' : 'mdi-chevron-down'"
         size="small"
-        variant="plain"
         @click="toggleExpand"
       ></v-btn>
     </v-sheet>

--- a/src/components/charts/TimeSeriesChart.vue
+++ b/src/components/charts/TimeSeriesChart.vue
@@ -35,7 +35,6 @@
         v-show="requiresExpand"
         :icon="expanded ? 'mdi-chevron-up' : 'mdi-chevron-down'"
         size="small"
-        variant="plain"
         @click="toggleExpand"
       ></v-btn>
     </v-sheet>

--- a/src/components/wms/InformationPanel.vue
+++ b/src/components/wms/InformationPanel.vue
@@ -1,10 +1,6 @@
 <template>
   <ControlChip>
-    <v-btn
-      @click="showLayer = !showLayer"
-      density="compact"
-      icon
-    >
+    <v-btn @click="showLayer = !showLayer" density="compact" icon>
       <v-icon>{{ showLayer ? 'mdi-layers' : 'mdi-layers-off' }}</v-icon>
     </v-btn>
     <v-menu

--- a/src/components/wms/InformationPanel.vue
+++ b/src/components/wms/InformationPanel.vue
@@ -3,7 +3,6 @@
     <v-btn
       @click="showLayer = !showLayer"
       density="compact"
-      variant="plain"
       icon
     >
       <v-icon>{{ showLayer ? 'mdi-layers' : 'mdi-layers-off' }}</v-icon>
@@ -14,7 +13,7 @@
       v-if="showLayer"
     >
       <template v-slot:activator="{ props }">
-        <v-btn variant="plain" v-bind="props" class="pe-0 text-none">
+        <v-btn v-bind="props" class="pe-0 text-none">
           <span
             class="me-2"
             :class="{ 'text-decoration-line-through': props.completelyMissing }"
@@ -121,7 +120,6 @@
       @click="toggleLayerType"
       icon
       density="compact"
-      variant="plain"
       :color="doAnimateStreamlines ? 'primary' : undefined"
     >
       <v-progress-circular v-if="isLoading" size="20" indeterminate />

--- a/src/components/wms/LocationsSearchControl.vue
+++ b/src/components/wms/LocationsSearchControl.vue
@@ -1,10 +1,6 @@
 <template>
   <ControlChip v-if="hasLocations" :class="{ 'pr-0': showLocations }">
-    <v-btn
-      @click="showLocations = !showLocations"
-      density="compact"
-      icon
-    >
+    <v-btn @click="showLocations = !showLocations" density="compact" icon>
       <v-icon>{{
         showLocations ? 'mdi-map-marker' : 'mdi-map-marker-off'
       }}</v-icon>

--- a/src/components/wms/LocationsSearchControl.vue
+++ b/src/components/wms/LocationsSearchControl.vue
@@ -3,7 +3,6 @@
     <v-btn
       @click="showLocations = !showLocations"
       density="compact"
-      variant="plain"
       icon
     >
       <v-icon>{{

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -97,15 +97,9 @@
               width="320"
             >
               <template #activator="{ props }">
-                <!-- <v-btn v-bind="props" variant="plain"> -->
-                <!--   <v-icon size="x-large" class="pe-9 me-1">mdi-help-circle-outline</v-icon> -->
-                <!--   <span>Info</span> -->
-                <!-- </v-btn> -->
-                <!-- <v-icon v-bind="props">mdi-help-circle-outline</v-icon> -->
                 <v-btn
                   v-bind="props"
                   size="24"
-                  variant="plain"
                   class="me-4"
                   icon="mdi-help-circle-outline"
                 />
@@ -132,7 +126,6 @@
           </template>
           <template #append>
             <v-btn
-              variant="plain"
               class="text-lowercase"
               size="small"
               @click="showHash = !showHash"

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -3,6 +3,12 @@ import '@/styles/main.scss'
 import '@mdi/font/css/materialdesignicons.css'
 import { createVuetify } from 'vuetify'
 
-const vuetify = createVuetify({})
+const vuetify = createVuetify({
+  defaults: {
+    VBtn: {
+      variant: 'text',
+    },
+  },
+})
 
 export default vuetify

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -32,7 +32,7 @@
   <Teleport to="#app-bar-content-end">
     <v-menu bottom left>
       <template v-slot:activator="{ props }">
-        <v-btn icon variant="plain" v-bind="props">
+        <v-btn icon v-bind="props">
           <v-icon>mdi-dots-horizontal-circle-outline</v-icon>
         </v-btn>
       </template>


### PR DESCRIPTION
### Description

Makes the ui colors more consistent by using a default button variant.
Should all old button instances currently using variant="text" also be updated to have those removed?

#### Vuetify updated because switch label opacity not matching the material design spec is fixed in 3.7.6:
VSelectionControl: label opacity matching regular text ([#20738](https://github.com/vuetifyjs/vuetify/issues/20738)) ([f804c50](https://github.com/vuetifyjs/vuetify/commit/f804c506813985494e5afa2e6610bd06fcb08cc0)), closes [#18804](https://github.com/vuetifyjs/vuetify/issues/18804)

### Screenshots
#### Old
![image](https://github.com/user-attachments/assets/69c12144-f8e4-4270-a7bb-bf03ac2597fc)
#### New
![image](https://github.com/user-attachments/assets/7e1370bb-3cf2-4db4-bb8d-cabec24fa5e2)

#### Old
![image](https://github.com/user-attachments/assets/772df740-4278-4400-8a7e-2ac2477d20c1)
#### New
![image](https://github.com/user-attachments/assets/97afd2fb-8bf7-48fe-bc74-d7ae8d5e610f)




### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
