### PR TITLE
Add support for selecting multiple locations on the map to compare data

### DIFF
--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -35,13 +35,19 @@
 </template>
 
 <script setup lang="ts">
-import { computed, defineAsyncComponent, ref, useTemplateRef, watch } from 'vue'
+import {
+  computed,
+  defineAsyncComponent,
+  ref,
+  useTemplateRef,
+  watch,
+  watchEffect,
+} from 'vue'
 import SpatialDisplayComponent from '@/components/spatialdisplay/SpatialDisplayComponent.vue'
 import { useDisplay } from 'vuetify'
 import { configManager } from '@/services/application-config'
 import { useRoute, useRouter } from 'vue-router'
 import { findParentRoute } from '@/router'
-import { onMounted } from 'vue'
 import {
   useWmsLayerCapabilities,
   useWmsMaxValuesTimeSeries,
@@ -195,8 +201,10 @@ const currentLongitude = ref<string>()
 const elevation = ref<number | undefined>()
 const currentTime = ref<Date>()
 
-onMounted(() => {
+watchEffect(() => {
   currentLocationIds.value = props.locationIds?.split(',')
+})
+watchEffect(() => {
   currentLatitude.value = props.latitude
   currentLongitude.value = props.longitude
 })
@@ -210,7 +218,9 @@ const containerIsMobileSize = computed(() => {
 const hideMap = computed(() => {
   return (
     containerIsMobileSize.value &&
-    (currentLocationIds.value || currentLongitude.value || currentLatitude.value)
+    (currentLocationIds.value ||
+      currentLongitude.value ||
+      currentLatitude.value)
   )
 })
 

--- a/src/components/spatialdisplay/SpatialDisplayComponent.vue
+++ b/src/components/spatialdisplay/SpatialDisplayComponent.vue
@@ -34,7 +34,7 @@
     <LocationsLayer
       v-if="showLocationsLayer && hasLocations"
       :locationsGeoJson="geojson"
-      :selectedLocationId="props.locationId"
+      :selectedLocationIds="props.locationIds"
       @click="onLocationClick"
     />
     <CoordinateSelectorLayer
@@ -97,8 +97,8 @@
         width="50vw"
         max-width="250"
         :locations="locations"
-        :selectedLocationId="props.locationId"
-        @changeLocationId="onLocationChange"
+        :selectedLocationIds="props.locationIds"
+        @changeLocationIds="onLocationsChange"
       />
     </template>
   </div>
@@ -192,7 +192,7 @@ interface Props {
   elevation?: number
   locations?: Location[]
   geojson: FeatureCollection<Geometry, Location>
-  locationId?: string
+  locationIds?: string[]
   latitude?: string
   longitude?: string
   currentTime?: Date
@@ -207,7 +207,7 @@ const props = withDefaults(defineProps<Props>(), {
 })
 
 const emit = defineEmits([
-  'changeLocationId',
+  'changeLocationIds',
   'coordinateClick',
   'update:elevation',
   'update:currentTime',
@@ -316,11 +316,19 @@ function onLocationClick(event: MapLayerMouseEvent | MapLayerTouchEvent): void {
   if (!event.features) return
   const locationId: string | undefined =
     event.features[0].properties?.locationId
-  if (locationId) onLocationChange(locationId)
+  if (!locationId) return
+
+  if (event.originalEvent.ctrlKey) {
+    const locationIds = props.locationIds ?? []
+    const newLocationIds = [...new Set([...locationIds, locationId])]
+    onLocationsChange(newLocationIds)
+  } else {
+    onLocationsChange([locationId])
+  }
 }
 
-function onLocationChange(locationId: string | null): void {
-  emit('changeLocationId', locationId)
+function onLocationsChange(locationIds: string[]): void {
+  emit('changeLocationIds', locationIds)
 }
 
 const canUseStreamlines = computed(

--- a/src/components/spatialdisplay/SpatialTimeSeriesDisplay.vue
+++ b/src/components/spatialdisplay/SpatialTimeSeriesDisplay.vue
@@ -144,7 +144,7 @@ const { tooltip } = useLocationTooltip(baseUrl, () =>
   isFilterActionsFilter(props.filter)
     ? {
         filterId: props.filter.filterId,
-        locationId: props.filter.locationIds,
+        locationId: props.filter.locationIds?.split(',')[0],
       }
     : undefined,
 )

--- a/src/components/wms/LocationsSearchControl.vue
+++ b/src/components/wms/LocationsSearchControl.vue
@@ -13,21 +13,23 @@
       hide-details
       @click="showLocationsSearch"
       >{{
-        selectedLocationId ? selectedLocation?.locationName : 'Search locations'
+        selectedLocationIds
+          ? selectedLocation?.locationName
+          : 'Search locations'
       }}</v-btn
     >
   </ControlChip>
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { computed, ref, watch, watchEffect } from 'vue'
 import { type Location } from '@deltares/fews-pi-requests'
 import { useGlobalSearchState } from '@/stores/globalSearch'
 import ControlChip from '@/components/wms/ControlChip.vue'
 
 interface Props {
   locations?: Location[]
-  selectedLocationId?: string | null
+  selectedLocationIds?: string[]
   maxWidth?: string | number
   width?: string | number
   tooltipOpenDelay?: number
@@ -48,7 +50,7 @@ watch(
   (item) => onSelectLocationId(item?.id),
 )
 
-const emit = defineEmits(['changeLocationId'])
+const emit = defineEmits(['changeLocationIds'])
 
 const selectedLocation = ref<Location | null>(null)
 
@@ -56,8 +58,8 @@ const hasLocations = computed(() => {
   return props.locations?.length
 })
 
-function getLocationFromId(locationId: string | null) {
-  if (locationId === null) return null
+function getLocationFromId(locationId: string | undefined) {
+  if (locationId === undefined) return null
   return (
     props.locations.find((location) => location.locationId === locationId) ??
     null
@@ -77,15 +79,19 @@ watch(
   },
 )
 
-watch(
-  () => props.selectedLocationId,
-  () => (selectedLocation.value = getLocationFromId(props.selectedLocationId)),
+watchEffect(
+  () =>
+    // TODO: What should this search control do in case of multiple locations?
+    //       For now just selects the first location.
+    (selectedLocation.value = getLocationFromId(
+      props.selectedLocationIds?.[0],
+    )),
 )
 
 function onSelectLocationId(id: string | undefined) {
   if (id === undefined) {
     return
   }
-  emit('changeLocationId', id)
+  emit('changeLocationIds', [id])
 }
 </script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -220,7 +220,7 @@ export const dynamicRoutes: Readonly<RouteRecordRaw[]> = [
         meta: { sidebar: true },
         children: [
           {
-            path: 'location/:locationId',
+            path: 'location/:locationIds',
             name: 'TopologySpatialTimeSeriesDisplay',
             component: SpatialTimeSeriesDisplay,
             props: true,

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -122,7 +122,7 @@ interface Props {
   nodeId?: string | string[]
   panelId?: string
   layerName?: string
-  locationId?: string
+  locationIds?: string
   latitude?: string
   longitude?: string
 }


### PR DESCRIPTION
### Description

Adds support for clicking multiple locations.
Can select more than 1 location by ctrl clicking on additional location points.

Currently no way to add more locations on mobile.

The location search control also only shows and selects the first selected location.

### Screenshots
![image](https://github.com/user-attachments/assets/2939bdd8-61eb-421e-9c5e-e4ec0cd7c6ff)

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
