### PR TITLE
Tomcat security login as alternative to OIDC

### DIFF
--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -47,6 +47,8 @@ A dist folder is created that can be used to deploy the web oc to different plat
 
 See [Deployments](deployments/) for more information on how to run Web OC stand-alone and/or from a webserver.
 
-## Authentication and Authorization with Open ID Connect
+## Authentication and Authorization
 
-See [OIDC](oidc/) for more information.
+Open ID Connect: See [OIDC](oidc/) 
+
+Tomcat Security: See [Tomcat](tomcat-security/)

--- a/docs/public/README.md
+++ b/docs/public/README.md
@@ -50,5 +50,3 @@ See [Deployments](deployments/) for more information on how to run Web OC stand-
 ## Authentication and Authorization
 
 Open ID Connect: See [OIDC](oidc/) 
-
-Tomcat Security: See [Tomcat](tomcat-security/)

--- a/docs/public/tomcat-login/README.md
+++ b/docs/public/tomcat-login/README.md
@@ -1,0 +1,43 @@
+# The Delft-FEWS Web OC Tomcat Login
+
+To support login with a username and password using tomcat configuration, both the weboc and Fews Web Services have to be deployed on the same tomcat server.
+
+
+## conf/server.xml
+
+<Valve className="org.apache.catalina.authenticator.SingleSignOn" />
+
+This will allow to share the login session between the weboc and the fews web services.
+
+## conf/web.xml
+
+We will protect all resources with a security constraint. 
+
+<security-constraint>
+             <display-name>SecurityConstraint</display-name>
+            <web-resource-collection>
+                  <web-resource-name>WebOC</web-resource-name>
+                 <url-pattern>/*</url-pattern>
+         </web-resource-collection>
+            <auth-constraint>
+                  <role-name>WS_VIEWER</role-name>
+                  <role-name>WS_EDITOR</role-name>
+            </auth-constraint>
+       </security-constraint>
+      <login-config>
+            <auth-method>FORM</auth-method>
+         <form-login-config>
+                  <form-login-page>/login.html</form-login-page>
+                 <form-error-page>/loginfailed.html</form-error-page>
+          </form-login-config>
+     </login-config>
+     <security-role>
+        <role-name>WS_VIEWER</role-name>
+    </security-role>
+     <security-role>
+        <role-name>WS_EDITOR</role-name>
+    </security-role>
+
+
+The loing.html and loginfailed.html pages have to be created in the webapps/ROOT folder.
+The login page will be login.html and the error page will be loginfailed.html.

--- a/docs/public/tomcat-login/README.md
+++ b/docs/public/tomcat-login/README.md
@@ -17,7 +17,7 @@ We will protect all resources with a security constraint.
              <display-name>SecurityConstraint</display-name>
             <web-resource-collection>
                   <web-resource-name>WebOC</web-resource-name>
-                 <url-pattern>/*</url-pattern>
+                 <url-pattern>*</url-pattern>
          </web-resource-collection>
             <auth-constraint>
                   <role-name>WS_VIEWER</role-name>
@@ -41,3 +41,36 @@ We will protect all resources with a security constraint.
 
 The loing.html and loginfailed.html pages have to be created in the webapps/ROOT folder.
 The login page will be login.html and the error page will be loginfailed.html.
+
+## ENV variable
+
+FEWS_WS_AUTHENTICATION_TYPE=AuthenticationJEE
+
+## conf/tomcat-users.xml
+
+<tomcat-users xmlns="http://tomcat.apache.org/xml"
+xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:schemaLocation="http://tomcat.apache.org/xml tomcat-users.xsd"
+version="1.0">
+
+  <role rolename="WS_VIEWER"/>
+  <role rolename="WS_EDITOR"/>
+  <user username="viewer" password="viewer" roles="WS_VIEWER"/>
+  <user username="editor" password="editor" roles="WS_VIEWER,WS_EDITOR"/>
+</tomcat-users>
+
+
+# UserGroups.xml
+
+Map tomcat roles to systemUserGroups in the UserGroups.xml
+
+<?xml version="1.0" encoding="UTF-8"?>
+<userGroups xmlns="http://www.wldelft.nl/fews" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.wldelft.nl/fews http://fews.wldelft.nl/schemas/version1.0/userGroups.xsd">
+	<userGroup id="WS_VIEWER">
+		<systemUserGroup id="WS_VIEWER"/>
+	</userGroup>
+	<userGroup id="WS_EDITOR">
+		<systemUserGroup id="WS_EDITOR"/>
+	</userGroup>
+</userGroups>
+

--- a/docs/public/tomcat-security/README.md
+++ b/docs/public/tomcat-security/README.md
@@ -1,7 +1,7 @@
 # The Delft-FEWS Web OC Tomcat Login
 
 To support login with a username and password using tomcat configuration, both the weboc and the Delft-FEWS Web Services have to be deployed on the same tomcat server.
-The weboc will have to be deployed in a Tomcat ROOT.war file: [See Tomcat Deployment](../deployments/tomcat/README.md).
+The weboc will have to be deployed in a Tomcat ROOT.war file: [See Tomcat Deployment](../deployments/README.md).
 Also Single Sign On has to be enabled in the tomcat server.xml. This wil allow sharing a session cookie between the weboc and the fews web services.
 
 ## conf/server.xml

--- a/docs/public/tomcat-security/README.md
+++ b/docs/public/tomcat-security/README.md
@@ -105,6 +105,8 @@ FEWS_WS_AUTHENTICATION_TYPE=AuthenticationTomcat
 Tomcat has some options for user management. See:
 https://tomcat.apache.org/tomcat-10.0-doc/realm-howto.html#Standard_Realm_Implementations
 
+Most common are using an LDAP connection or managing the users in a tomcat-users.xml file.
+
 The following shows how to use the tomcat UserDatabseReleam with a SecretKeyCredentialHandler. 
 This handler uses the PBKDF2WithHmacSHA512 algorithm to hash the password. The number of iterations, salt length and key length can be set as well.
 

--- a/docs/public/tomcat-security/README.md
+++ b/docs/public/tomcat-security/README.md
@@ -19,41 +19,42 @@ In the following configuration the WS_VIEWER role only has access to GET request
 The list of roles can be extended with more application specific roles that can be used as systemUserGroup in the UserGroups.xml. 
 
 ``` xml
-		<security-constraint>
-             <display-name>SecurityConstraint Web OC Viewer</display-name>
-            <web-resource-collection>
-                  <web-resource-name>WebOC Viewer</web-resource-name>
-                 <url-pattern>/*</url-pattern>
-                 <http-method>GET</http-method>
-         </web-resource-collection>
+
+	    <security-constraint>
+            <display-name>SecurityConstraint Web OC Viewer</display-name>
+                <web-resource-collection>
+                    <web-resource-name>WebOC Viewer</web-resource-name>
+                    <url-pattern>/*</url-pattern>
+                    <http-method>GET</http-method>
+            </web-resource-collection>
             <auth-constraint>
                   <role-name>WS_VIEWER</role-name>
                   <role-name>WS_EDITOR</role-name>
             </auth-constraint>
-       </security-constraint>
-		<security-constraint>
-             <display-name>SecurityConstraint Editor</display-name>
+        </security-constraint>
+	    <security-constraint>
+            <display-name>SecurityConstraint Editor</display-name>
             <web-resource-collection>
                   <web-resource-name>WebOC Editor</web-resource-name>
                  <url-pattern>/*</url-pattern>
-         </web-resource-collection>
+            </web-resource-collection>
             <auth-constraint>
                   <role-name>WS_EDITOR</role-name>
             </auth-constraint>
-       </security-constraint>
-      <login-config>
+        </security-constraint>
+        <login-config>
             <auth-method>FORM</auth-method>
-         <form-login-config>
+            <form-login-config>
                   <form-login-page>/login.html</form-login-page>
                  <form-error-page>/loginfailed.html</form-error-page>
-          </form-login-config>
-     </login-config>
-     <security-role>
-        <role-name>WS_VIEWER</role-name>
-    </security-role>
-     <security-role>
-        <role-name>WS_EDITOR</role-name>
-    </security-role>
+            </form-login-config>
+        </login-config>
+        <security-role>
+            <role-name>WS_VIEWER</role-name>
+        </security-role>
+        <security-role>
+            <role-name>WS_EDITOR</role-name>
+        </security-role>
 ```
 
 ## webapps/ROOT

--- a/docs/public/tomcat-security/README.md
+++ b/docs/public/tomcat-security/README.md
@@ -12,17 +12,32 @@ Also Single Sign On has to be enabled in the tomcat server.xml. This wil allow s
 
 ## conf/web.xml
 
-All URLs will be protected by the security constraint. The login page will be login.html and the error page will be loginfailed.html. 
+All URLs will be protected by the security constraint. 
+The login page will be login.html and the error page will be loginfailed.html.
+To access any resources a user needs to have the rol WS_VIEWER or WS_EDITOR.
+In the following configuration the WS_VIEWER role only has access to GET requests.
+The list of roles can be extended with more application specific roles that can be used as systemUserGroup in the UserGroups.xml. 
 
 ``` xml
-        <security-constraint>
-             <display-name>SecurityConstraint</display-name>
+		<security-constraint>
+             <display-name>SecurityConstraint Web OC Viewer</display-name>
             <web-resource-collection>
-                  <web-resource-name>WebOC</web-resource-name>
-                 <url-pattern>*</url-pattern>
+                  <web-resource-name>WebOC Viewer</web-resource-name>
+                 <url-pattern>/*</url-pattern>
+                 <http-method>GET</http-method>
          </web-resource-collection>
             <auth-constraint>
                   <role-name>WS_VIEWER</role-name>
+                  <role-name>WS_EDITOR</role-name>
+            </auth-constraint>
+       </security-constraint>
+		<security-constraint>
+             <display-name>SecurityConstraint Editor</display-name>
+            <web-resource-collection>
+                  <web-resource-name>WebOC Editor</web-resource-name>
+                 <url-pattern>/*</url-pattern>
+         </web-resource-collection>
+            <auth-constraint>
                   <role-name>WS_EDITOR</role-name>
             </auth-constraint>
        </security-constraint>

--- a/docs/public/tomcat-security/README.md
+++ b/docs/public/tomcat-security/README.md
@@ -1,7 +1,7 @@
 # The Delft-FEWS Web OC Tomcat Login
 
-To support login with a username and password using tomcat configuration,
-both the weboc and Fews Web Services have to be deployed on the same tomcat server.
+To support login with a username and password using tomcat configuration, both the weboc and the Delft-FEWS Web Services have to be deployed on the same tomcat server.
+The weboc will have to be deployed in a Tomcat ROOT.war file: [See Tomcat Deployment](../deployments/tomcat/README.md).
 Also Single Sign On has to be enabled in the tomcat server.xml. This wil allow sharing a session cookie between the weboc and the fews web services.
 
 ## conf/server.xml
@@ -42,7 +42,7 @@ All URLs will be protected by the security constraint. The login page will be lo
 ```
 
 ## webapps/ROOT
-The login.html and loginfailed.html pages have to be added to the webapps/ROOT folder.
+The login.html and loginfailed.html pages have to be added to the ROOT.war file.
 The login page will be login.html and the error page will be loginfailed.html.
 
 ### login.html


### PR DESCRIPTION
## Pull Request Template

### Description

Documentation on how tomcat security can be used as an alternative to OIDC.
