### PR TITLE
Make locations searchable by name and ID

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:weboc": "vue-tsc && vite build --base=/weboc/",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:dev": "vitest",
     "lint": "npm run prettier",
     "prettier": "prettier . --check",
     "format": "prettier .  --write",

--- a/src/components/general/GlobalSearchComponent.vue
+++ b/src/components/general/GlobalSearchComponent.vue
@@ -40,7 +40,7 @@
             <v-list density="compact">
               <v-list-item
                 v-for="item in items"
-                key="id"
+                :key="item.raw.id"
                 @click="itemClick(item.raw)"
               >
                 {{ item.raw.name }}

--- a/src/components/general/GlobalSearchComponent.vue
+++ b/src/components/general/GlobalSearchComponent.vue
@@ -31,6 +31,7 @@
       </v-card-title>
       <v-card-text class="pa-0">
         <v-data-iterator
+          :custom-filter="isMatchingItem"
           :items="state.items"
           :items-per-page="200"
           :search="search"
@@ -59,9 +60,15 @@
 </template>
 
 <script lang="ts" setup>
-import { useGlobalSearchState } from '@/stores/globalSearch'
 import { ref } from 'vue'
 import { useDisplay } from 'vuetify'
+
+import { containsSubstring } from '@/lib/search'
+
+import {
+  type GlobalSearchItem,
+  useGlobalSearchState,
+} from '@/stores/globalSearch'
 
 const { mobile } = useDisplay()
 const state = useGlobalSearchState()
@@ -70,6 +77,18 @@ const search = ref('')
 function itemClick(item: any) {
   state.selectedItem = item
   state.active = false
+}
+
+function isMatchingItem(
+  id: string,
+  query: string,
+  item?: { raw: GlobalSearchItem },
+): boolean {
+  // A location matches if name and/or ID contains a substring that matches the
+  // query.
+  const isMatchingId = containsSubstring(id, query)
+  const isMatchingName = item ? containsSubstring(item.raw.name, query) : false
+  return isMatchingId || isMatchingName
 }
 </script>
 

--- a/src/components/general/GlobalSearchComponent.vue
+++ b/src/components/general/GlobalSearchComponent.vue
@@ -42,8 +42,9 @@
                 v-for="item in items"
                 key="id"
                 @click="itemClick(item.raw)"
-                >{{ item.raw.name }}</v-list-item
               >
+                {{ item.raw.name }}
+              </v-list-item>
             </v-list>
           </template>
           <template v-slot:footer="{ items }">

--- a/src/components/general/GlobalSearchComponent.vue
+++ b/src/components/general/GlobalSearchComponent.vue
@@ -44,7 +44,10 @@
                 :key="item.raw.id"
                 @click="itemClick(item.raw)"
               >
-                {{ item.raw.name }}
+                <HighlightMatch :value="item.raw.name" :query="search" />
+                <span class="id-match" v-if="showId(item.raw)">
+                  ID: <HighlightMatch :value="item.raw.id" :query="search" />
+                </span>
               </v-list-item>
             </v-list>
           </template>
@@ -70,13 +73,25 @@ import {
   useGlobalSearchState,
 } from '@/stores/globalSearch'
 
+import HighlightMatch from './HighlightMatch.vue'
+
 const { mobile } = useDisplay()
 const state = useGlobalSearchState()
-const search = ref('')
+const search = ref<string | undefined>()
 
 function itemClick(item: any) {
   state.selectedItem = item
   state.active = false
+}
+
+function showId(item: GlobalSearchItem): boolean {
+  const query = search.value
+  if (!query) return false
+
+  const isMatchingName = containsSubstring(item.name, query)
+  const isMatchingId = containsSubstring(item.id, query)
+  // Only show the ID if the search query matches the ID but not the name.
+  return isMatchingId && !isMatchingName
 }
 
 function isMatchingItem(
@@ -92,4 +107,10 @@ function isMatchingItem(
 }
 </script>
 
-<style scoped></style>
+<style scoped>
+.id-match {
+  margin-left: 20px;
+  font-size: 0.8em;
+  font-style: italic;
+}
+</style>

--- a/src/components/general/HighlightMatch.vue
+++ b/src/components/general/HighlightMatch.vue
@@ -1,0 +1,19 @@
+<template>
+  <span>{{ match.before }}</span>
+  <span class="font-weight-bold">{{ match.match }}</span>
+  <span>{{ match.after }}</span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+import { findMatchingParts } from '@/lib/search'
+
+interface Props {
+  value: string
+  query?: string
+}
+const props = defineProps<Props>()
+
+const match = computed(() => findMatchingParts(props.value, props.query ?? ''))
+</script>

--- a/src/components/wms/LocationsSearchControl.vue
+++ b/src/components/wms/LocationsSearchControl.vue
@@ -1,9 +1,9 @@
 <template>
   <ControlChip v-if="hasLocations" :class="{ 'pr-0': showLocations }">
     <v-btn @click="showLocations = !showLocations" density="compact" icon>
-      <v-icon>{{
-        showLocations ? 'mdi-map-marker' : 'mdi-map-marker-off'
-      }}</v-icon>
+      <v-icon>
+        {{ showLocations ? 'mdi-map-marker' : 'mdi-map-marker-off' }}
+      </v-icon>
     </v-btn>
 
     <v-btn
@@ -12,12 +12,13 @@
       class="locations-search text-capitalize"
       hide-details
       @click="showLocationsSearch"
-      >{{
+    >
+      {{
         selectedLocationIds
           ? selectedLocation?.locationName
           : 'Search locations'
-      }}</v-btn
-    >
+      }}
+    </v-btn>
   </ControlChip>
 </template>
 

--- a/src/lib/search/index.ts
+++ b/src/lib/search/index.ts
@@ -1,0 +1,1 @@
+export * from './substring'

--- a/src/lib/search/substring.test.ts
+++ b/src/lib/search/substring.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'vitest'
+
+import { containsSubstring, findMatchingParts } from './substring'
+
+describe('containsSubstring', () => {
+  test('with substring at the start', () => {
+    expect(containsSubstring('hello world', 'hello')).toEqual(true)
+  })
+
+  test('with substring at the end', () => {
+    expect(containsSubstring('hello world', 'world')).toEqual(true)
+  })
+
+  test('with substring in the middle', () => {
+    expect(containsSubstring('hello world', 'lo wo')).toEqual(true)
+  })
+
+  test('with substring not in the string', () => {
+    expect(containsSubstring('hello world', 'foo')).toEqual(false)
+  })
+
+  test('with empty string', () => {
+    expect(containsSubstring('', 'foo')).toEqual(false)
+  })
+
+  test('with empty substring', () => {
+    expect(containsSubstring('hello world', '')).toEqual(true)
+  })
+
+  test('with empty string and substring', () => {
+    expect(containsSubstring('', '')).toEqual(false)
+  })
+
+  test('with capital letters', () => {
+    expect(containsSubstring('hello world', 'HELLO')).toEqual(true)
+  })
+})
+
+describe('findMatchingParts', () => {
+  test('with substring at the start', () => {
+    expect(findMatchingParts('hello world', 'hello')).toEqual({
+      before: '',
+      match: 'hello',
+      after: ' world',
+    })
+  })
+
+  test('with substring at the end', () => {
+    expect(findMatchingParts('hello world', 'world')).toEqual({
+      before: 'hello ',
+      match: 'world',
+      after: '',
+    })
+  })
+
+  test('with substring in the middle', () => {
+    expect(findMatchingParts('hello world', 'lo wo')).toEqual({
+      before: 'hel',
+      match: 'lo wo',
+      after: 'rld',
+    })
+  })
+
+  test('with substring not in the string', () => {
+    expect(findMatchingParts('hello world', 'foo')).toEqual({
+      before: 'hello world',
+      match: '',
+      after: '',
+    })
+  })
+
+  test('with empty string', () => {
+    expect(findMatchingParts('', 'foo')).toEqual({
+      before: '',
+      match: '',
+      after: '',
+    })
+  })
+
+  test('with empty substring', () => {
+    expect(findMatchingParts('hello world', '')).toEqual({
+      before: 'hello world',
+      match: '',
+      after: '',
+    })
+  })
+
+  test('with empty string and substring', () => {
+    expect(findMatchingParts('', '')).toEqual({
+      before: '',
+      match: '',
+      after: '',
+    })
+  })
+
+  test('with capital letters', () => {
+    expect(findMatchingParts('Hello World', 'lo wo')).toEqual({
+      before: 'Hel',
+      match: 'lo Wo',
+      after: 'rld',
+    })
+  })
+})

--- a/src/lib/search/substring.ts
+++ b/src/lib/search/substring.ts
@@ -1,0 +1,34 @@
+import { SearchMatch } from './types'
+
+export function containsSubstring(haystack: string, needle: string): boolean {
+  if (haystack === '') return false
+  if (needle === '') return true
+  const haystackToSearch = haystack.toLowerCase()
+  const needleToSearch = needle.toLowerCase()
+  return haystackToSearch.includes(needleToSearch)
+}
+
+export function findMatchingParts(
+  haystack: string,
+  needle: string,
+): SearchMatch {
+  if (needle === '' || !containsSubstring(haystack, needle)) {
+    return {
+      before: haystack,
+      match: '',
+      after: '',
+    }
+  }
+  const haystackToSearch = haystack.toLowerCase()
+  const needleToSearch = needle.toLowerCase()
+  // We are certain that the needle is in the haystack, so this will never
+  // return -1.
+  const matchStartIndex = haystackToSearch.indexOf(needleToSearch)
+  const matchEndIndex = matchStartIndex + needle.length
+
+  return {
+    before: haystack.slice(0, matchStartIndex),
+    match: haystack.slice(matchStartIndex, matchEndIndex),
+    after: haystack.slice(matchEndIndex),
+  }
+}

--- a/src/lib/search/types.ts
+++ b/src/lib/search/types.ts
@@ -1,0 +1,5 @@
+export interface SearchMatch {
+  before: string
+  match: string
+  after: string
+}

--- a/src/stores/globalSearch.ts
+++ b/src/stores/globalSearch.ts
@@ -1,15 +1,15 @@
 import { defineStore } from 'pinia'
 
+export interface GlobalSearchItem {
+  id: string
+  name: string
+}
+
 interface GlobalSearchState {
   active: boolean
   type: 'locations' | 'parameters' | 'nodes'
   items: GlobalSearchItem[]
   selectedItem: GlobalSearchItem | null
-}
-
-interface GlobalSearchItem {
-  id: string
-  name: string
 }
 
 const useGlobalSearchState = defineStore('globalSearchState', {

--- a/src/stores/globalSearch.ts
+++ b/src/stores/globalSearch.ts
@@ -19,13 +19,6 @@ const useGlobalSearchState = defineStore('globalSearchState', {
     items: [],
     selectedItem: null,
   }),
-
-  actions: {},
-
-  getters: {
-    // activeAlerts: (state) => state.alerts.filter((alert) => alert.active),
-    // hasActiveAlerts: (state) => state.alerts.some((alert) => alert.active),
-  },
 })
 
 export { useGlobalSearchState }


### PR DESCRIPTION
# Description
Previously, when searching locations, only the ID was used to match results. This PR introduces a set of changes that make sure both name and ID are matched when searching. In addition, the matching part of the location name or ID is highlight, and the ID is shown when relevant (i.e. there is a match with the ID, but not with the name).

# Screenshots
![image](https://github.com/user-attachments/assets/d0ddc3c1-fdc3-418e-973f-e38ddf61666c)

# Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes
- [x] Update tests.
