### PR TITLE
Run release workflow on published not on created

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Upload assets on new release
 on:
   release:
     types:
-      - created
+      - published
 
 jobs:
   build:


### PR DESCRIPTION
### Description
This is to prevent the workflow from not running when first creating a draft release.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
