### PR TITLE
Do not hardcode queryparameters in the time series edit POST

### DIFF
--- a/src/components/timeseries/TimeSeriesComponent.vue
+++ b/src/components/timeseries/TimeSeriesComponent.vue
@@ -210,7 +210,14 @@ function isLoading(subplot: ChartConfig, loadingSeriesIds: string[]) {
 }
 
 async function onDataChange(newData: Record<string, TimeSeriesEvent[]>) {
-  await postTimeSeriesEdit(baseUrl, props.config.requests, newData)
+  const seriesHeader = series.value[props.config.requests[0].key].header
+  await postTimeSeriesEdit(
+    baseUrl,
+    props.config.requests,
+    newData,
+    seriesHeader.version ?? '',
+    seriesHeader.timeZone ?? '',
+  )
   lastUpdated.value = new Date()
 }
 

--- a/src/lib/timeseries/types/SeriesHeader.ts
+++ b/src/lib/timeseries/types/SeriesHeader.ts
@@ -7,4 +7,6 @@ export interface SeriesHeader {
   source?: string
   unit?: string
   timeStep?: TimeStep
+  version?: string
+  timeZone?: string
 }


### PR DESCRIPTION
### Description

The 'editUrl' is used directly to POST the edited time series values. The version (required by the TimeSeriesResponseSchema) is taken from the original time series request, instead of performing an additional (only header) timeseries request to get these when editing data.

Currently, this is done by simply adding the version and the timezone through function parameters. It would be cleaner to change the type of the edited data from `Record<string, TimeSeriesEvent[]>`, to `Record<string, TimeSeriesResponse>`, as the time series edit POST expects the body to be of type `TimeSeriesResponse`. Created #1267 to address this.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [ ] Update documentation.
- [ ] Update tests.
