### PR TITLE
Fix topology display not rerouting to spatial display

### DIFF
--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -250,10 +250,13 @@ topologyNodesStore
 const subNodes = computed(() =>
   topologyNodesStore.getSubNodesForIds(topologyDisplayNodes.value),
 )
-watch(topologyNodesStore.nodes, () => {
-  const to = reroute(route)
-  if (to) router.push(to)
-})
+watch(
+  () => topologyNodesStore.nodes,
+  () => {
+    const to = reroute(route)
+    if (to) router.push(to)
+  },
+)
 
 function updateItems(): void {
   if (subNodes.value) {


### PR DESCRIPTION
### Description

Fixes `/topology/:topologyId?/node/:nodeId*` not rerouting to `map/:layerName?` when the nodes have not been loaded yet.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
