### PR TITLE
Fix animated streamlines layer with zero-valued elevation bounds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@deltares/fews-ssd-webcomponent": "^1.0.2",
         "@deltares/fews-web-oc-charts": "^3.1.0",
         "@deltares/fews-wms-requests": "^1.0.2",
-        "@deltares/webgl-streamline-visualizer": "^1.0.1",
+        "@deltares/webgl-streamline-visualizer": "^1.0.2",
         "@indoorequal/vue-maplibre-gl": "^7.7.1",
         "@jsonforms/core": "^3.4.1",
         "@jsonforms/vue": "^3.4.1",
@@ -563,9 +563,9 @@
       }
     },
     "node_modules/@deltares/webgl-streamline-visualizer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@deltares/webgl-streamline-visualizer/-/webgl-streamline-visualizer-1.0.1.tgz",
-      "integrity": "sha512-R788dhGC3UHZwk5OuHcLy+W19o9l5SVEs4FGNBwiiZGnrzOygEWPUbhy9jrKhP0y5HkW+lSF+CjvtktEl82paA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@deltares/webgl-streamline-visualizer/-/webgl-streamline-visualizer-1.0.2.tgz",
+      "integrity": "sha512-lV6tsbHgcPaJNKXlJdBBNAbszSphTkUsi30zABw19oh3X6wSfwOBECwE7bN1IzBREs4fbVhEXQiEUe/05CVX/A==",
       "license": "MIT",
       "dependencies": {
         "geotiff": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@deltares/fews-ssd-webcomponent": "^1.0.2",
     "@deltares/fews-web-oc-charts": "^3.1.0",
     "@deltares/fews-wms-requests": "^1.0.2",
-    "@deltares/webgl-streamline-visualizer": "^1.0.1",
+    "@deltares/webgl-streamline-visualizer": "^1.0.2",
     "@indoorequal/vue-maplibre-gl": "^7.7.1",
     "@jsonforms/core": "^3.4.1",
     "@jsonforms/vue": "^3.4.1",


### PR DESCRIPTION
# Description
Previously, attempting to use the animated streamlines layer would fail with elevation bounds where the lower or upper bound was zero, the new version of `@deltares/webgl-streamline-visualizer` fixes this.

# Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes.