### PR TITLE
Fix display tab is not being active when reloading page

### DIFF
--- a/src/lib/topology/displayTabs.ts
+++ b/src/lib/topology/displayTabs.ts
@@ -47,7 +47,7 @@ export function displayTabsForNode(
 ) {
   for (const tab of displayTabs) {
     const params = {
-      nodeId: parentNodeId ? [parentNodeId, node.id] : node.id,
+      nodeId: parentNodeId ? [parentNodeId, node.id] : [node.id],
       topologyId,
     }
     switch (tab.type) {

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -280,9 +280,10 @@ watchEffect(() => {
       : props.nodeId[0]
     : props.nodeId
 
-  const parentNodeIdNodeId = Array.isArray(props.nodeId)
-    ? props.nodeId[0]
-    : undefined
+  const parentNodeIdNodeId =
+    Array.isArray(props.nodeId) && props.nodeId.length > 1
+      ? props.nodeId[0]
+      : undefined
 
   // Check if the active node is a leaf.
   const node = topologyNodesStore.getNodeById(activeNodeId)


### PR DESCRIPTION
### Description
Fixes that when selecting a report tab and reloading the page, the display tab will not be active.
Only happens when nodeId is not an array.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
