### PR TITLE
Fix chartdisplay being shown as if on mobile on too large screens

### DIFF
--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -213,7 +213,7 @@ watchEffect(() => {
 const { width: containerWidth } = useElementSize(containerRef)
 
 const containerIsMobileSize = computed(() => {
-  return containerWidth.value < thresholds.value.lg
+  return containerWidth.value < thresholds.value.md
 })
 
 const hideMap = computed(() => {


### PR DESCRIPTION
### Description

Change the breakpoint for showing chart sidepanel as it currently makes it mobile on quite large screens.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
