### PR TITLE
Show child locations only when zooming in

### DIFF
--- a/src/components/map/MapComponent.vue
+++ b/src/components/map/MapComponent.vue
@@ -13,6 +13,7 @@
     :touchPitch="false"
     :attributionControl="false"
     :bounds="bounds"
+    :fadeDuration="0"
   >
     <mgl-attribution-control position="top-right" :compact="true" />
     <mgl-scale-control position="bottom-right" />

--- a/src/components/wms/locations/LocationsCircleLayer.vue
+++ b/src/components/wms/locations/LocationsCircleLayer.vue
@@ -1,0 +1,22 @@
+<template>
+  <mgl-circle-layer :layerId="layerId" :paint="paint" :filter="filter" />
+</template>
+
+<script setup lang="ts">
+import { MglCircleLayer } from '@indoorequal/vue-maplibre-gl'
+
+interface Props {
+  layerId: string
+}
+
+defineProps<Props>()
+
+const paint = {
+  'circle-radius': 5,
+  'circle-color': '#dfdfdf',
+  'circle-stroke-color': 'black',
+  'circle-stroke-width': 1.5,
+}
+
+const filter = ['all', ['!has', 'iconName'], ['==', '$type', 'Point']]
+</script>

--- a/src/components/wms/locations/LocationsFillLayer.vue
+++ b/src/components/wms/locations/LocationsFillLayer.vue
@@ -1,0 +1,64 @@
+<template>
+  <mgl-fill-layer :layerId="layerId" :paint="paint" :filter="filter" />
+</template>
+
+<script setup lang="ts">
+import { MglFillLayer } from '@indoorequal/vue-maplibre-gl'
+import { computed } from 'vue'
+
+interface Props {
+  layerId: string
+  selectedLocationIds: string[] | undefined
+  isDark: boolean
+  hoveredStateId: string | undefined
+}
+
+const props = defineProps<Props>()
+
+const filter = ['==', '$type', 'Polygon']
+
+const paint = computed(() => {
+  const selectedIds = props.selectedLocationIds?.length
+    ? props.selectedLocationIds
+    : ['invalid-no-layer-selected']
+  const hoverStateId = props.hoveredStateId ?? 'invalid-no-hover'
+  const hoverId = selectedIds.includes(hoverStateId)
+    ? 'invalid-already-selected'
+    : hoverStateId
+  return props.isDark
+    ? getDarkPaint(selectedIds, hoverId)
+    : getLightPaint(selectedIds, hoverId)
+})
+
+function getDarkPaint(selectedIds: string[], hoverId: string) {
+  return {
+    'fill-color': 'darkgrey',
+    'fill-opacity': [
+      'match',
+      ['get', 'locationId'],
+      selectedIds,
+      0.35,
+      hoverId,
+      0.3,
+      0.2,
+    ],
+    'fill-outline-color': 'white',
+  }
+}
+
+function getLightPaint(selectedIds: string[], hoverId: string) {
+  return {
+    'fill-color': '#dfdfdf',
+    'fill-opacity': [
+      'match',
+      ['get', 'locationId'],
+      selectedIds,
+      0.8,
+      hoverId,
+      0.6,
+      0.3,
+    ],
+    'fill-outline-color': 'black',
+  }
+}
+</script>

--- a/src/components/wms/locations/LocationsMarkers.vue
+++ b/src/components/wms/locations/LocationsMarkers.vue
@@ -1,0 +1,55 @@
+<template>
+  <mgl-marker
+    v-for="coordinates in selectedLocationsCoordinates"
+    :coordinates="coordinates"
+    :offset="[0, 4]"
+    anchor="bottom"
+  >
+    <template #marker>
+      <v-icon class="text-shadow" size="32px">mdi-map-marker</v-icon>
+    </template>
+  </mgl-marker>
+</template>
+
+<script setup lang="ts">
+import { MglMarker } from '@indoorequal/vue-maplibre-gl'
+import type { Feature, FeatureCollection, Geometry } from 'geojson'
+import { type Location } from '@deltares/fews-pi-requests'
+import { computed } from 'vue'
+import { LngLat } from 'maplibre-gl'
+
+interface Props {
+  selectedLocationIds: string[] | undefined
+  geojson: FeatureCollection<Geometry, Location>
+}
+
+const props = defineProps<Props>()
+
+const selectedLocationsCoordinates = computed(() => {
+  const selectedLocations = props.geojson.features.filter((feature) =>
+    props.selectedLocationIds?.includes(feature.properties.locationId),
+  )
+
+  return selectedLocations
+    .flatMap(getLngLatForFeature)
+    .filter((lngLat) => lngLat !== undefined)
+})
+
+function getLngLatForFeature(feature: Feature<Geometry, Location>) {
+  const geometry = feature.geometry
+  if (geometry.type === 'Point') {
+    const lng = geometry.coordinates[0]
+    const lat = geometry.coordinates[1]
+
+    return new LngLat(lng, lat)
+  }
+
+  const properties = feature.properties
+  if (properties.lon && properties.lat) {
+    const lng = +properties.lon
+    const lat = +properties.lat
+
+    return new LngLat(lng, lat)
+  }
+}
+</script>

--- a/src/components/wms/locations/LocationsSymbolLayer.vue
+++ b/src/components/wms/locations/LocationsSymbolLayer.vue
@@ -1,21 +1,64 @@
 <template>
-  <mgl-symbol-layer :layerId="layerId" :layout="layout" :filter="filter" />
+  <mgl-symbol-layer
+    :layerId="layerId"
+    :layout="layout"
+    :filter="filter"
+    :paint="paint"
+  />
 </template>
 
 <script setup lang="ts">
 import { MglSymbolLayer } from '@indoorequal/vue-maplibre-gl'
+import { computed } from 'vue'
 
 interface Props {
   layerId: string
+  isDark: boolean
+  child?: boolean
 }
 
-defineProps<Props>()
+const props = defineProps<Props>()
 
-const layout = {
-  'icon-allow-overlap': true,
+const filter = [
+  'all',
+  ['has', 'iconName'],
+  ['==', '$type', 'Point'],
+  [props.child ? 'has' : '!has', 'parentLocationId'],
+]
+
+const baseLayout = {
   'icon-image': ['get', 'iconName'],
   'symbol-sort-key': ['get', 'sortKey'],
 }
 
-const filter = ['all', ['has', 'iconName'], ['==', '$type', 'Point']]
+const childLayout = {
+  ...baseLayout,
+  'icon-overlap': 'never',
+  'text-optional': true,
+  'text-field': ['get', 'locationName'],
+  'text-size': 12,
+  'text-overlap': 'never',
+  'text-justify': 'auto',
+  'text-anchor': 'right',
+  'text-max-width': 15,
+}
+
+const parentLayout = {
+  ...baseLayout,
+  'icon-overlap': 'always',
+}
+
+const layout = computed(() => {
+  return props.child ? childLayout : parentLayout
+})
+
+const paint = computed(() => {
+  return {
+    'text-color': props.isDark ? 'rgb(255,255,255)' : 'rgb(0,0,0)',
+    'text-halo-color': props.isDark ? 'rgb(0,0,0)' : 'rgb(255,255,255)',
+    'text-halo-width': 1,
+    'text-halo-blur': 1,
+    'text-translate': [-10, 0],
+  }
+})
 </script>

--- a/src/components/wms/locations/LocationsSymbolLayer.vue
+++ b/src/components/wms/locations/LocationsSymbolLayer.vue
@@ -1,0 +1,21 @@
+<template>
+  <mgl-symbol-layer :layerId="layerId" :layout="layout" :filter="filter" />
+</template>
+
+<script setup lang="ts">
+import { MglSymbolLayer } from '@indoorequal/vue-maplibre-gl'
+
+interface Props {
+  layerId: string
+}
+
+defineProps<Props>()
+
+const layout = {
+  'icon-allow-overlap': true,
+  'icon-image': ['get', 'iconName'],
+  'symbol-sort-key': ['get', 'sortKey'],
+}
+
+const filter = ['all', ['has', 'iconName'], ['==', '$type', 'Point']]
+</script>

--- a/src/components/wms/locations/LocationsTextLayer.vue
+++ b/src/components/wms/locations/LocationsTextLayer.vue
@@ -1,0 +1,44 @@
+<template>
+  <mgl-symbol-layer
+    :layerId="layerId"
+    :layout="layout"
+    :paint="paint"
+    :filter="filter"
+  />
+</template>
+
+<script setup lang="ts">
+import { MglSymbolLayer } from '@indoorequal/vue-maplibre-gl'
+import { computed } from 'vue'
+
+interface Props {
+  layerId: string
+  isDark: boolean
+}
+
+const props = defineProps<Props>()
+
+const filter = ['==', '$type', 'Point']
+
+const layout = {
+  'text-field': ['get', 'locationName'],
+  'text-size': 12,
+  'text-overlap': 'never',
+  'text-padding': 10,
+  'text-justify': 'auto',
+  'text-variable-anchor': ['right', 'left'],
+  'text-max-width': 15,
+  // When overlap is false sort order has to be inverted for some reason:
+  // https://maplibre.org/maplibre-style-spec/layers/#symbol-sort-key
+  'symbol-sort-key': ['+', 999, ['-', ['get', 'sortKey']]],
+}
+
+const paint = computed(() => {
+  return {
+    'text-color': props.isDark ? 'rgb(255,255,255)' : 'rgb(0,0,0)',
+    'text-halo-color': props.isDark ? 'rgb(0,0,0)' : 'rgb(255,255,255)',
+    'text-halo-width': 1,
+    'text-halo-blur': 1,
+  }
+})
+</script>

--- a/src/components/wms/locations/LocationsTextLayer.vue
+++ b/src/components/wms/locations/LocationsTextLayer.vue
@@ -14,11 +14,16 @@ import { computed } from 'vue'
 interface Props {
   layerId: string
   isDark: boolean
+  child?: boolean
 }
 
 const props = defineProps<Props>()
 
-const filter = ['==', '$type', 'Point']
+const filter = [
+  'all',
+  ['==', '$type', 'Point'],
+  [props.child ? 'has' : '!has', 'parentLocationId'],
+]
 
 const layout = {
   'text-field': ['get', 'locationName'],
@@ -28,9 +33,7 @@ const layout = {
   'text-justify': 'auto',
   'text-variable-anchor': ['right', 'left'],
   'text-max-width': 15,
-  // When overlap is false sort order has to be inverted for some reason:
-  // https://maplibre.org/maplibre-style-spec/layers/#symbol-sort-key
-  'symbol-sort-key': ['+', 999, ['-', ['get', 'sortKey']]],
+  'symbol-sort-key': ['get', 'invertedSortKey'],
 }
 
 const paint = computed(() => {

--- a/src/lib/map/locations.ts
+++ b/src/lib/map/locations.ts
@@ -1,14 +1,25 @@
 import { getLayerId, getSourceId } from '@/lib/map/utils'
 
-export const locationsCircleLayerId = getLayerId('location-circle')
-export const locationsSymbolLayerId = getLayerId('location-symbol')
-export const locationsTextLayerId = getLayerId('location-text')
-export const locationsFillLayerId = getLayerId('location-fill')
-export const locationsSourceId = getSourceId('location')
+export const locationIds = {
+  layer: {
+    circle: getLayerId('location-circle'),
+    symbol: getLayerId('location-symbol'),
+    text: getLayerId('location-text'),
+    fill: getLayerId('location-fill'),
+  },
+  source: getSourceId('location'),
+}
 
 export const locationLayerIds = [
-  locationsCircleLayerId,
-  locationsSymbolLayerId,
-  locationsTextLayerId,
-  locationsFillLayerId,
+  locationIds.layer.circle,
+  locationIds.layer.symbol,
+  locationIds.layer.text,
+  locationIds.layer.fill,
+]
+
+// NOTE: When multiple layers are clicked the order of the layers here is important.
+export const clickableLocationLayerIds = [
+  locationIds.layer.fill,
+  locationIds.layer.circle,
+  locationIds.layer.symbol,
 ]

--- a/src/lib/map/locations.ts
+++ b/src/lib/map/locations.ts
@@ -1,9 +1,12 @@
 import { getLayerId, getSourceId } from '@/lib/map/utils'
+import { Location } from '@deltares/fews-pi-requests'
+import { Feature, FeatureCollection, Geometry } from 'geojson'
 
 export const locationIds = {
   layer: {
     circle: getLayerId('location-circle'),
     symbol: getLayerId('location-symbol'),
+    childSymbol: getLayerId('location-child-symbol'),
     text: getLayerId('location-text'),
     fill: getLayerId('location-fill'),
   },
@@ -13,6 +16,7 @@ export const locationIds = {
 export const locationLayerIds = [
   locationIds.layer.circle,
   locationIds.layer.symbol,
+  locationIds.layer.childSymbol,
   locationIds.layer.text,
   locationIds.layer.fill,
 ]
@@ -22,4 +26,42 @@ export const clickableLocationLayerIds = [
   locationIds.layer.fill,
   locationIds.layer.circle,
   locationIds.layer.symbol,
+  locationIds.layer.childSymbol,
 ]
+
+export function addPropertiesToLocationGeojson(
+  geojson: FeatureCollection<Geometry, Location>,
+  showNames: boolean,
+): FeatureCollection<Geometry, Location> {
+  const features = geojson.features.map((feature) => ({
+    ...feature,
+    properties: {
+      ...feature.properties,
+      locationName: showNames ? feature.properties.locationName : '',
+      iconName: getIconName(feature),
+      sortKey: getSortKey(feature),
+      invertedSortKey: getInvertedSortKey(feature),
+    },
+  }))
+
+  return {
+    ...geojson,
+    features,
+  }
+}
+
+function getIconName({ properties }: Feature<Geometry, Location>) {
+  return properties.thresholdIconName ?? properties.iconName
+}
+
+function getSortArray({ properties }: Feature<Geometry, Location>) {
+  return [properties.thresholdIconName]
+}
+
+function getSortKey(feature: Feature<Geometry, Location>): number {
+  return getSortArray(feature).filter(Boolean).length
+}
+
+function getInvertedSortKey(feature: Feature<Geometry, Location>): number {
+  return getSortArray(feature).filter((v) => !v).length
+}


### PR DESCRIPTION
### Description
Adds the functionality that parents are always visible and children are occluded by other locations. 

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
