### PR TITLE
Move available workflows fetch to store initialization

### DIFF
--- a/src/components/download/TimeSeriesFileDownloadComponent.vue
+++ b/src/components/download/TimeSeriesFileDownloadComponent.vue
@@ -207,7 +207,7 @@ function determineViewPeriod(): string {
   return viewPeriod
 }
 
-const downloadFile = async (downloadFormat: string) => {
+const downloadFile = (downloadFormat: string) => {
   let viewPeriod = determineViewPeriod()
   if (props.filter) {
     if (isDataDownloadFilter(props.filter)) {
@@ -219,7 +219,7 @@ const downloadFile = async (downloadFormat: string) => {
         url.href,
         fileName.value,
         downloadFormat,
-        await authenticationManager.getAccessToken(),
+        authenticationManager.getAccessToken(),
       )
     }
   }
@@ -233,7 +233,7 @@ const downloadFile = async (downloadFormat: string) => {
         url.href,
         fileName.value,
         downloadFormat,
-        await authenticationManager.getAccessToken(),
+        authenticationManager.getAccessToken(),
       )
     }
     if (isTimeSeriesGridActionsFilter(props.filter)) {
@@ -246,7 +246,7 @@ const downloadFile = async (downloadFormat: string) => {
         url.href,
         fileName.value,
         downloadFormat,
-        await authenticationManager.getAccessToken(),
+        authenticationManager.getAccessToken(),
       )
     }
   }
@@ -266,7 +266,7 @@ const downloadFile = async (downloadFormat: string) => {
     url.href,
     fileName.value,
     downloadFormat,
-    await authenticationManager.getAccessToken(),
+    authenticationManager.getAccessToken(),
   )
 }
 </script>

--- a/src/components/map/MapComponent.vue
+++ b/src/components/map/MapComponent.vue
@@ -35,7 +35,7 @@ import type {
   LngLatBounds,
   Map,
 } from 'maplibre-gl'
-import { computed, onMounted, ref, useTemplateRef, watch } from 'vue'
+import { computed, useTemplateRef, watch } from 'vue'
 import { transformStyle } from '@/lib/map'
 import { getResourcesStaticUrl } from '@/lib/fews-config'
 import { useBaseMapsStore } from '@/stores/baseMaps'
@@ -74,13 +74,6 @@ watch(selectedStyle, (newBaseStyle) => {
   map?.setStyle(newBaseStyle, { transformStyle })
 })
 
-const authorizationHeaders = ref<Headers>()
-
-onMounted(async () => {
-  authorizationHeaders.value =
-    await authenticationManager.getAuthorizationHeaders()
-})
-
 function transformRequest(
   url: string,
   resourceType?: ResourceType,
@@ -90,10 +83,10 @@ function transformRequest(
       url,
     }
   if (resourceType === 'Image' && url.indexOf('GetMap') > -1) {
-    const headers = authorizationHeaders.value
+    const requestAuthHeaders = authenticationManager.getAuthorizationHeaders()
     return {
       url,
-      headers,
+      headers: requestAuthHeaders,
     }
   }
   return {

--- a/src/lib/fews-properties/fewsProperties.ts
+++ b/src/lib/fews-properties/fewsProperties.ts
@@ -8,7 +8,8 @@ import { authenticationManager } from '@/services/authentication/AuthenticationM
 
 export async function loadTimeSeriesFlags(): Promise<TimeSeriesFlag[]> {
   const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
-  const transformRequestFn = authenticationManager.transformRequestAuth
+  const transformRequestFn = (request: Request) =>
+    Promise.resolve(authenticationManager.transformRequestAuth(request))
   const webServiceProvider = new PiWebserviceProvider(baseUrl, {
     transformRequestFn,
   })
@@ -21,7 +22,8 @@ export async function loadTimeSeriesFlagSources(): Promise<
   TimeSeriesFlagSource[]
 > {
   const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
-  const transformRequestFn = authenticationManager.transformRequestAuth
+  const transformRequestFn = (request: Request) =>
+    Promise.resolve(authenticationManager.transformRequestAuth(request))
   const webServiceProvider = new PiWebserviceProvider(baseUrl, {
     transformRequestFn,
   })

--- a/src/lib/requests/transformRequest.ts
+++ b/src/lib/requests/transformRequest.ts
@@ -1,8 +1,11 @@
 import { authenticationManager } from '@/services/authentication/AuthenticationManager.ts'
 
 export function createTransformRequestFn(controller?: AbortController) {
-  return (request: Request) =>
-    authenticationManager.transformRequestAuth(request, controller?.signal)
+  return async (request: Request): Promise<Request> => {
+    return Promise.resolve(
+      authenticationManager.transformRequestAuth(request, controller?.signal),
+    )
+  }
 }
 
 export function mergeHeaders(headers1: Headers, headers2: Headers): Headers {

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,6 @@ import { createPinia } from 'pinia'
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 import { defineCustomElements } from '@deltares/fews-ssd-webcomponent/loader'
 import 'maplibre-gl/dist/maplibre-gl.css'
-import { useAvailableWorkflowsStore } from './stores/availableWorkflows'
 
 const pinia = createPinia()
 pinia.use(piniaPluginPersistedstate)
@@ -31,10 +30,4 @@ fetch(`${import.meta.env.BASE_URL}app-config.json`)
     }
     app.use(router)
     app.mount('#app')
-
-    // Fetch metadata for all available workflows.
-    const availableWorkflowsStore = useAvailableWorkflowsStore()
-    availableWorkflowsStore
-      .fetch()
-      .catch(() => console.error('Failed to fetch available workflows.'))
   })

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,10 +24,10 @@ app.use(vuetify)
 
 fetch(`${import.meta.env.BASE_URL}app-config.json`)
   .then((res) => res.json())
-  .then((data) => {
+  .then(async (data) => {
     configManager.update(data)
     if (configManager.authenticationIsEnabled) {
-      authenticationManager.init(configManager.getUserManagerSettings())
+      await authenticationManager.init(configManager.getUserManagerSettings())
     }
     app.use(router)
     app.mount('#app')

--- a/src/stores/availableWorkflows.ts
+++ b/src/stores/availableWorkflows.ts
@@ -50,6 +50,9 @@ export const useAvailableWorkflowsStore = defineStore(
       preferredWorkflowIds.value = []
     }
 
+    // Fetch metadata for all available workflows.
+    fetch().catch(() => console.error('Failed to fetch available workflows.'))
+
     return {
       workflows,
       preferredWorkflowIds,


### PR DESCRIPTION
### Description
When going to a auth redirect the workflows where already being requested. This caused the user to be null and the fetch to not go through. We now only get the workflows the moment the store is initialized. This also ensures we don't fetch if it is not necessary.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
