### PR TITLE
Do not round off values in chart mouseover tooltips

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@deltares/fews-pi-requests": "^1.4.1",
         "@deltares/fews-ssd-requests": "^1.0.1",
         "@deltares/fews-ssd-webcomponent": "^1.0.2",
-        "@deltares/fews-web-oc-charts": "^3.1.0",
+        "@deltares/fews-web-oc-charts": "^4.0.0-alpha.0",
         "@deltares/fews-wms-requests": "^1.0.2",
         "@deltares/webgl-streamline-visualizer": "^1.0.1",
         "@indoorequal/vue-maplibre-gl": "^7.7.1",
@@ -527,18 +527,17 @@
       }
     },
     "node_modules/@deltares/fews-web-oc-charts": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@deltares/fews-web-oc-charts/-/fews-web-oc-charts-3.1.0.tgz",
-      "integrity": "sha512-dpP9sOBOGUSGIV9BXlJKvN4hRFJ3JEHS2C84TBZ073BKOP53Jdyp8cn3NsEHAl7WWs8dZlCEusvD6amy4oxmCA==",
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@deltares/fews-web-oc-charts/-/fews-web-oc-charts-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-f3pY8ZxYx8YBOg51vBMsiOw5muHeZiBj48T4TGRqh7S8Mhno6tg0tBeUMICI068VqUX4KFMOnVQGdxl3d4XBtw==",
       "license": "MIT",
       "dependencies": {
-        "csstype": "^3.0.0",
-        "d3": "^7.8.5",
+        "d3": "^7.9.0",
         "lodash-es": "^4.17.21",
-        "luxon": "^3.4.3"
+        "luxon": "^3.5.0"
       },
       "engines": {
-        "node": ">=0.14"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@deltares/fews-web-oc-utils": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@deltares/fews-pi-requests": "^1.4.1",
     "@deltares/fews-ssd-requests": "^1.0.1",
     "@deltares/fews-ssd-webcomponent": "^1.0.2",
-    "@deltares/fews-web-oc-charts": "^3.1.0",
+    "@deltares/fews-web-oc-charts": "^4.0.0-alpha.0",
     "@deltares/fews-wms-requests": "^1.0.2",
     "@deltares/webgl-streamline-visualizer": "^1.0.1",
     "@indoorequal/vue-maplibre-gl": "^7.7.1",

--- a/src/components/charts/ElevationChart.vue
+++ b/src/components/charts/ElevationChart.vue
@@ -147,7 +147,11 @@ onMounted(() => {
       chartHeight,
       axisOptions,
     )
-    const mouseOver = new VerticalMouseOver()
+    // Use custom number formatter that just converts the value to a string;
+    // appropriate rounding has already been done by the backend.
+    const mouseOver = new VerticalMouseOver(undefined, (value: number) =>
+      value.toString(),
+    )
     const zoom = props.zoomHandler ?? new ZoomHandler(WheelMode.NONE)
 
     axis.accept(zoom)

--- a/src/components/charts/TimeSeriesChart.vue
+++ b/src/components/charts/TimeSeriesChart.vue
@@ -161,7 +161,11 @@ onMounted(() => {
       null,
       merge(axisOptions, { x: props.config?.xAxis, y: props.config?.yAxis }),
     )
-    const mouseOver = new MouseOver()
+    // Use custom number formatter that just converts the value to a string;
+    // appropriate rounding has already been done by the backend.
+    const mouseOver = new MouseOver(undefined, (value: number) =>
+      value.toString(),
+    )
     const zoom = props.zoomHandler ?? new ZoomHandler(WheelMode.NONE)
     axisTime.value = new CurrentTime({
       x: {


### PR DESCRIPTION
# Description
Previously, values in chart mouseover tooltips were rounded off based on the extent of the axes. In this PR, we make sure that this round-off does not happen, and we use values as they come (appropriately rounded) from the backend.

# Screenshots
Before:
![image](https://github.com/user-attachments/assets/9d0342cf-4ae6-4c7e-b312-624ccf83ab7c)

After:
![image](https://github.com/user-attachments/assets/89d0f997-d66e-4da3-98d2-c9b88c8135ec)

# Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes
