### PR TITLE
Selecting a map location fires two getAction requests

### DIFF
--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -237,7 +237,6 @@ function openLocationsTimeSeriesDisplay(locationIds: string[]) {
     ?.toString()
     .replace('SpatialDisplay', 'SpatialTimeSeriesDisplay')
     .replace('WithCoordinates', '')
-  currentLocationIds.value = locationIds
   currentLatitude.value = undefined
   currentLongitude.value = undefined
   router.push({


### PR DESCRIPTION
### Description

Do not set the currentLocationsIds directly as it triggers an update of the getActions filter.

