### PR TITLE
Get customStyleSheet from remote static resources with local fallback

### DIFF
--- a/src/components/dialog/StartupDialog.vue
+++ b/src/components/dialog/StartupDialog.vue
@@ -16,19 +16,16 @@ import SplashScreenDialog from '@/components/dialog/SplashScreenDialog.vue'
 import TermsOfUseDialog from '@/components/dialog/TermsOfUseDialog.vue'
 import packageConfig from '@/../package.json'
 import { computed } from 'vue'
-import { getLocalOrRemoteFileUrl } from '@/lib/fews-config'
+import { getResourcesStaticUrl } from '@/lib/fews-config'
 import { useConfigStore } from '@/stores/config'
 import { asyncComputed, useStorage } from '@vueuse/core'
 
 const configStore = useConfigStore()
 
-const imagesBaseUrl = `${import.meta.env.BASE_URL}images/`
-
 const splashSrc = asyncComputed(async () => {
   if (!configStore.general.splashScreen) return
-  const localPath = `${imagesBaseUrl}${configStore.general.splashScreen}`
-  const remoteResource = configStore.general.splashScreen
-  return await getLocalOrRemoteFileUrl(localPath, remoteResource)
+
+  return getResourcesStaticUrl(configStore.general.splashScreen)
 })
 
 const shouldAgreeToTerms = computed(

--- a/src/components/dialog/StartupDialog.vue
+++ b/src/components/dialog/StartupDialog.vue
@@ -26,10 +26,9 @@ const imagesBaseUrl = `${import.meta.env.BASE_URL}images/`
 
 const splashSrc = asyncComputed(async () => {
   if (!configStore.general.splashScreen) return
-  return await getLocalOrRemoteFileUrl(
-    imagesBaseUrl,
-    configStore.general.splashScreen,
-  )
+  const localPath = `${imagesBaseUrl}${configStore.general.splashScreen}`
+  const remoteResource = configStore.general.splashScreen
+  return await getLocalOrRemoteFileUrl(localPath, remoteResource)
 })
 
 const shouldAgreeToTerms = computed(

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -170,7 +170,10 @@ import StartupDialog from '@/components/dialog/StartupDialog.vue'
 import GlobalSearchComponent from '@/components/general/GlobalSearchComponent.vue'
 
 import { configManager } from '@/services/application-config'
-import { getLocalOrRemoteFileUrl } from '@/lib/fews-config'
+import {
+  getLocalOrRemoteFileUrl,
+  getResourcesStaticUrl,
+} from '@/lib/fews-config'
 import { StyleValue, nextTick } from 'vue'
 import packageConfig from '@/../package.json'
 import { useUserSettingsStore } from '@/stores/userSettings.ts'
@@ -187,7 +190,6 @@ const { isRtl } = useRtl()
 const route = useRoute()
 
 const showHash = ref(false)
-const logoSrc = ref('')
 const appBarStyle = ref<StyleValue>()
 const appBarColor = ref<string>('')
 
@@ -235,21 +237,14 @@ const currentItemTitle = computed(
     '',
 )
 
-watch(
-  () => configStore.general,
-  async () => {
-    const imagesBaseUrl = `${import.meta.env.BASE_URL}images/`
-    const defaultLogo = `${imagesBaseUrl}logo.png`
-    if (configStore.general.icons?.logo === undefined) {
-      logoSrc.value = defaultLogo
-      return
-    }
-    const localPath = `${imagesBaseUrl}${configStore.general.icons.logo}`
-    const remoteResource = configStore.general.icons.logo
-    const logoUrl = await getLocalOrRemoteFileUrl(localPath, remoteResource)
-    logoSrc.value = logoUrl ?? defaultLogo
-  },
-)
+const logoSrc = computed(() => {
+  const imagesBaseUrl = `${import.meta.env.BASE_URL}images/`
+  const defaultLogo = `${imagesBaseUrl}logo.png`
+
+  return configStore.general.icons?.logo
+    ? getResourcesStaticUrl(configStore.general.icons.logo)
+    : defaultLogo
+})
 
 const versionString = computed(() => {
   if (showHash.value && !__GIT_TAG__) {

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -170,10 +170,7 @@ import StartupDialog from '@/components/dialog/StartupDialog.vue'
 import GlobalSearchComponent from '@/components/general/GlobalSearchComponent.vue'
 
 import { configManager } from '@/services/application-config'
-import {
-  getLocalOrRemoteFileUrl,
-  getResourcesStaticUrl,
-} from '@/lib/fews-config'
+import { getResourcesStaticUrl } from '@/lib/fews-config'
 import { StyleValue, nextTick } from 'vue'
 import packageConfig from '@/../package.json'
 import { useUserSettingsStore } from '@/stores/userSettings.ts'

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -214,7 +214,7 @@ watch(
       const link = document.createElement('link')
       link.id = 'custom-style-sheet'
       link.rel = 'stylesheet'
-      link.href = configStore.customStyleSheet
+      link.href = await configStore.getCustomStyleSheet()
       link.onload = () => {
         appBarStyle.value = {
           backgroundImage: 'var(--weboc-app-bar-bg-image)',
@@ -244,10 +244,9 @@ watch(
       logoSrc.value = defaultLogo
       return
     }
-    const logoUrl = await getLocalOrRemoteFileUrl(
-      imagesBaseUrl,
-      configStore.general.icons?.logo,
-    )
+    const localPath = `${imagesBaseUrl}${configStore.general.icons.logo}`
+    const remoteResource = configStore.general.icons.logo
+    const logoUrl = await getLocalOrRemoteFileUrl(localPath, remoteResource)
     logoSrc.value = logoUrl ?? defaultLogo
   },
 )

--- a/src/lib/fews-config/index.ts
+++ b/src/lib/fews-config/index.ts
@@ -46,11 +46,11 @@ export function getResourcesIconsUrl(resource: string) {
 }
 
 export async function getLocalOrRemoteFileUrl(
-  localBase: string,
-  relativePath: string,
+  localPath: string,
+  remoteResource: string,
 ) {
-  const remoteUrl = getResourcesStaticUrl(relativePath)
-  const localUrl = `${localBase}${relativePath}`
+  const remoteUrl = getResourcesStaticUrl(remoteResource)
+  const localUrl = localPath
 
   const isHtmlResponse = (response: Response) => {
     const contentType = response.headers.get('Content-Type')

--- a/src/stores/config.ts
+++ b/src/stores/config.ts
@@ -116,11 +116,12 @@ const useConfigStore = defineStore('config', {
 
       if (this.general.customStyleSheet) {
         const localPath = `${import.meta.env.BASE_URL}${this.general.customStyleSheet}`
-        const remoteResource = `css/${this.general.customStyleSheet}`
-        return (
-          (await getLocalOrRemoteFileUrl(localPath, remoteResource)) ??
-          defaultStyle
+        const remoteResource = this.general.customStyleSheet
+        const customStyle = await getLocalOrRemoteFileUrl(
+          localPath,
+          remoteResource,
         )
+        return customStyle ?? defaultStyle
       }
 
       return defaultStyle

--- a/src/stores/config.ts
+++ b/src/stores/config.ts
@@ -1,5 +1,8 @@
 import { defineStore } from 'pinia'
-import { getFewsConfig } from '../lib/fews-config/index.js'
+import {
+  getFewsConfig,
+  getLocalOrRemoteFileUrl,
+} from '@/lib/fews-config/index.js'
 import type { WebOcGeneralConfig } from '@deltares/fews-pi-requests'
 import type { WebOcComponent } from '@/lib/fews-config/types'
 import { RouteLocation } from 'vue-router'
@@ -108,6 +111,20 @@ const useConfigStore = defineStore('config', {
 
       return components as Extract<WebOcComponent, { type: T }>[]
     },
+    async getCustomStyleSheet() {
+      const defaultStyle = `${import.meta.env.BASE_URL}weboc-default-style.css`
+
+      if (this.general.customStyleSheet) {
+        const localPath = `${import.meta.env.BASE_URL}${this.general.customStyleSheet}`
+        const remoteResource = `css/${this.general.customStyleSheet}`
+        return (
+          (await getLocalOrRemoteFileUrl(localPath, remoteResource)) ??
+          defaultStyle
+        )
+      }
+
+      return defaultStyle
+    },
   },
   getters: {
     activeComponents: (state) => {
@@ -127,14 +144,6 @@ const useConfigStore = defineStore('config', {
     defaultComponent: (state) => {
       if (state.general.defaultComponent) {
         return state.components[state.general.defaultComponent]
-      }
-    },
-
-    customStyleSheet: (state) => {
-      if (state.general.customStyleSheet) {
-        return `${import.meta.env.BASE_URL}${state.general.customStyleSheet}`
-      } else {
-        return `${import.meta.env.BASE_URL}weboc-default-style.css`
       }
     },
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,7 +36,7 @@ export default defineConfig(({ mode }) => {
         'content-security-policy': [
           `default-src 'none'`,
           `script-src 'self'`,
-          `font-src 'self'`,
+          `font-src 'self' ${env.VITE_FEWS_WEBSERVICES_URL}`,
           `style-src 'self' ${env.VITE_FEWS_WEBSERVICES_URL} 'unsafe-inline'`, // vuetify
           `worker-src blob:`, // maplibre-gl
           `img-src 'self' data: blob: ${env.VITE_FEWS_WEBSERVICES_URL}`, // FEWS webservices


### PR DESCRIPTION
### Description

Gets the custom stylesheet from the static resources `css/` folder. If not present tries to look in the public folder (previous behaviour).

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
