### PR TITLE
Allow zooming in ssd elements

### DIFF
--- a/src/components/general/DashboardItem.vue
+++ b/src/components/general/DashboardItem.vue
@@ -20,6 +20,7 @@ import {
 } from '@/lib/topology/dashboard'
 import { useComponentSettingsStore } from '@/stores/componentSettings'
 import { useTopologyNodesStore } from '@/stores/topologyNodes'
+import { getSettings } from '@/lib/topology/componentSettings'
 import { computed } from 'vue'
 
 interface Props {
@@ -58,6 +59,6 @@ function getComponentSettingsForItem(item: WebOCDashboardItem) {
   const settings = item.componentSettingsId
     ? componentSettingsStore.getSettingsById(item.componentSettingsId)
     : undefined
-  return settings?.[item.component]
+  return getSettings(settings, item.component)
 }
 </script>

--- a/src/components/general/LoadingSpinner.vue
+++ b/src/components/general/LoadingSpinner.vue
@@ -1,0 +1,42 @@
+<template>
+  <v-icon
+    v-if="showLoading"
+    icon="mdi-loading mdi-spin"
+    :color
+    :size
+    class="overlay-spinner"
+  />
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+
+interface Props {
+  color?: string
+  size?: string
+  delay?: number
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  color: 'black',
+  size: '48',
+  delay: 500,
+})
+
+const showLoading = ref(false)
+
+onMounted(() => {
+  setTimeout(() => {
+    showLoading.value = true
+  }, props.delay)
+})
+</script>
+
+<style scoped>
+.overlay-spinner {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+</style>

--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -57,7 +57,10 @@ import { useUserSettingsStore } from '@/stores/userSettings'
 import { useFilterLocations } from '@/services/useFilterLocations'
 import type { BoundingBox } from '@deltares/fews-wms-requests'
 import type { UseDisplayConfigOptions } from '@/services/useDisplayConfig'
-import type { MapSettings } from '@/lib/topology/componentSettings'
+import {
+  type MapSettings,
+  getDefaultSettings,
+} from '@/lib/topology/componentSettings'
 import { useElementSize } from '@vueuse/core'
 const SpatialTimeSeriesDisplay = defineAsyncComponent(
   () => import('@/components/spatialdisplay/SpatialTimeSeriesDisplay.vue'),
@@ -76,6 +79,7 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
   layerName: '',
   filterIds: () => [],
+  settings: () => getDefaultSettings('map'),
 })
 
 const route = useRoute()
@@ -170,9 +174,7 @@ const filter = computed(() => {
 })
 
 const showChartPanel = computed(() => {
-  return (
-    filter.value !== undefined && (props.settings?.chartPanelEnabled ?? true)
-  )
+  return filter.value !== undefined && props.settings.chartPanelEnabled
 })
 
 const elevationChartFilter = computed(() => {

--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -12,7 +12,7 @@
         :layer-capabilities="layerCapabilities"
         :bounding-box="boundingBox"
         :times="times"
-        :settings="props.settings"
+        :settings="settings"
         :max-values-time-series="maxValuesTimeSeries"
         v-model:elevation="elevation"
         v-model:current-time="currentTime"
@@ -27,7 +27,7 @@
           :filter="filter"
           :elevation-chart-filter="elevationChartFilter"
           :current-time="currentTime"
-          :settings="props.settings"
+          :settings="settings"
         />
       </router-view>
     </div>
@@ -171,7 +171,7 @@ const filter = computed(() => {
 
 const showChartPanel = computed(() => {
   return (
-    filter.value !== undefined && !(props.settings?.chartPanelEnabled === false)
+    filter.value !== undefined && (props.settings?.chartPanelEnabled ?? true)
   )
 })
 

--- a/src/components/spatialdisplay/SpatialDisplayComponent.vue
+++ b/src/components/spatialdisplay/SpatialDisplayComponent.vue
@@ -92,7 +92,7 @@
         </template>
       </InformationPanel>
       <LocationsSearchControl
-        v-if="showLocationSearchControl"
+        v-if="settings.locationSearchEnabled"
         v-model:showLocations="showLocationsLayer"
         width="50vw"
         max-width="250"
@@ -198,7 +198,7 @@ interface Props {
   currentTime?: Date
   maxValuesTimeSeries?: TimeSeriesData[]
   boundingBox?: BoundingBox
-  settings?: MapSettings
+  settings: MapSettings
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -352,10 +352,6 @@ const offsetBottomControls = computed(() => {
 
 const layerHasElevation = computed(() => {
   return props.layerCapabilities?.elevation !== undefined
-})
-
-const showLocationSearchControl = computed(() => {
-  return props.settings?.locationSearchEnabled ?? true
 })
 
 watch(

--- a/src/components/spatialdisplay/SpatialDisplayComponent.vue
+++ b/src/components/spatialdisplay/SpatialDisplayComponent.vue
@@ -355,7 +355,7 @@ const layerHasElevation = computed(() => {
 })
 
 const showLocationSearchControl = computed(() => {
-  return !(props.settings?.locationSearchEnabled === false)
+  return props.settings?.locationSearchEnabled ?? true
 })
 
 watch(

--- a/src/components/spatialdisplay/SpatialTimeSeriesDisplay.vue
+++ b/src/components/spatialdisplay/SpatialTimeSeriesDisplay.vue
@@ -158,7 +158,7 @@ interface DisplayTypeItem {
 }
 
 const displayActionItems = computed(() => {
-  const dataDownloadEnabled = !(props.settings?.downloadEnabled === false)
+  const dataDownloadEnabled = props.settings?.downloadEnabled ?? true
   return [
     {
       icon: 'mdi-download',
@@ -179,12 +179,10 @@ const displayTypeItems = computed<DisplayTypeItem[]>(() => {
   )
   const noTooltip = !tooltip.value
 
-  const chartEnabled = !(props.settings?.chartEnabled === false)
-  const elevationChartEnabled = !(
-    props.settings?.elevationChartEnabled === false
-  )
-  const tableEnabled = !(props.settings?.tableEnabled === false)
-  const metaDataEnabled = !(props.settings?.metaDataEnabled === false)
+  const chartEnabled = props.settings?.chartEnabled ?? true
+  const elevationChartEnabled = props.settings?.elevationChartEnabled ?? true
+  const tableEnabled = props.settings?.tableEnabled ?? true
+  const metaDataEnabled = props.settings?.metaDataEnabled ?? true
   return [
     {
       icon: 'mdi-chart-line',

--- a/src/components/spatialdisplay/SpatialTimeSeriesDisplay.vue
+++ b/src/components/spatialdisplay/SpatialTimeSeriesDisplay.vue
@@ -94,7 +94,7 @@ interface Props {
   filter: filterActionsFilter | timeSeriesGridActionsFilter
   elevationChartFilter?: timeSeriesGridActionsFilter
   currentTime?: Date
-  settings?: ChartSettings
+  settings: ChartSettings
 }
 
 const userSettings = useUserSettingsStore()
@@ -158,7 +158,7 @@ interface DisplayTypeItem {
 }
 
 const displayActionItems = computed(() => {
-  const dataDownloadEnabled = props.settings?.downloadEnabled ?? true
+  const dataDownloadEnabled = props.settings.downloadEnabled
   return [
     {
       icon: 'mdi-download',
@@ -179,10 +179,10 @@ const displayTypeItems = computed<DisplayTypeItem[]>(() => {
   )
   const noTooltip = !tooltip.value
 
-  const chartEnabled = props.settings?.chartEnabled ?? true
-  const elevationChartEnabled = props.settings?.elevationChartEnabled ?? true
-  const tableEnabled = props.settings?.tableEnabled ?? true
-  const metaDataEnabled = props.settings?.metaDataEnabled ?? true
+  const chartEnabled = props.settings.chartEnabled
+  const elevationChartEnabled = props.settings.elevationChartEnabled
+  const tableEnabled = props.settings.tableEnabled
+  const metaDataEnabled = props.settings.metaDataEnabled
   return [
     {
       icon: 'mdi-chart-line',

--- a/src/components/ssd/SchematicStatusDisplay.vue
+++ b/src/components/ssd/SchematicStatusDisplay.vue
@@ -8,6 +8,7 @@
       <SsdComponent
         :src="src"
         :key="panelId"
+        :allowZooming="allowZooming"
         @action="onAction"
         ref="ssdComponent"
       />
@@ -49,6 +50,7 @@ interface Props {
   panelId?: string
   objectId?: string
   showDateTimeSlider?: boolean
+  allowZooming?: boolean
 }
 
 interface SsdActionEventPayload {

--- a/src/components/ssd/SchematicStatusDisplay.vue
+++ b/src/components/ssd/SchematicStatusDisplay.vue
@@ -8,7 +8,7 @@
       <SsdComponent
         :src="src"
         :key="panelId"
-        :allowZooming="allowZooming"
+        :allowZooming="!disableZooming"
         @action="onAction"
         ref="ssdComponent"
       />
@@ -33,24 +33,20 @@ import type {
 import debounce from 'lodash-es/debounce'
 import { ref, computed, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-
 import { useAlertsStore } from '@/stores/alerts.ts'
-
 import { configManager } from '@/services/application-config/index.ts'
-
 import { useSsd } from '@/services/useSsd/index.ts'
-
 import DateTimeSlider from '@/components/general/DateTimeSlider.vue'
 import SsdComponent from '@/components/ssd/SsdComponent.vue'
 import { useDisplay } from 'vuetify'
 import { useElementSize } from '@vueuse/core'
+import type { SchematicStatusDisplaySettings } from '@/lib/topology/componentSettings'
 
 interface Props {
   groupId?: string
   panelId?: string
   objectId?: string
-  showDateTimeSlider?: boolean
-  allowZooming?: boolean
+  settings?: SchematicStatusDisplaySettings
 }
 
 interface SsdActionEventPayload {
@@ -58,6 +54,14 @@ interface SsdActionEventPayload {
   panelId: string
   results: SsdActionResult[]
 }
+
+const disableZooming = computed(() => {
+  return props.settings?.zoomingDisabled ?? true
+})
+
+const showDateTimeSlider = computed(() => {
+  return props.settings?.dateTimeSliderEnabled ?? true
+})
 
 const sliderDebounceInterval = 500
 

--- a/src/components/ssd/SchematicStatusDisplay.vue
+++ b/src/components/ssd/SchematicStatusDisplay.vue
@@ -9,12 +9,12 @@
         :src="src"
         :key="panelId"
         :mobile="mobile"
-        :allowZooming="!disableZooming"
+        :allowZooming="settings.zoomingEnabled"
         @action="onAction"
         ref="ssdComponent"
       />
       <DateTimeSlider
-        v-if="showDateTimeSlider"
+        v-if="settings.dateTimeSliderEnabled"
         v-model:selectedDate="selectedDateSlider"
         :dates="dates"
         :hide-speed-controls="mobile"
@@ -41,14 +41,24 @@ import DateTimeSlider from '@/components/general/DateTimeSlider.vue'
 import SsdComponent from '@/components/ssd/SsdComponent.vue'
 import { useDisplay } from 'vuetify'
 import { useElementSize } from '@vueuse/core'
-import type { SchematicStatusDisplaySettings } from '@/lib/topology/componentSettings'
+import {
+  getDefaultSettings,
+  type SchematicStatusDisplaySettings,
+} from '@/lib/topology/componentSettings'
 
 interface Props {
   groupId?: string
   panelId?: string
   objectId?: string
-  settings?: SchematicStatusDisplaySettings
+  settings: SchematicStatusDisplaySettings
 }
+
+const props = withDefaults(defineProps<Props>(), {
+  groupId: '',
+  panelId: '',
+  objectId: '',
+  settings: () => getDefaultSettings('schematic-status-display'),
+})
 
 interface SsdActionEventPayload {
   objectId: string
@@ -56,27 +66,12 @@ interface SsdActionEventPayload {
   results: SsdActionResult[]
 }
 
-const disableZooming = computed(() => {
-  return props.settings?.zoomingDisabled ?? true
-})
-
-const showDateTimeSlider = computed(() => {
-  return props.settings?.dateTimeSliderEnabled ?? true
-})
-
 const sliderDebounceInterval = 500
 
 const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
 const alertsStore = useAlertsStore()
 const route = useRoute()
 const router = useRouter()
-
-const props = withDefaults(defineProps<Props>(), {
-  groupId: '',
-  panelId: '',
-  objectId: '',
-  showDateTimeSlider: true,
-})
 
 const ssdComponent = ref<InstanceType<typeof SsdComponent> | null>(null)
 const ssdContainer = ref<HTMLElement | null>(null)

--- a/src/components/ssd/SchematicStatusDisplay.vue
+++ b/src/components/ssd/SchematicStatusDisplay.vue
@@ -8,6 +8,7 @@
       <SsdComponent
         :src="src"
         :key="panelId"
+        :mobile="mobile"
         :allowZooming="!disableZooming"
         @action="onAction"
         ref="ssdComponent"
@@ -83,8 +84,6 @@ const ssdContainer = ref<HTMLElement | null>(null)
 const selectedDate = ref<Date>(new Date())
 const selectedDateSlider = ref<Date>(selectedDate.value)
 
-const { mobile } = useDisplay()
-
 const selectedDateString = computed(() => {
   if (selectedDate.value === undefined) return ''
   const dateString = selectedDate.value.toISOString()
@@ -114,10 +113,18 @@ const hideSSD = computed(() => {
   return mobile.value && props.objectId !== ''
 })
 
-const ssdContainerSize = useElementSize(ssdContainer)
-watch(ssdContainerSize.width, () => {
-  if (ssdComponent.value) {
-    ssdComponent.value.resize()
+const { width: containerWidth } = useElementSize(ssdContainer)
+watch(containerWidth, () => {
+  ssdComponent.value?.resize()
+})
+
+const { thresholds, mobileBreakpoint } = useDisplay()
+const mobile = computed(() => {
+  const breakpoint = mobileBreakpoint.value
+  if (typeof breakpoint === 'number') {
+    return containerWidth.value < breakpoint
+  } else {
+    return containerWidth.value < thresholds.value[breakpoint]
   }
 })
 

--- a/src/components/ssd/SchematicStatusDisplay.vue
+++ b/src/components/ssd/SchematicStatusDisplay.vue
@@ -50,7 +50,7 @@ interface Props {
   groupId?: string
   panelId?: string
   objectId?: string
-  settings: SchematicStatusDisplaySettings
+  settings?: SchematicStatusDisplaySettings
 }
 
 const props = withDefaults(defineProps<Props>(), {

--- a/src/components/ssd/SsdComponent.vue
+++ b/src/components/ssd/SsdComponent.vue
@@ -1,11 +1,10 @@
 <template>
   <div
-    class="ssd-container w-100 h-100"
     ref="ssdContainer"
     id="ssd-container"
     v-resize="resize"
-    :style="isHidden ? {} : { width: containerWidth + 'px' }"
     :class="{ hidden: isHidden }"
+    class="ssd-container w-100 h-100"
   >
     <schematic-status-display
       v-if="src"
@@ -54,7 +53,6 @@ const width = ref(100)
 const height = ref(100)
 const margin = ref({ top: 0, left: 0 })
 const isHidden = ref(true)
-const containerWidth = ref(0)
 const aspectRatio = ref(1)
 
 const shouldFitWidth = computed(() => !mobile.value && props.fitWidth)
@@ -96,8 +94,6 @@ function setAspectRatio() {
 
 function setDimensions() {
   if (!ssdContainer.value) return
-
-  containerWidth.value = ssdContainer.value.offsetWidth
 
   const dimensions = getDimensions(
     ssdContainer.value,

--- a/src/components/ssd/SsdComponent.vue
+++ b/src/components/ssd/SsdComponent.vue
@@ -167,10 +167,6 @@ function getSvgElement() {
   display: none;
 }
 
-.weboc-ssd > svg {
-  background-color: #fff;
-}
-
 .ssd {
   pointer-events: auto !important;
   user-drag: none;

--- a/src/components/ssd/SsdComponent.vue
+++ b/src/components/ssd/SsdComponent.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onUnmounted, useTemplateRef } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, useTemplateRef } from 'vue'
 import { ref, watch } from 'vue'
 import { createTransformRequestFn } from '@/lib/requests/transformRequest'
 import {
@@ -78,16 +78,18 @@ watch(
   },
 )
 
-function onLoad(): void {
-  isLoading.value = false
-
-  resize()
-
+onMounted(() => {
   if (props.allowZooming) {
     setupD3Zoom()
   } else {
     setupHorizontalScroll()
   }
+})
+
+function onLoad(): void {
+  isLoading.value = false
+
+  resize()
 }
 
 function onAction(event: CustomEvent): void {

--- a/src/components/ssd/SsdComponent.vue
+++ b/src/components/ssd/SsdComponent.vue
@@ -79,15 +79,17 @@ watch(
 )
 
 onMounted(() => {
-  if (props.allowZooming) {
-    setupD3Zoom()
-  } else {
+  if (!props.allowZooming) {
     setupHorizontalScroll()
   }
 })
 
 function onLoad(): void {
   isLoading.value = false
+
+  if (props.allowZooming) {
+    setupD3Zoom()
+  }
 
   resize()
 }

--- a/src/components/ssd/SsdComponent.vue
+++ b/src/components/ssd/SsdComponent.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="ssd-container h-100" ref="ssdContainer">
+    <LoadingSpinner v-if="isLoading" />
     <div :style="ssdSpacerStyle">
       <schematic-status-display
         v-if="src"
@@ -18,7 +19,6 @@
 <script setup lang="ts">
 import { computed, nextTick, onUnmounted, useTemplateRef } from 'vue'
 import { ref, watch } from 'vue'
-import { useDisplay } from 'vuetify'
 import { createTransformRequestFn } from '@/lib/requests/transformRequest'
 import {
   addD3ZoomToSvg,
@@ -27,9 +27,11 @@ import {
   isSVGElement,
 } from '@/lib/svg'
 import { useHorizontalScroll } from '@/services/useHorizontalScroll'
+import LoadingSpinner from '@/components/general/LoadingSpinner.vue'
 
 interface Props {
   src?: string
+  mobile?: boolean
   fitWidth?: boolean
   allowZooming?: boolean
 }
@@ -45,12 +47,11 @@ const svgContainer =
 const emit = defineEmits(['action'])
 defineExpose({ resize })
 
-const { mobile } = useDisplay()
-
 const width = ref(100)
 const height = ref(100)
 const margin = ref({ top: 0, left: 0 })
 const aspectRatio = ref(1)
+const isLoading = ref(true)
 
 const ssdSpacerStyle = computed(() => {
   return props.allowZooming
@@ -67,10 +68,19 @@ const ssdSpacerStyle = computed(() => {
       }
 })
 
-const shouldFitWidth = computed(() => !mobile.value && props.fitWidth)
+const shouldFitWidth = computed(() => !props.mobile && props.fitWidth)
 watch(shouldFitWidth, setDimensions)
 
+watch(
+  () => props.src,
+  () => {
+    isLoading.value = true
+  },
+)
+
 function onLoad(): void {
+  isLoading.value = false
+
   resize()
 
   if (props.allowZooming) {

--- a/src/components/ssd/SsdComponent.vue
+++ b/src/components/ssd/SsdComponent.vue
@@ -159,7 +159,7 @@ function getSvgElement() {
 .ssd-container {
   display: flex;
   flex-direction: column;
-  overflow-x: scroll;
+  overflow-x: auto;
   overflow-y: hidden;
   white-space: nowrap;
   background-color: white;

--- a/src/components/ssd/SsdComponent.vue
+++ b/src/components/ssd/SsdComponent.vue
@@ -169,6 +169,16 @@ function getSvgElement() {
   background-color: #fff;
 }
 
+.ssd {
+  pointer-events: auto !important;
+  user-drag: none;
+  -webkit-user-drag: none;
+  user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+}
+
 :deep(.ssd > svg) {
   pointer-events: auto !important;
 }

--- a/src/components/ssd/SsdComponent.vue
+++ b/src/components/ssd/SsdComponent.vue
@@ -1,58 +1,51 @@
 <template>
   <div
-    class="ssd-container"
+    class="ssd-container w-100 h-100"
     ref="ssdContainer"
     id="ssd-container"
     v-resize="resize"
     :style="isHidden ? {} : { width: containerWidth + 'px' }"
+    :class="{ hidden: isHidden }"
   >
-    <div
-      class="tile-grid-content"
-      :class="{ hidden: isHidden }"
-      :style="{
-        width: width + 'px',
-        height: height + 'px',
-        'margin-left': margin.left + 'px',
-        'margin-top': margin.top + 'px',
-        'margin-bottom': margin.top + 'px',
-      }"
-      ref="scroll-content"
-    >
-      <schematic-status-display
-        v-if="src"
-        class="weboc-ssd"
-        :src="src"
-        ref="svgContainer"
-        @load="onLoad"
-        @action="onAction"
-        style="width: 100%"
-        :transformRequestFn="createTransformRequestFn()"
-      >
-      </schematic-status-display>
-    </div>
+    <schematic-status-display
+      v-if="src"
+      class="ssd w-100 h-100"
+      :src="src"
+      ref="svgContainer"
+      @load="onLoad"
+      @action="onAction"
+      :transformRequestFn="createTransformRequestFn()"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { nextTick, onBeforeUnmount } from 'vue'
-import { ref, onMounted, watch } from 'vue'
+import { computed, nextTick, useTemplateRef } from 'vue'
+import { ref, watch } from 'vue'
 import { useDisplay } from 'vuetify'
 import { createTransformRequestFn } from '@/lib/requests/transformRequest'
+import {
+  addD3ZoomToSvg,
+  getAspectRatio,
+  getDimensions,
+  isSVGElement,
+} from '@/lib/svg'
 
 interface Props {
   src?: string
   fitWidth?: boolean
+  allowZooming?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  src: '',
   fitWidth: true,
 })
 
-const ssdContainer = ref<HTMLElement>()
-const svgContainer = ref<HTMLElement>()
+const ssdContainer = useTemplateRef('ssdContainer')
+const svgContainer =
+  useTemplateRef<HTMLSchematicStatusDisplayElement>('svgContainer')
 
-const emit = defineEmits(['action', 'submit'])
+const emit = defineEmits(['action'])
 defineExpose({ resize })
 
 const { mobile } = useDisplay()
@@ -62,181 +55,69 @@ const height = ref(100)
 const margin = ref({ top: 0, left: 0 })
 const isHidden = ref(true)
 const containerWidth = ref(0)
+const aspectRatio = ref(1)
 
-let pos = { top: 0, left: 0, x: 0, y: 0 }
-let aspectRatio = 1
-let fitWidthValue = true
-
-onMounted(() => {
-  resize()
-  if (ssdContainer.value) {
-    ssdContainer.value.addEventListener('pointerdown', mouseDownHandler)
-    ssdContainer.value.addEventListener('wheel', mouseWheelHandler, {
-      passive: true,
-    })
-  }
-
-  fitWidthHeightHandler()
-})
-
-onBeforeUnmount(() => {
-  if (ssdContainer.value) {
-    ssdContainer.value.removeEventListener('pointerdown', mouseDownHandler)
-    ssdContainer.value.removeEventListener('wheel', mouseWheelHandler)
-  }
-})
-
-watch(mobile, fitWidthHeightHandler)
-watch(() => props.fitWidth, fitWidthHeightHandler)
-function fitWidthHeightHandler(): void {
-  fitWidthValue = !mobile.value && props.fitWidth
-  setDimensions()
-  pos = { top: 0, left: 0, x: 0, y: 0 }
-  if (ssdContainer.value) {
-    if (fitWidthValue) {
-      ssdContainer.value.removeEventListener('pointerdown', mouseDownHandler)
-      ssdContainer.value.removeEventListener('wheel', mouseWheelHandler)
-    } else {
-      ssdContainer.value.addEventListener('pointerdown', mouseDownHandler)
-      ssdContainer.value.addEventListener('wheel', mouseWheelHandler, {
-        passive: true,
-      })
-    }
-  }
-}
-
-function mouseWheelHandler(event: WheelEvent): void {
-  if (ssdContainer.value) {
-    ssdContainer.value.scrollLeft += event.deltaY
-    pos.left = ssdContainer.value.scrollLeft
-  }
-}
-
-function mouseMoveHandler(event: PointerEvent): void {
-  // How far the mouse has been moved
-  const dx = event.clientX - pos.x
-  const dy = event.clientY - pos.y
-
-  // Scroll the element
-  if (ssdContainer.value) {
-    // ssdContainer.value.scrollLeft += event.deltaY
-    pos.left = ssdContainer.value.scrollLeft
-    ssdContainer.value.scrollTop = pos.top - dy
-    ssdContainer.value.scrollLeft = pos.left - dx
-    ssdContainer.value.style.cursor = 'grabbing'
-  }
-}
-
-function mouseDownHandler(event: PointerEvent): void {
-  if (ssdContainer.value) {
-    const { scrollLeft, scrollTop } = ssdContainer.value
-
-    pos = {
-      // The current scroll
-      left: scrollLeft,
-      top: scrollTop,
-      // Get the current mouse position
-      x: event.clientX,
-      y: event.clientY,
-    }
-
-    document.addEventListener('pointermove', mouseMoveHandler)
-    document.addEventListener('pointerup', mouseUpHandler)
-  }
-}
-
-function mouseUpHandler(): void {
-  document.removeEventListener('pointermove', mouseMoveHandler)
-  document.removeEventListener('pointerup', mouseUpHandler)
-  if (ssdContainer.value) {
-    const { scrollLeft, scrollTop } = ssdContainer.value
-
-    pos.left = scrollLeft
-    pos.top = scrollTop
-    ssdContainer.value.style.cursor = 'inherit'
-    ssdContainer.value.style.removeProperty('user-select')
-  }
-}
-
-function restoreScrollPosition(): void {
-  if (ssdContainer.value) {
-    ssdContainer.value.scrollTop = pos.top
-    ssdContainer.value.scrollLeft = pos.left
-  }
-}
+const shouldFitWidth = computed(() => !mobile.value && props.fitWidth)
+watch(shouldFitWidth, setDimensions)
 
 function onLoad(): void {
   resize()
+  setupD3Zoom()
 }
 
 function onAction(event: CustomEvent): void {
   emit('action', event)
 }
 
-function resize(): void {
-  if (ssdContainer.value === undefined) return
+async function resize() {
   isHidden.value = true
-  nextTick(() => {
-    margin.value = { top: 0, left: 0 }
-    setAspectRatio()
-    setDimensions()
-    isHidden.value = false
-    restoreScrollPosition()
-  })
+
+  await nextTick()
+
+  setAspectRatio()
+  setDimensions()
+
+  isHidden.value = false
 }
 
-function setAspectRatio(): void {
-  const sizes = getSvgContainerSizes()
-  if (sizes.length) {
-    // check if sizes is empty
-    aspectRatio = +sizes[2] / +sizes[3]
-    return
-  }
-  aspectRatio = 1
+function setupD3Zoom() {
+  const svg = getSvgElement()
+  if (!svg) return
+
+  addD3ZoomToSvg(svg)
 }
 
-function getSvgContainerSizes(): number[] {
-  if (svgContainer.value && svgContainer.value.firstChild) {
-    const svg = svgContainer.value.firstChild as SVGElement
-    const viewBox = svg.getAttribute('viewBox')
-    if (viewBox) {
-      const sizes = viewBox.split(' ', 4).map((x) => +x) as [
-        number,
-        number,
-        number,
-        number,
-      ]
-      return sizes
-    }
-  }
-  return []
+function setAspectRatio() {
+  const svg = getSvgElement()
+  if (!svg) return
+
+  aspectRatio.value = getAspectRatio(svg)
 }
 
-function setDimensions(): void {
-  if (ssdContainer.value && aspectRatio) {
-    let h = ssdContainer.value.clientHeight
-    let w = ssdContainer.value.offsetWidth
-    containerWidth.value = ssdContainer.value.offsetWidth
-    let m = { top: 0, left: 0 }
-    const dx = w - h * aspectRatio
-    if (dx < 0 && !fitWidthValue) {
-      // add space for scrollbar
-      w = h * aspectRatio
-    } else if (dx < 0) {
-      const h1 = w / aspectRatio
-      m = { top: (h - h1) / 2, left: 0 }
-    } else {
-      w = h * aspectRatio
-      m = { top: 0, left: dx / 2 }
-    }
-    margin.value = m
-    width.value = w
-    height.value = h
+function setDimensions() {
+  if (!ssdContainer.value) return
+
+  containerWidth.value = ssdContainer.value.offsetWidth
+
+  const dimensions = getDimensions(
+    ssdContainer.value,
+    aspectRatio.value,
+    shouldFitWidth.value,
+  )
+  height.value = dimensions.height
+  width.value = dimensions.width
+  margin.value = dimensions.margins
+}
+
+function getSvgElement() {
+  const svg = svgContainer.value?.firstChild
+  if (svg && isSVGElement(svg)) {
+    return svg
   }
 }
 </script>
 
-<style>
+<style scoped>
 .ssd-container {
   height: 100%;
   display: flex;
@@ -244,9 +125,10 @@ function setDimensions(): void {
   overflow-x: scroll;
   overflow-y: hidden;
   white-space: nowrap;
+  background-color: white;
 }
 
-.tile-grid-content.hidden {
+.hidden {
   display: none;
 }
 
@@ -254,12 +136,7 @@ function setDimensions(): void {
   background-color: #fff;
 }
 
-.fit-content-button {
-  position: absolute;
-  padding: auto;
-}
-
-.scroll-content {
-  position: relative;
+:deep(.ssd > svg) {
+  pointer-events: auto !important;
 }
 </style>

--- a/src/lib/svg/index.ts
+++ b/src/lib/svg/index.ts
@@ -1,0 +1,90 @@
+import * as d3 from 'd3'
+
+export function addD3ZoomToSvg(element: SVGElement) {
+  const svg = d3.select(element)
+
+  const allChildren = svg.selectChildren()
+  const content = svg.append('g')
+  const contentNode = content.node()
+  if (!contentNode) return
+
+  allChildren.each((_, i, nodes) => {
+    const child = nodes[i] as Element
+    contentNode.appendChild(child)
+  })
+
+  const { width, height } = getSvgContainerSizes(element) ?? {
+    width: 0,
+    height: 0,
+  }
+
+  const zoom = d3
+    .zoom<SVGElement, unknown>()
+    .scaleExtent([1, 10])
+    .translateExtent([
+      [0, 0],
+      [width, height],
+    ])
+    .on('zoom', ({ transform }) => {
+      content.attr('transform', transform)
+    })
+
+  const resetZoom = () => {
+    svg.transition().duration(100).call(zoom.transform, d3.zoomIdentity)
+  }
+
+  svg.call(zoom).on('dblclick.zoom', resetZoom)
+}
+
+export function isSVGElement(node: Node): node is SVGElement {
+  return node.nodeType === Node.ELEMENT_NODE && node.nodeName === 'svg'
+}
+
+export function getAspectRatio(svg: SVGElement): number {
+  const containerSizes = getSvgContainerSizes(svg)
+  if (!containerSizes) return 1
+
+  const { width, height } = containerSizes
+  return width / height
+}
+
+export function getSvgContainerSizes(svg: SVGElement) {
+  const viewBox = svg.getAttribute('viewBox')
+  if (!viewBox) return
+
+  const [minX, minY, width, height] = viewBox.split(' ', 4).map((x) => +x)
+  return {
+    minX,
+    minY,
+    width,
+    height,
+  }
+}
+
+export function getDimensions(
+  element: HTMLElement,
+  aspectRatio: number,
+  fitWidthValue: boolean,
+) {
+  let height = element.clientHeight
+  let width = element.offsetWidth
+  let margins = { top: 0, left: 0 }
+
+  const dx = width - height * aspectRatio
+
+  if (dx < 0 && !fitWidthValue) {
+    // add space for scrollbar
+    width = height * aspectRatio
+  } else if (dx < 0) {
+    margins = { top: (height - width / aspectRatio) / 2, left: 0 }
+  } else {
+    width = height * aspectRatio
+    margins = { top: 0, left: dx / 2 }
+  }
+
+  return {
+    width,
+    height,
+    margins,
+  }
+}

--- a/src/lib/svg/index.ts
+++ b/src/lib/svg/index.ts
@@ -18,6 +18,24 @@ export function addD3ZoomToSvg(element: SVGElement) {
     height: 0,
   }
 
+  type D3ZoomEvent = d3.D3ZoomEvent<SVGElement, unknown>
+
+  const zoomStart = (event: D3ZoomEvent) => {
+    if (event.sourceEvent?.type === 'mousedown') {
+      svg.style('cursor', 'grabbing')
+    }
+  }
+
+  const zooming = ({ transform }: D3ZoomEvent) => {
+    content.attr('transform', transform.toString())
+  }
+
+  const zoomEnd = (event: D3ZoomEvent) => {
+    if (event.sourceEvent?.type === 'mouseup') {
+      svg.style('cursor', 'inherit')
+    }
+  }
+
   const zoom = d3
     .zoom<SVGElement, unknown>()
     .scaleExtent([1, 10])
@@ -25,9 +43,9 @@ export function addD3ZoomToSvg(element: SVGElement) {
       [0, 0],
       [width, height],
     ])
-    .on('zoom', ({ transform }) => {
-      content.attr('transform', transform)
-    })
+    .on('start', zoomStart)
+    .on('zoom', zooming)
+    .on('end', zoomEnd)
 
   const resetZoom = () => {
     svg.transition().duration(100).call(zoom.transform, d3.zoomIdentity)

--- a/src/lib/topology/componentSettings.ts
+++ b/src/lib/topology/componentSettings.ts
@@ -1,5 +1,6 @@
 import type { FillPaintProps, LinePaintProps } from 'maplibre-gl'
 import type { ComponentType } from './component'
+import { componentTypeToDefaultSettingsMap } from './defaultComponentSettings'
 
 type PaintMapping = {
   fill: FillPaintProps
@@ -11,7 +12,7 @@ export interface ComponentSettingsResponse {
   declarations?: Declarations
 }
 
-interface ComponentSettingsMapping {
+export interface ComponentSettingsMapping {
   map: MapSettings
   charts: ChartSettings
   'data-download-display': undefined
@@ -25,7 +26,7 @@ interface ComponentSettingsMapping {
 }
 
 type SettingsPerComponent = {
-  [key in ComponentType]?: ComponentSettingsMapping[key]
+  [key in ComponentType]?: Partial<ComponentSettingsMapping[key]>
 }
 
 export interface ComponentSettings extends SettingsPerComponent {
@@ -33,21 +34,21 @@ export interface ComponentSettings extends SettingsPerComponent {
 }
 
 export interface ChartSettings {
-  chartEnabled?: boolean
-  elevationChartEnabled?: boolean
-  tableEnabled?: boolean
-  metaDataEnabled?: boolean
-  downloadEnabled?: boolean
+  chartEnabled: boolean
+  elevationChartEnabled: boolean
+  tableEnabled: boolean
+  metaDataEnabled: boolean
+  downloadEnabled: boolean
 }
 
 export interface MapSettings extends ChartSettings {
-  chartPanelEnabled?: boolean
-  locationSearchEnabled?: boolean
+  chartPanelEnabled: boolean
+  locationSearchEnabled: boolean
 }
 
 export interface SchematicStatusDisplaySettings {
-  dateTimeSliderEnabled?: boolean
-  zoomingDisabled?: boolean
+  dateTimeSliderEnabled: boolean
+  zoomingEnabled: boolean
 }
 
 export interface Declarations {
@@ -72,4 +73,20 @@ export interface OverlayLocation {
   locationSet: string
   type: keyof PaintMapping
   paint: PaintMapping[OverlayLocation['type']]
+}
+
+export function getDefaultSettings<T extends ComponentType>(componentType: T) {
+  return componentTypeToDefaultSettingsMap[componentType]
+}
+
+export function getSettings<T extends ComponentType>(
+  componentSettings: ComponentSettings,
+  componentType: T,
+) {
+  const defaultSettings = getDefaultSettings(componentType)
+  const settings = componentSettings[componentType]
+  return {
+    ...defaultSettings,
+    ...settings,
+  }
 }

--- a/src/lib/topology/componentSettings.ts
+++ b/src/lib/topology/componentSettings.ts
@@ -16,7 +16,7 @@ interface ComponentSettingsMapping {
   charts: ChartSettings
   'data-download-display': undefined
   report: undefined
-  'schematic-status-display': undefined
+  'schematic-status-display': SchematicStatusDisplaySettings
   'system-monitor': undefined
   'html-display': undefined
   dashboard: undefined
@@ -43,6 +43,11 @@ export interface ChartSettings {
 export interface MapSettings extends ChartSettings {
   chartPanelEnabled?: boolean
   locationSearchEnabled?: boolean
+}
+
+export interface SchematicStatusDisplaySettings {
+  dateTimeSliderEnabled?: boolean
+  zoomingDisabled?: boolean
 }
 
 export interface Declarations {

--- a/src/lib/topology/componentSettings.ts
+++ b/src/lib/topology/componentSettings.ts
@@ -80,11 +80,11 @@ export function getDefaultSettings<T extends ComponentType>(componentType: T) {
 }
 
 export function getSettings<T extends ComponentType>(
-  componentSettings: ComponentSettings,
+  componentSettings: ComponentSettings | undefined,
   componentType: T,
 ) {
   const defaultSettings = getDefaultSettings(componentType)
-  const settings = componentSettings[componentType]
+  const settings = componentSettings?.[componentType]
   return {
     ...defaultSettings,
     ...settings,

--- a/src/lib/topology/dashboard.ts
+++ b/src/lib/topology/dashboard.ts
@@ -82,8 +82,6 @@ export function getComponentPropsForNode(
       panelId: node.scadaPanelId,
       groupId: node.id,
       objectId: '',
-      showDateTimeSlider: false,
-      allowZooming: true,
     }
     return result
   }

--- a/src/lib/topology/dashboard.ts
+++ b/src/lib/topology/dashboard.ts
@@ -83,6 +83,7 @@ export function getComponentPropsForNode(
       groupId: node.id,
       objectId: '',
       showDateTimeSlider: false,
+      allowZooming: true,
     }
     return result
   }

--- a/src/lib/topology/defaultComponentSettings.ts
+++ b/src/lib/topology/defaultComponentSettings.ts
@@ -1,0 +1,37 @@
+import type {
+  ChartSettings,
+  ComponentSettingsMapping,
+  MapSettings,
+  SchematicStatusDisplaySettings,
+} from './componentSettings'
+
+const defaultChartSettings: ChartSettings = {
+  chartEnabled: true,
+  elevationChartEnabled: true,
+  tableEnabled: true,
+  metaDataEnabled: true,
+  downloadEnabled: true,
+}
+
+const defaultMapSettings: MapSettings = {
+  ...defaultChartSettings,
+  chartPanelEnabled: true,
+  locationSearchEnabled: true,
+}
+
+const defaultSchematicStatusDisplaySettings: SchematicStatusDisplaySettings = {
+  dateTimeSliderEnabled: true,
+  zoomingEnabled: false,
+}
+
+export const componentTypeToDefaultSettingsMap: ComponentSettingsMapping = {
+  map: defaultMapSettings,
+  charts: defaultChartSettings,
+  'data-download': undefined,
+  reports: undefined,
+  'schematic-status-display': defaultSchematicStatusDisplaySettings,
+  'system-monitor': undefined,
+  'web-display': undefined,
+  dashboard: undefined,
+  tasks: undefined,
+} as const

--- a/src/lib/topology/defaultComponentSettings.ts
+++ b/src/lib/topology/defaultComponentSettings.ts
@@ -27,11 +27,12 @@ const defaultSchematicStatusDisplaySettings: SchematicStatusDisplaySettings = {
 export const componentTypeToDefaultSettingsMap: ComponentSettingsMapping = {
   map: defaultMapSettings,
   charts: defaultChartSettings,
-  'data-download': undefined,
-  reports: undefined,
+  'data-download-display': undefined,
+  report: undefined,
   'schematic-status-display': defaultSchematicStatusDisplaySettings,
   'system-monitor': undefined,
-  'web-display': undefined,
+  'html-display': undefined,
   dashboard: undefined,
   tasks: undefined,
+  'log-display': undefined,
 } as const

--- a/src/services/useHorizontalScroll/index.ts
+++ b/src/services/useHorizontalScroll/index.ts
@@ -1,0 +1,63 @@
+export function useHorizontalScroll() {
+  let pos = { top: 0, left: 0, x: 0, y: 0 }
+
+  function mouseWheelHandler(event: WheelEvent): void {
+    if (!event.currentTarget) return
+    const element = event.currentTarget as HTMLElement
+
+    element.scrollLeft += event.deltaY
+    pos.left = element.scrollLeft
+  }
+
+  function mouseMoveHandler(event: MouseEvent): void {
+    if (!event.currentTarget) return
+    const element = event.currentTarget as HTMLElement
+
+    const dx = event.clientX - pos.x
+    const dy = event.clientY - pos.y
+
+    pos.left = element.scrollLeft
+
+    element.scrollTop = pos.top - dy
+    element.scrollLeft = pos.left - dx
+
+    element.style.cursor = 'grabbing'
+  }
+
+  function mouseDownHandler(event: MouseEvent): void {
+    if (!event.currentTarget) return
+    const element = event.currentTarget as HTMLElement
+    const { scrollLeft, scrollTop } = element
+
+    pos = {
+      // The current scroll
+      left: scrollLeft,
+      top: scrollTop,
+      // Get the current mouse position
+      x: event.clientX,
+      y: event.clientY,
+    }
+
+    element.addEventListener('pointermove', mouseMoveHandler)
+    element.addEventListener('pointerup', mouseUpHandler)
+  }
+
+  function mouseUpHandler(event: MouseEvent): void {
+    if (!event.currentTarget) return
+    const element = event.currentTarget as HTMLElement
+    const { scrollLeft, scrollTop } = element
+
+    pos.left = scrollLeft
+    pos.top = scrollTop
+
+    element.style.cursor = 'inherit'
+
+    element.removeEventListener('pointermove', mouseMoveHandler)
+    element.removeEventListener('pointerup', mouseUpHandler)
+  }
+
+  return {
+    mouseWheelHandler,
+    mouseDownHandler,
+  }
+}

--- a/src/services/useHorizontalScroll/index.ts
+++ b/src/services/useHorizontalScroll/index.ts
@@ -1,59 +1,49 @@
 export function useHorizontalScroll() {
-  let pos = { top: 0, left: 0, x: 0, y: 0 }
+  let lastPos = { x: 0, y: 0 }
+  let moveHandler: (event: MouseEvent) => void
+  let upHandler: (event: MouseEvent) => void
 
   function mouseWheelHandler(event: WheelEvent): void {
     if (!event.currentTarget) return
     const element = event.currentTarget as HTMLElement
 
     element.scrollLeft += event.deltaY
-    pos.left = element.scrollLeft
-  }
-
-  function mouseMoveHandler(event: MouseEvent): void {
-    if (!event.currentTarget) return
-    const element = event.currentTarget as HTMLElement
-
-    const dx = event.clientX - pos.x
-    const dy = event.clientY - pos.y
-
-    pos.left = element.scrollLeft
-
-    element.scrollTop = pos.top - dy
-    element.scrollLeft = pos.left - dx
-
-    element.style.cursor = 'grabbing'
   }
 
   function mouseDownHandler(event: MouseEvent): void {
     if (!event.currentTarget) return
     const element = event.currentTarget as HTMLElement
-    const { scrollLeft, scrollTop } = element
 
-    pos = {
-      // The current scroll
-      left: scrollLeft,
-      top: scrollTop,
-      // Get the current mouse position
+    lastPos = {
       x: event.clientX,
       y: event.clientY,
     }
 
-    element.addEventListener('pointermove', mouseMoveHandler)
-    element.addEventListener('pointerup', mouseUpHandler)
+    moveHandler = (event) => mouseMoveHandler(event, element)
+    upHandler = () => mouseUpHandler(element)
+
+    document.addEventListener('pointermove', moveHandler)
+    document.addEventListener('pointerup', upHandler)
   }
 
-  function mouseUpHandler(event: MouseEvent): void {
-    if (!event.currentTarget) return
-    const element = event.currentTarget as HTMLElement
-    const { scrollLeft, scrollTop } = element
+  function mouseMoveHandler(event: MouseEvent, element: HTMLElement): void {
+    const dx = event.clientX - lastPos.x
 
-    pos.left = scrollLeft
-    pos.top = scrollTop
+    lastPos = {
+      x: event.clientX,
+      y: event.clientY,
+    }
 
+    element.scrollLeft -= dx
+
+    element.style.cursor = 'grabbing'
+  }
+
+  function mouseUpHandler(element: HTMLElement): void {
     element.style.cursor = 'inherit'
 
-    element.removeEventListener('pointermove', mouseMoveHandler)
-    element.removeEventListener('pointerup', mouseUpHandler)
+    document.removeEventListener('pointermove', moveHandler)
+    document.removeEventListener('pointerup', upHandler)
   }
 
   return {


### PR DESCRIPTION
### Description

Can now switch between d3 zoom and scrollbar vertical pan (old behaviour) by changing zoomingEnabled (default false) in the ssd component settings.

Also adds initial default component settings.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
