### PR TITLE
Fix regression causing current location ids to not be saved

### DIFF
--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -239,6 +239,7 @@ function openLocationsTimeSeriesDisplay(locationIds: string[]) {
     .replace('WithCoordinates', '')
   currentLatitude.value = undefined
   currentLongitude.value = undefined
+  currentLocationIds.value = locationIds
   router.push({
     name: routeName,
     params: {

--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -35,14 +35,7 @@
 </template>
 
 <script setup lang="ts">
-import {
-  computed,
-  defineAsyncComponent,
-  ref,
-  useTemplateRef,
-  watch,
-  watchEffect,
-} from 'vue'
+import { computed, defineAsyncComponent, ref, useTemplateRef, watch } from 'vue'
 import SpatialDisplayComponent from '@/components/spatialdisplay/SpatialDisplayComponent.vue'
 import { useDisplay } from 'vuetify'
 import { configManager } from '@/services/application-config'
@@ -204,13 +197,29 @@ const currentLongitude = ref<string>()
 const elevation = ref<number | undefined>()
 const currentTime = ref<Date>()
 
-watchEffect(() => {
-  currentLocationIds.value = props.locationIds?.split(',')
-})
-watchEffect(() => {
-  currentLatitude.value = props.latitude
-  currentLongitude.value = props.longitude
-})
+watch(
+  () => props.locationIds?.split(','),
+  (newLocationIds) => {
+    const isSameLocationIds =
+      JSON.stringify(newLocationIds) ===
+      JSON.stringify(currentLocationIds.value)
+    if (isSameLocationIds) return
+
+    currentLocationIds.value = newLocationIds
+  },
+)
+watch(
+  [() => props.latitude, () => props.longitude],
+  ([newLatitude, newLongitude]) => {
+    const isSameCoordinates =
+      newLatitude === currentLatitude.value &&
+      newLongitude === currentLongitude.value
+    if (isSameCoordinates) return
+
+    currentLatitude.value = newLatitude
+    currentLongitude.value = newLongitude
+  },
+)
 
 const { width: containerWidth } = useElementSize(containerRef)
 

--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -207,6 +207,7 @@ watch(
 
     currentLocationIds.value = newLocationIds
   },
+  { immediate: true },
 )
 watch(
   [() => props.latitude, () => props.longitude],
@@ -219,6 +220,7 @@ watch(
     currentLatitude.value = newLatitude
     currentLongitude.value = newLongitude
   },
+  { immediate: true },
 )
 
 const { width: containerWidth } = useElementSize(containerRef)


### PR DESCRIPTION
### Description
Fix current location ids not being saved.
Important for dashboard as it uses it to maintain selected location state.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
