### PR TITLE
Fix wms sometimes not creating a source

### DIFF
--- a/src/components/wms/AnimatedRasterLayer.vue
+++ b/src/components/wms/AnimatedRasterLayer.vue
@@ -178,7 +178,7 @@ function getImageSourceOptions(): any {
 }
 
 function createSource() {
-  if (!map?.isStyleLoaded()) return
+  if (!map) return
 
   const rasterSource: any = {
     type: 'image',

--- a/src/components/wms/AnimatedStreamlineRasterLayer.vue
+++ b/src/components/wms/AnimatedStreamlineRasterLayer.vue
@@ -122,7 +122,7 @@ addUpdateWatcher(
 )
 
 function addLayer(): void {
-  if (!map?.isStyleLoaded()) return
+  if (!map) return
   if (!props.layerOptions || !props.streamlineOptions) return
   const options = mergeOptions(props.layerOptions, props.streamlineOptions)
 


### PR DESCRIPTION
### Description

This happened when the locations layer was showing and a location is selected and you are trying to go to a different topologynode. In that case the entire wms layer would not be showing. This happened because the styleloaded check considers all layers of the map.

To test:
Select a location with location layer showing and click on another node that includes that location.
Before the wms layer would not show.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
