### PR TITLE
Change dashboard borders

### DIFF
--- a/src/components/general/DashboardDisplay.vue
+++ b/src/components/general/DashboardDisplay.vue
@@ -1,12 +1,14 @@
 <template>
-  <div v-if="hasLoadedCss" class="display-container pa-2 ga-2">
-    <div class="dashboard-container flex-1-1 ga-2">
+  <div v-if="hasLoadedCss" class="display-container">
+    <div class="dashboard-container flex-1-1">
       <template v-for="group in groups">
         <template v-for="element in group.elements">
           <v-card
             :style="{ gridArea: element.gridTemplateArea }"
             class="d-flex flex-column"
             density="compact"
+            flat
+            :rounded="false"
           >
             <!-- TODO: For now we only support one item per element -->
             <!--       to prevent UI clutter. -->
@@ -20,7 +22,12 @@
         </template>
       </template>
     </div>
-    <v-card v-if="sliderEnabled" class="flex-0-0 overflow-visible">
+    <v-card
+      v-if="sliderEnabled"
+      class="flex-0-0 overflow-visible"
+      flat
+      :rounded="false"
+    >
       <DateTimeSlider
         v-model:selectedDate="selectedDate"
         :dates="combinedDates"

--- a/src/components/general/DashboardDisplay.vue
+++ b/src/components/general/DashboardDisplay.vue
@@ -1,6 +1,6 @@
 <template>
-  <div v-if="hasLoadedCss" class="display-container">
-    <div class="dashboard-container flex-1-1">
+  <div v-if="hasLoadedCss" class="display-container pa-1 ga-1">
+    <div class="dashboard-container flex-1-1 ga-1">
       <template v-for="group in groups">
         <template v-for="element in group.elements">
           <v-card
@@ -122,11 +122,6 @@ watch(
 
 .display-container {
   display: flex;
-  background-color: color-mix(
-    in srgb,
-    rgb(var(--v-theme-on-surface-variant)) 90%,
-    rgb(var(--v-theme-on-surface))
-  );
   flex-direction: column;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
### Description

Removes the default dashboard border gap background color by making the cards flat and unrounded as well as reducing the padding / gap from level 2 to 1.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
