### PR TITLE
Fix wrong map object being used for locations layer and selected coordinates layer

### DIFF
--- a/src/components/wms/LocationsLayer.vue
+++ b/src/components/wms/LocationsLayer.vue
@@ -43,7 +43,6 @@ import {
   MglSymbolLayer,
   MglGeoJsonSource,
   MglMarker,
-  useMap,
 } from '@indoorequal/vue-maplibre-gl'
 import { FeatureCollection, Geometry } from 'geojson'
 import { type Location } from '@deltares/fews-pi-requests'
@@ -59,6 +58,7 @@ import { addLocationIconsToMap } from '@/lib/location-icons'
 import { useDark } from '@vueuse/core'
 import { useUserSettingsStore } from '@/stores/userSettings'
 import { getLayerId, getSourceId } from '@/lib/map'
+import { useMap } from '@/services/useMap'
 
 const settings = useUserSettingsStore()
 const isDark = useDark()

--- a/src/components/wms/SelectedCoordinateLayer.vue
+++ b/src/components/wms/SelectedCoordinateLayer.vue
@@ -14,12 +14,9 @@
 <script setup lang="ts">
 import { LngLat, MapMouseEvent, MapTouchEvent, Popup } from 'maplibre-gl'
 import { computed, ref, watch } from 'vue'
-import {
-  MglGeoJsonSource,
-  MglCircleLayer,
-  useMap,
-} from '@indoorequal/vue-maplibre-gl'
+import { MglGeoJsonSource, MglCircleLayer } from '@indoorequal/vue-maplibre-gl'
 import { getLayerId, getSourceId } from '@/lib/map'
+import { useMap } from '@/services/useMap'
 
 interface Props {
   coordinate?: LngLat


### PR DESCRIPTION
### Description

Causes on dashboards the locations layer too not load with a second map.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
