### PR TITLE
Use topologyNode extent for map extent

### DIFF
--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -10,6 +10,7 @@
         :geojson="geojson"
         @changeLocationId="onLocationChange"
         :layer-capabilities="layerCapabilities"
+        :bounding-box="boundingBox"
         :times="times"
         :max-values-time-series="maxValuesTimeSeries"
         v-model:elevation="elevation"
@@ -50,6 +51,7 @@ import bbox from '@turf/bbox'
 import { useUserSettingsStore } from '@/stores/userSettings'
 import { UseDisplayConfigOptions } from '@/services/useDisplayConfig'
 import { useFilterLocations } from '@/services/useFilterLocations'
+import type { BoundingBox } from '@deltares/fews-wms-requests'
 
 interface Props {
   layerName?: string
@@ -57,6 +59,7 @@ interface Props {
   filterIds?: string[]
   latitude?: string
   longitude?: string
+  boundingBox?: BoundingBox
 }
 
 const props = withDefaults(defineProps<Props>(), {

--- a/src/components/spatialdisplay/SpatialDisplayComponent.vue
+++ b/src/components/spatialdisplay/SpatialDisplayComponent.vue
@@ -423,7 +423,6 @@ const bounds = ref<LngLatBounds>()
 watch(
   () => props.boundingBox,
   (newBoundingBox) => {
-    // TODO: What to do when the topologyNode does not have a bounding box?
     if (!newBoundingBox) return
 
     const newBounds = convertBoundingBoxToLngLatBounds(newBoundingBox)

--- a/src/components/spatialdisplay/SpatialDisplayComponent.vue
+++ b/src/components/spatialdisplay/SpatialDisplayComponent.vue
@@ -146,7 +146,7 @@ import {
   type MapLayerMouseEvent,
   type MapLayerTouchEvent,
 } from 'maplibre-gl'
-import type { Layer, Style } from '@deltares/fews-wms-requests'
+import type { BoundingBox, Layer, Style } from '@deltares/fews-wms-requests'
 import type { Location } from '@deltares/fews-pi-requests'
 import { LayerKind } from '@/lib/streamlines'
 import { ColourScale, useColourScalesStore } from '@/stores/colourScales'
@@ -178,6 +178,7 @@ interface Props {
   longitude?: string
   currentTime?: Date
   maxValuesTimeSeries?: TimeSeriesData[]
+  boundingBox?: BoundingBox
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -420,13 +421,16 @@ function setLayerOptions(): void {
 
 const bounds = ref<LngLatBounds>()
 watch(
-  () => layerOptions.value?.bbox,
-  (layerBounds) => {
-    if (!layerBounds) return
+  () => props.boundingBox,
+  (newBoundingBox) => {
+    // TODO: What to do when the topologyNode does not have a bounding box?
+    if (!newBoundingBox) return
 
-    const boundsChanged = bounds.value?.toString() !== layerBounds.toString()
+    const newBounds = convertBoundingBoxToLngLatBounds(newBoundingBox)
+
+    const boundsChanged = bounds.value?.toString() !== newBounds.toString()
     if (boundsChanged) {
-      bounds.value = layerBounds
+      bounds.value = newBounds
     }
   },
   { immediate: true },

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -68,6 +68,7 @@
           :is="Component"
           :filter-ids="filterIds"
           :topologyNode="topologyNode"
+          :boundingBox="boundingBox"
         />
       </keep-alive>
     </router-view>
@@ -115,6 +116,7 @@ import {
   type DisplayTab,
 } from '@/lib/topology/displayTabs.js'
 import { useTopologyNodesStore } from '@/stores/topologyNodes'
+import type { BoundingBox } from '@deltares/fews-wms-requests'
 
 interface Props {
   topologyId?: string
@@ -162,6 +164,11 @@ const activeNode = computed(() => {
 const secondaryWorkflows = computed(() => {
   if (!activeNode.value?.secondaryWorkflows) return null
   return activeNode.value.secondaryWorkflows
+})
+
+const boundingBox = computed(() => {
+  // @ts-expect-error FIXME: Update when the types are updated
+  return activeNode.value?.boundingBox as BoundingBox | undefined
 })
 
 const items = ref<ColumnItem[]>([])

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -116,7 +116,6 @@ import {
   type DisplayTab,
 } from '@/lib/topology/displayTabs.js'
 import { useTopologyNodesStore } from '@/stores/topologyNodes'
-import type { BoundingBox } from '@deltares/fews-wms-requests'
 
 interface Props {
   topologyId?: string
@@ -166,10 +165,7 @@ const secondaryWorkflows = computed(() => {
   return activeNode.value.secondaryWorkflows
 })
 
-const boundingBox = computed(() => {
-  // @ts-expect-error FIXME: Update when the types are updated
-  return activeNode.value?.boundingBox as BoundingBox | undefined
-})
+const boundingBox = computed(() => activeNode.value?.boundingBox)
 
 const items = ref<ColumnItem[]>([])
 


### PR DESCRIPTION
### Description

Get the map extent from the topologyNode's boundingBox.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
