### PR TITLE
Fix downloads of csv not working with some baseurls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "fews-weboc",
       "version": "1.2.0-rc.0",
       "dependencies": {
-        "@deltares/fews-pi-requests": "^1.10.0",
+        "@deltares/fews-pi-requests": "^1.11.0",
         "@deltares/fews-ssd-requests": "^1.0.1",
         "@deltares/fews-ssd-webcomponent": "^1.0.2",
         "@deltares/fews-web-oc-charts": "^4.0.0-alpha.0",
@@ -494,9 +494,9 @@
       }
     },
     "node_modules/@deltares/fews-pi-requests": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@deltares/fews-pi-requests/-/fews-pi-requests-1.10.0.tgz",
-      "integrity": "sha512-yZYVYjWnzOTaCxn89B/V9W0uNdZydPsiUfDmL8D1mdRtihyU7dpAI1SxxlOek3boEsLJbVvoyKWfmMHE1W2CTA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@deltares/fews-pi-requests/-/fews-pi-requests-1.11.0.tgz",
+      "integrity": "sha512-nOARhyvNtg9wegi6xo83HTQ4iORbALVODulUcGbGg/zVYaRzas7pEJlJj+eN7SZ2wNrZ5BQgHG9d3pxiRUMsHw==",
       "license": "MIT",
       "dependencies": {
         "@deltares/fews-web-oc-utils": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test-ct": "playwright test -c playwright-ct.config.ts"
   },
   "dependencies": {
-    "@deltares/fews-pi-requests": "^1.10.0",
+    "@deltares/fews-pi-requests": "^1.11.0",
     "@deltares/fews-ssd-requests": "^1.0.1",
     "@deltares/fews-ssd-webcomponent": "^1.0.2",
     "@deltares/fews-web-oc-charts": "^4.0.0-alpha.0",

--- a/src/components/download/TimeSeriesFileDownloadComponent.vue
+++ b/src/components/download/TimeSeriesFileDownloadComponent.vue
@@ -220,12 +220,11 @@ const downloadFile = (downloadFormat: DocumentFormat) => {
 
   if (props.filter) {
     if (isDataDownloadFilter(props.filter)) {
-      const queryParameters = filterToParams(props.filter).replace('?', '&')
-      const timeSeriesUrl = piProvider.timeSeriesUrl({
+      const url = piProvider.timeSeriesUrl({
+        ...props.filter,
         documentFormat: downloadFormat,
         ...viewPeriod,
       })
-      const url = new URL(`${timeSeriesUrl.href}${queryParameters}`)
       return downloadFileAttachment(
         url.href,
         fileName.value,
@@ -236,7 +235,7 @@ const downloadFile = (downloadFormat: DocumentFormat) => {
   }
   if (props.filter) {
     if (isFilterActionsFilter(props.filter)) {
-      const url = piProvider.filterActionsUrl({
+      const url = piProvider.timeSeriesFilterActionsUrl({
         ...props.filter,
         documentFormat: downloadFormat,
         ...viewPeriod,

--- a/src/components/download/TimeSeriesFileDownloadComponent.vue
+++ b/src/components/download/TimeSeriesFileDownloadComponent.vue
@@ -59,7 +59,6 @@ import { configManager } from '@/services/application-config'
 import { DisplayConfig } from '@/lib/display/DisplayConfig.ts'
 import type { UseDisplayConfigOptions } from '@/services/useDisplayConfig'
 import { authenticationManager } from '@/services/authentication/AuthenticationManager.ts'
-import { filterToParams } from '@deltares/fews-wms-requests'
 import { downloadFileAttachment } from '@/lib/download/downloadFiles.ts'
 import {
   computed,

--- a/src/components/download/TimeSeriesFileDownloadComponent.vue
+++ b/src/components/download/TimeSeriesFileDownloadComponent.vue
@@ -269,11 +269,9 @@ const downloadFile = (downloadFormat: DocumentFormat) => {
     timeSeriesDisplayIndex: props.config?.index ?? 0,
     convertDatum: props.options.convertDatum,
     useDisplayUnits: props.options.useDisplayUnits,
+    ...viewPeriod,
   }
-  const queryParameters = filterToParams(timeSeriesFilter)
-  const url = new URL(
-    `${baseUrl}rest/fewspiservice/v1/timeseries/topology/actions${queryParameters}${viewPeriod}`,
-  )
+  const url = piProvider.timeSeriesTopologyActionsUrl(timeSeriesFilter)
   return downloadFileAttachment(
     url.href,
     fileName.value,

--- a/src/services/useTopologyThresholds/index.ts
+++ b/src/services/useTopologyThresholds/index.ts
@@ -32,7 +32,7 @@ export function useTopologyThresholds(
       const provider = new PiWebserviceProvider(baseUrl, {
         transformRequestFn: createTransformRequestFn(),
       })
-      const response = await provider.getTopologyThresholds()
+      const response = await provider.getTopologyThresholds({})
       thresholds.value = response.topologyNodes
     } catch {
       error.value = 'Error loading topology thresholds'


### PR DESCRIPTION
### Description

Didn't work when baseUrl did not end with /.
Fix it by using piprovider to get data download urls.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
