### PR TITLE
Add missing topology ssdtimeseriesdisplay to the router

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -197,6 +197,15 @@ export const dynamicRoutes: Readonly<RouteRecordRaw[]> = [
         component: SchematicStatusDisplay,
         props: true,
         meta: { sidebar: true },
+        children: [
+          {
+            path: 'object/:objectId',
+            name: 'TopologySSDTimeSeriesDisplay',
+            component: SSDTimeSeriesDisplay,
+            props: true,
+            meta: { sidebar: true },
+          },
+        ],
       },
       {
         path: 'systemmonitor',


### PR DESCRIPTION
### Description

Adds missing topology ssdtimeseriesdisplay to the router fixing click leading to empty screen.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
