### PR TITLE
Fix ssd stencil's .hydrated being overwritten by class v-bind

### DIFF
--- a/src/components/ssd/SsdComponent.vue
+++ b/src/components/ssd/SsdComponent.vue
@@ -5,7 +5,7 @@
       <schematic-status-display
         v-if="src"
         class="ssd w-100"
-        :class="{ 'h-100': props.allowZooming }"
+        :style="svgContainerStyle"
         :src="src"
         ref="svgContainer"
         @load="onLoad"
@@ -52,6 +52,9 @@ const height = ref(100)
 const margin = ref({ top: 0, left: 0 })
 const aspectRatio = ref(1)
 const isLoading = ref(true)
+const svgContainerStyle = computed(() => ({
+  height: props.allowZooming ? '100%' : undefined,
+}))
 
 const ssdSpacerStyle = computed(() => {
   return props.allowZooming


### PR DESCRIPTION
### Description
With v-bind:class="someReactiveVar" during certain updates (probably in the same tick) we get that the class that stencil adds (.hydrated) gets overwritten by the addition of a new class through v-bind:class. As such the ssd still has visibity:hidden.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
