### PR TITLE
Use vue-maplibre for animated raster layer

### DIFF
--- a/src/components/spatialdisplay/SpatialDisplayComponent.vue
+++ b/src/components/spatialdisplay/SpatialDisplayComponent.vue
@@ -4,6 +4,7 @@
       v-if="layerKind === LayerKind.Static && showLayer && layerOptions"
       v-model:isLoading="isLoading"
       :layer="layerOptions"
+      :key="layerOptions?.name"
       @doubleclick="onCoordinateClick"
     />
     <AnimatedStreamlineRasterLayer

--- a/src/components/wms/AnimatedRasterLayer.vue
+++ b/src/components/wms/AnimatedRasterLayer.vue
@@ -75,7 +75,6 @@ onUnmounted(() => {
   removeHooksFromMapObject()
 })
 
-watch(() => props.layer.time, onMapMove)
 function onMapMove(): void {
   updateSource()
 }
@@ -189,6 +188,7 @@ function getImageSourceOptions() {
   }
 }
 
+watch(() => props.layer, updateSource)
 function updateSource() {
   const source = map?.getSource(sourceId.value) as ImageSource
   if (!source) return


### PR DESCRIPTION
### Description
This fixes the creation of sources when the map is still loading and removes some complexity from animatedrasterlayer.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
