### PR TITLE
Fix map extents dont translate to dashboard maps

### DIFF
--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -10,7 +10,7 @@
         :geojson="geojson"
         @changeLocationIds="onLocationsChange"
         :layer-capabilities="layerCapabilities"
-        :bounding-box="boundingBox"
+        :bounding-box="topologyNode?.boundingBox"
         :times="times"
         :settings="settings"
         :max-values-time-series="maxValuesTimeSeries"
@@ -55,13 +55,13 @@ import {
 import {
   filterActionsFilter,
   timeSeriesGridActionsFilter,
+  type TopologyNode,
 } from '@deltares/fews-pi-requests'
 import { toMercator } from '@turf/projection'
 import circle from '@turf/circle'
 import bbox from '@turf/bbox'
 import { useUserSettingsStore } from '@/stores/userSettings'
 import { useFilterLocations } from '@/services/useFilterLocations'
-import type { BoundingBox } from '@deltares/fews-wms-requests'
 import type { UseDisplayConfigOptions } from '@/services/useDisplayConfig'
 import {
   type MapSettings,
@@ -79,7 +79,7 @@ interface Props {
   filterIds?: string[]
   latitude?: string
   longitude?: string
-  boundingBox?: BoundingBox
+  topologyNode?: TopologyNode
   settings?: MapSettings
 }
 

--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -10,7 +10,7 @@
         :geojson="geojson"
         @changeLocationIds="onLocationsChange"
         :layer-capabilities="layerCapabilities"
-        :bounding-box="topologyNode?.boundingBox"
+        :bounding-box="boundingBox"
         :times="times"
         :settings="settings"
         :max-values-time-series="maxValuesTimeSeries"
@@ -76,7 +76,6 @@ const SpatialTimeSeriesDisplay = defineAsyncComponent(
 interface Props {
   layerName?: string
   locationIds?: string
-  filterIds?: string[]
   latitude?: string
   longitude?: string
   topologyNode?: TopologyNode
@@ -85,7 +84,6 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   layerName: '',
-  filterIds: () => [],
   settings: () => getDefaultSettings('map'),
 })
 
@@ -93,6 +91,9 @@ const route = useRoute()
 const router = useRouter()
 const { thresholds } = useDisplay()
 const containerRef = useTemplateRef('container')
+
+const boundingBox = computed(() => props.topologyNode?.boundingBox)
+const filterIds = computed(() => props.topologyNode?.filterIds ?? [])
 
 const userSettings = useUserSettingsStore()
 const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
@@ -102,7 +103,7 @@ const { layerCapabilities, times } = useWmsLayerCapabilities(
 )
 const { locations, geojson } = useFilterLocations(
   baseUrl,
-  () => props.filterIds,
+  filterIds,
 )
 
 const start = computed(() => {
@@ -133,7 +134,7 @@ function getFilterActionsFilter(): filterActionsFilter &
   UseDisplayConfigOptions {
   return {
     locationIds: currentLocationIds.value?.join(','),
-    filterId: props.filterIds ? props.filterIds[0] : undefined,
+    filterId: filterIds.value ? filterIds.value[0] : undefined,
     useDisplayUnits: userSettings.useDisplayUnits,
     convertDatum: userSettings.convertDatum,
   }

--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -101,10 +101,7 @@ const { layerCapabilities, times } = useWmsLayerCapabilities(
   baseUrl,
   () => props.layerName,
 )
-const { locations, geojson } = useFilterLocations(
-  baseUrl,
-  filterIds,
-)
+const { locations, geojson } = useFilterLocations(baseUrl, filterIds)
 
 const start = computed(() => {
   if (!times.value || times.value.length === 0) return null

--- a/src/lib/topology/dashboard.ts
+++ b/src/lib/topology/dashboard.ts
@@ -50,7 +50,6 @@ export function getComponentPropsForNode(
   if (componentType === 'map') {
     const result: PropsForComponentType<'map'> = {
       layerName: node.gridDisplaySelection?.plotId,
-      filterIds: node.filterIds,
     }
     return result
   }

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -64,10 +64,7 @@
   <div class="d-flex w-100 h-100">
     <router-view v-slot="{ Component }">
       <keep-alive include="SpatialDisplay">
-        <component
-          :is="Component"
-          :topologyNode="topologyNode"
-        />
+        <component :is="Component" :topologyNode="topologyNode" />
       </keep-alive>
     </router-view>
     <div

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -68,7 +68,6 @@
           :is="Component"
           :filter-ids="filterIds"
           :topologyNode="topologyNode"
-          :boundingBox="boundingBox"
         />
       </keep-alive>
     </router-view>
@@ -164,8 +163,6 @@ const secondaryWorkflows = computed(() => {
   if (!activeNode.value?.secondaryWorkflows) return null
   return activeNode.value.secondaryWorkflows
 })
-
-const boundingBox = computed(() => activeNode.value?.boundingBox)
 
 const items = ref<ColumnItem[]>([])
 

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -66,7 +66,6 @@
       <keep-alive include="SpatialDisplay">
         <component
           :is="Component"
-          :filter-ids="filterIds"
           :topologyNode="topologyNode"
         />
       </keep-alive>
@@ -166,7 +165,6 @@ const secondaryWorkflows = computed(() => {
 
 const items = ref<ColumnItem[]>([])
 
-const filterIds = ref<string[]>([])
 const topologyNode = ref<TopologyNode | undefined>(undefined)
 
 const displayTabs = ref<DisplayTab[]>([])
@@ -288,10 +286,8 @@ watchEffect(() => {
   // Check if the active node is a leaf.
   const node = topologyNodesStore.getNodeById(activeNodeId)
   if (node === undefined) {
-    filterIds.value = []
     return
   }
-  filterIds.value = node.filterIds ?? []
   topologyNode.value = node
 
   if (showLeafsAsButton.value && Array.isArray(props.nodeId)) {


### PR DESCRIPTION
### Description
Passing props through topology display view have to also be implemented in dahsboard and other topologynode based places.
As such move paramater extraction to spatial display itself.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
