### PR TITLE
Add treshold event widget

### DIFF
--- a/src/components/general/ColumnMenu.vue
+++ b/src/components/general/ColumnMenu.vue
@@ -33,7 +33,7 @@
             <v-badge
               color="#00BBF0"
               :model-value="(child.thresholdCount ?? 0) > 0"
-              :content="child.thresholdCount"
+              content="!"
             >
               <v-icon
                 :icon="
@@ -79,7 +79,7 @@
             <v-badge
               color="#00BBF0"
               :model-value="(child.thresholdCount ?? 0) > 0"
-              :content="child.thresholdCount"
+              content="!"
             >
               <v-icon
                 :icon="child.icon ?? toCharacterIcon(child.name)"

--- a/src/components/general/ColumnMenu.vue
+++ b/src/components/general/ColumnMenu.vue
@@ -33,7 +33,7 @@
             <v-badge
               color="#00BBF0"
               :model-value="(child.thresholdCount ?? 0) > 0"
-              content="!"
+              :content="(child.thresholdCount ?? 0) > 0 ? '!' : undefined"
             >
               <v-icon
                 :icon="
@@ -79,7 +79,7 @@
             <v-badge
               color="#00BBF0"
               :model-value="(child.thresholdCount ?? 0) > 0"
-              content="!"
+              :content="(child.thresholdCount ?? 0) > 0 ? '!' : undefined"
             >
               <v-icon
                 :icon="child.icon ?? toCharacterIcon(child.name)"

--- a/src/components/general/ColumnMenu.vue
+++ b/src/components/general/ColumnMenu.vue
@@ -30,17 +30,20 @@
           data-testid="column-menu--item"
         >
           <template v-slot:prepend>
-            <v-badge
-              color="#00BBF0"
-              :model-value="(child.thresholdCount ?? 0) > 0"
-              :content="(child.thresholdCount ?? 0) > 0 ? '!' : undefined"
-            >
+            <div class="icon-container">
               <v-icon
                 :icon="
                   child.icon ?? toCharacterIcon(child.name, '-circle-outline')
                 "
               ></v-icon>
-            </v-badge>
+              <v-icon
+                v-if="(child.thresholdCount ?? 0) > 0"
+                class="alert-icon"
+                size="x-small"
+                color="#00BBF0"
+                icon="mdi-alert-circle"
+              ></v-icon>
+            </div>
           </template>
           <v-list-item-title>{{ child.name }}</v-list-item-title>
           <template v-slot:append>
@@ -76,15 +79,18 @@
           data-testid="column-menu--item"
         >
           <template v-slot:prepend>
-            <v-badge
-              color="#00BBF0"
-              :model-value="(child.thresholdCount ?? 0) > 0"
-              :content="(child.thresholdCount ?? 0) > 0 ? '!' : undefined"
-            >
+            <div class="icon-container">
               <v-icon
                 :icon="child.icon ?? toCharacterIcon(child.name)"
               ></v-icon>
-            </v-badge>
+              <v-icon
+                v-if="(child.thresholdCount ?? 0) > 0"
+                class="alert-icon"
+                size="x-small"
+                color="#00BBF0"
+                icon="mdi-alert-circle"
+              ></v-icon>
+            </div>
           </template>
           <v-list-item-title>{{ child.name }}</v-list-item-title>
           <template v-slot:append>
@@ -159,3 +165,23 @@ function onItemClick(event: Event, item: ColumnItem): void {
   }
 }
 </script>
+
+<style scoped>
+.icon-container {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.alert-icon {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background-color: rgba(
+    var(--v-theme-surface),
+    var(--v-high-emphasis-opacity)
+  );
+  border-radius: 50%;
+}
+</style>

--- a/src/components/general/ThresholdDataTable.vue
+++ b/src/components/general/ThresholdDataTable.vue
@@ -44,11 +44,12 @@ defineProps<Props>()
 .data-table th,
 .data-table td {
   text-align: left;
-  padding-right: 10px;
+  padding-right: 1.5px;
 }
 
 .data-table td {
-  padding-bottom: 5px;
+  padding-bottom: 1px;
+  line-height: 0.9rem;
   font-size: 0.75em;
 }
 </style>

--- a/src/components/general/ThresholdDataTable.vue
+++ b/src/components/general/ThresholdDataTable.vue
@@ -1,17 +1,29 @@
 <template>
-  <div class="table-container pb-1">
-    <table class="data-table">
-      <tbody>
-        <tr v-for="row in tableData">
-          <td class="text-high-emphasis">
-            {{ row.header }}
-            <span class="text-medium-emphasis">
-              {{ row.value }}
-            </span>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+  <div class="table-container py-1 border-t">
+    <v-list-item class="pa-1 ps-2 w-100">
+      <template #prepend>
+        <v-img width="25px" :src="crossing.icon" class="pe-1"></v-img>
+      </template>
+      <div class="d-flex w-100 justify-space-between align-center">
+        <div>
+          <v-list-item-title class="ps-1">
+            <div>
+              {{ crossing.parameterId }}
+            </div>
+          </v-list-item-title>
+        </div>
+        <div>
+          <v-list-item-title class="ps-1 text-end">
+            <div>
+              {{ crossing.maxValue }}
+            </div>
+          </v-list-item-title>
+          <v-list-item-subtitle class="ps-1 text-end">
+            {{ timeToMaxString }}
+          </v-list-item-subtitle>
+        </div>
+      </div>
+    </v-list-item>
   </div>
 </template>
 
@@ -20,11 +32,6 @@ import { toDateAbsDifferenceString } from '@/lib/date'
 import { LevelThresholdCrossings } from '@deltares/fews-pi-requests'
 import { useNow } from '@vueuse/core'
 import { computed } from 'vue'
-
-interface Row {
-  header: string | undefined | null
-  value: string | undefined | null
-}
 
 interface Props {
   crossing: Omit<LevelThresholdCrossings, 'locationId'>
@@ -41,23 +48,6 @@ const timeToMaxString = computed(() =>
     relativeFormat: true,
   }),
 )
-
-const tableData = computed<Row[]>(() => {
-  return [
-    {
-      header: 'Warning level:',
-      value: props.crossing.warningLevelName,
-    },
-    {
-      header: 'Max value:',
-      value: `${props.crossing.maxValue}, ${timeToMaxString.value}`,
-    },
-    {
-      header: 'Parameter:',
-      value: props.crossing.parameterId,
-    },
-  ]
-})
 </script>
 
 <style scoped>
@@ -65,20 +55,5 @@ const tableData = computed<Row[]>(() => {
   display: flex;
   flex-direction: row;
   align-items: flex-start;
-}
-
-.data-table {
-  border-collapse: collapse;
-}
-
-.data-table th,
-.data-table td {
-  text-align: left;
-}
-
-.data-table td {
-  padding-bottom: 2px;
-  line-height: 1;
-  font-size: 0.875rem;
 }
 </style>

--- a/src/components/general/ThresholdDataTable.vue
+++ b/src/components/general/ThresholdDataTable.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script setup lang="ts">
-import { toDateDifferenceString } from '@/lib/date';
+import { toDateRelativeString } from '@/lib/date';
 import { LevelThresholdCrossings } from '@deltares/fews-pi-requests'
 import { useIntervalFn } from '@vueuse/core';
 import { computed, ref, watchEffect } from 'vue';
@@ -34,12 +34,12 @@ interface Props {
 const props = defineProps<Props>()
 
 const NOW_REFRESH_INTERVAL = 1000
-const timeToMaxString = ref(toDateDifferenceString(new Date(), props.crossing.maxValueTime))
+const timeToMaxString = ref(toDateRelativeString(props.crossing.maxValueTime))
 useIntervalFn(updateTimeToMaxString, NOW_REFRESH_INTERVAL)
 
 watchEffect(updateTimeToMaxString)
 function updateTimeToMaxString() {
-  timeToMaxString.value = toDateDifferenceString(new Date(), props.crossing.maxValueTime)
+  timeToMaxString.value = toDateRelativeString(props.crossing.maxValueTime)
 }
 
 const tableData = computed<Row[]>(() => {
@@ -49,7 +49,7 @@ const tableData = computed<Row[]>(() => {
       value: props.crossing.warningLevelName,
     },
     {
-      header: 'Time to maximum:',
+      header: 'Max value reached:',
       value: timeToMaxString.value,
     },
     {

--- a/src/components/general/ThresholdDataTable.vue
+++ b/src/components/general/ThresholdDataTable.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script setup lang="ts">
-import { toDateRelativeString } from '@/lib/date';
+import { toDateDifferenceString } from '@/lib/date';
 import { LevelThresholdCrossings } from '@deltares/fews-pi-requests'
 import { useIntervalFn } from '@vueuse/core';
 import { computed, ref, watchEffect } from 'vue';
@@ -34,12 +34,12 @@ interface Props {
 const props = defineProps<Props>()
 
 const NOW_REFRESH_INTERVAL = 1000
-const timeToMaxString = ref(toDateRelativeString(props.crossing.maxValueTime))
+const timeToMaxString = ref(toDateDifferenceString(new Date(), props.crossing.maxValueTime, { excludeSeconds: true }))
 useIntervalFn(updateTimeToMaxString, NOW_REFRESH_INTERVAL)
 
 watchEffect(updateTimeToMaxString)
 function updateTimeToMaxString() {
-  timeToMaxString.value = toDateRelativeString(props.crossing.maxValueTime)
+  timeToMaxString.value = toDateDifferenceString(new Date(), props.crossing.maxValueTime, { excludeSeconds: true })
 }
 
 const tableData = computed<Row[]>(() => {
@@ -49,7 +49,7 @@ const tableData = computed<Row[]>(() => {
       value: props.crossing.warningLevelName,
     },
     {
-      header: 'Max value reached:',
+      header: 'Max value reached in:',
       value: timeToMaxString.value,
     },
     {

--- a/src/components/general/ThresholdDataTable.vue
+++ b/src/components/general/ThresholdDataTable.vue
@@ -1,27 +1,23 @@
 <template>
-  <div class="table-container py-1 border-t">
-    <v-list-item class="pa-1 ps-2 w-100">
-      <template #prepend>
-        <v-img width="25px" :src="crossing.icon" class="pe-1"></v-img>
-      </template>
-      <div class="d-flex w-100 justify-space-between align-center">
-        <div>
-          <v-list-item-title class="ps-1">
-            <div>
-              {{ parameterName }}
-            </div>
-          </v-list-item-title>
-        </div>
-        <div>
-          <v-list-item-title class="ps-1 text-end">
-            <div>
-              {{ crossing.maxValue }}
-            </div>
-          </v-list-item-title>
-          <v-list-item-subtitle class="ps-1 text-end">
-            {{ timeToMaxString }}
-          </v-list-item-subtitle>
-        </div>
+  <div class="table-container border-t">
+    <v-list-item class="parameter-item pa-1 ps-2 w-100">
+      <div class="d-flex pb-1">
+        <v-list-item-title>
+          {{ parameterName }}
+        </v-list-item-title>
+        <v-spacer />
+        <v-list-item-title class="ps-1 flex-0-0">
+          {{ crossing.maxValue }} {{ parameterUnit }}
+        </v-list-item-title>
+      </div>
+      <div class="d-flex">
+        <v-list-item-subtitle class="">
+          {{ crossing.warningLevelName }}
+        </v-list-item-subtitle>
+        <v-spacer />
+        <v-list-item-subtitle class="flex-0-0">
+          {{ timeToMaxString }}
+        </v-list-item-subtitle>
       </div>
     </v-list-item>
   </div>
@@ -52,15 +48,23 @@ const timeToMaxString = computed(() =>
   }),
 )
 
-const parameterName = computed(() => {
-  console.log(
-    'computed parameterName. parameter by id: ',
-    parameterStore.byId(props.crossing.parameterId),
-  )
-  return (
-    parameterStore.byId(props.crossing.parameterId)?.shortName ??
-    props.crossing.parameterId
-  )
+const crossingColor = computed(() => {
+  return props.crossing.color
+})
+
+const parameter = computed(() => {
+  return parameterStore.byId(props.crossing.parameterId)
+})
+
+const parameterName = computed(
+  () =>
+    parameter.value?.shortName ??
+    parameter.value?.name ??
+    props.crossing.parameterId,
+)
+
+const parameterUnit = computed(() => {
+  return parameter.value?.unit
 })
 </script>
 
@@ -69,5 +73,9 @@ const parameterName = computed(() => {
   display: flex;
   flex-direction: row;
   align-items: flex-start;
+}
+
+.parameter-item {
+  border-right: 5px solid v-bind(crossingColor);
 }
 </style>

--- a/src/components/general/ThresholdDataTable.vue
+++ b/src/components/general/ThresholdDataTable.vue
@@ -8,7 +8,7 @@
         <div>
           <v-list-item-title class="ps-1">
             <div>
-              {{ crossing.parameterId }}
+              {{ parameterName }}
             </div>
           </v-list-item-title>
         </div>
@@ -32,12 +32,15 @@ import { toDateAbsDifferenceString } from '@/lib/date'
 import { LevelThresholdCrossings } from '@deltares/fews-pi-requests'
 import { useNow } from '@vueuse/core'
 import { computed } from 'vue'
+import { useParametersStore } from '@/stores/parameters'
 
 interface Props {
   crossing: Omit<LevelThresholdCrossings, 'locationId'>
 }
 
 const props = defineProps<Props>()
+
+const parameterStore = useParametersStore()
 
 const NOW_REFRESH_INTERVAL = 1000
 const now = useNow({ interval: NOW_REFRESH_INTERVAL })
@@ -48,6 +51,17 @@ const timeToMaxString = computed(() =>
     relativeFormat: true,
   }),
 )
+
+const parameterName = computed(() => {
+  console.log(
+    'computed parameterName. parameter by id: ',
+    parameterStore.byId(props.crossing.parameterId),
+  )
+  return (
+    parameterStore.byId(props.crossing.parameterId)?.shortName ??
+    props.crossing.parameterId
+  )
+})
 </script>
 
 <style scoped>

--- a/src/components/general/ThresholdDataTable.vue
+++ b/src/components/general/ThresholdDataTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="table-container">
+  <div class="table-container pb-1">
     <table class="data-table">
       <thead></thead>
       <tbody>
@@ -82,12 +82,11 @@ const tableData = computed<Row[]>(() => {
 .data-table th,
 .data-table td {
   text-align: left;
-  padding-right: 1.5px;
 }
 
 .data-table td {
-  padding-bottom: 1px;
-  line-height: 0.9rem;
-  font-size: 0.75em;
+  padding-bottom: 2px;
+  line-height: 1;
+  font-size: 0.875rem;
 }
 </style>

--- a/src/components/general/ThresholdDataTable.vue
+++ b/src/components/general/ThresholdDataTable.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="table-container">
+    <table class="data-table">
+      <thead></thead>
+      <tbody>
+        <tr v-for="row in tableData">
+          <td class="text-high-emphasis">
+            {{ row.header }}
+            <span class="text-medium-emphasis">
+              {{ row.value }}
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup lang="ts">
+
+interface Row {
+  header: string
+  value: string | undefined | null
+}
+
+interface Props {
+  tableData: Row[]
+}
+
+defineProps<Props>()
+</script>
+
+<style scoped>
+.table-container {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+}
+
+.data-table {
+  border-collapse: collapse;
+}
+
+.data-table th,
+.data-table td {
+  text-align: left;
+  padding-right: 10px;
+}
+
+.data-table td {
+  padding-bottom: 5px;
+  font-size: 0.75em;
+}
+</style>

--- a/src/components/general/ThresholdDataTable.vue
+++ b/src/components/general/ThresholdDataTable.vue
@@ -17,6 +17,10 @@
 </template>
 
 <script setup lang="ts">
+import { toDateDifferenceString } from '@/lib/date';
+import { LevelThresholdCrossings } from '@deltares/fews-pi-requests'
+import { useIntervalFn } from '@vueuse/core';
+import { computed, ref, watchEffect } from 'vue';
 
 interface Row {
   header: string
@@ -24,10 +28,36 @@ interface Row {
 }
 
 interface Props {
-  tableData: Row[]
+  crossing: LevelThresholdCrossings
 }
 
-defineProps<Props>()
+const props = defineProps<Props>()
+
+const NOW_REFRESH_INTERVAL = 1000
+const timeToMaxString = ref(toDateDifferenceString(new Date(), props.crossing.maxValueTime))
+useIntervalFn(updateTimeToMaxString, NOW_REFRESH_INTERVAL)
+
+watchEffect(updateTimeToMaxString)
+function updateTimeToMaxString() {
+  timeToMaxString.value = toDateDifferenceString(new Date(), props.crossing.maxValueTime)
+}
+
+const tableData = computed<Row[]>(() => {
+  return [
+    {
+      header: 'Warning level:',
+      value: props.crossing.warningLevelName,
+    },
+    {
+      header: 'Time to maximum:',
+      value: timeToMaxString.value,
+    },
+    {
+      header: 'Parameter:',
+      value: props.crossing.parameterId,
+    },
+  ]
+})
 </script>
 
 <style scoped>

--- a/src/components/general/ThresholdDataTable.vue
+++ b/src/components/general/ThresholdDataTable.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="table-container pb-1">
     <table class="data-table">
-      <thead></thead>
       <tbody>
         <tr v-for="row in tableData">
           <td class="text-high-emphasis">
@@ -39,14 +38,9 @@ const now = useNow({ interval: NOW_REFRESH_INTERVAL })
 const timeToMaxString = computed(() =>
   toDateAbsDifferenceString(now.value, props.crossing.maxValueTime, {
     excludeSeconds: true,
+    relativeFormat: true,
   }),
 )
-
-const isMaxValueInFuture = computed(() => {
-  const diff =
-    new Date(props.crossing.maxValueTime ?? '').getTime() - now.value.getTime()
-  return diff > 0
-})
 
 const tableData = computed<Row[]>(() => {
   return [
@@ -56,9 +50,7 @@ const tableData = computed<Row[]>(() => {
     },
     {
       header: 'Max value:',
-      value: isMaxValueInFuture.value
-        ? `in ${timeToMaxString.value}`
-        : `${timeToMaxString.value} ago`,
+      value: timeToMaxString.value,
     },
     {
       header: 'Parameter:',

--- a/src/components/general/ThresholdDataTable.vue
+++ b/src/components/general/ThresholdDataTable.vue
@@ -17,10 +17,10 @@
 </template>
 
 <script setup lang="ts">
-import { toDateDifferenceString } from '@/lib/date';
+import { toDateDifferenceString } from '@/lib/date'
 import { LevelThresholdCrossings } from '@deltares/fews-pi-requests'
-import { useIntervalFn } from '@vueuse/core';
-import { computed, ref, watchEffect } from 'vue';
+import { useIntervalFn } from '@vueuse/core'
+import { computed, ref, watchEffect } from 'vue'
 
 interface Row {
   header: string
@@ -34,12 +34,20 @@ interface Props {
 const props = defineProps<Props>()
 
 const NOW_REFRESH_INTERVAL = 1000
-const timeToMaxString = ref(toDateDifferenceString(new Date(), props.crossing.maxValueTime, { excludeSeconds: true }))
+const timeToMaxString = ref(
+  toDateDifferenceString(new Date(), props.crossing.maxValueTime, {
+    excludeSeconds: true,
+  }),
+)
 useIntervalFn(updateTimeToMaxString, NOW_REFRESH_INTERVAL)
 
 watchEffect(updateTimeToMaxString)
 function updateTimeToMaxString() {
-  timeToMaxString.value = toDateDifferenceString(new Date(), props.crossing.maxValueTime, { excludeSeconds: true })
+  timeToMaxString.value = toDateDifferenceString(
+    new Date(),
+    props.crossing.maxValueTime,
+    { excludeSeconds: true },
+  )
 }
 
 const tableData = computed<Row[]>(() => {

--- a/src/components/general/ThresholdDataTable.vue
+++ b/src/components/general/ThresholdDataTable.vue
@@ -19,8 +19,8 @@
 <script setup lang="ts">
 import { toDateDifferenceString } from '@/lib/date'
 import { LevelThresholdCrossings } from '@deltares/fews-pi-requests'
-import { useIntervalFn } from '@vueuse/core'
-import { computed, ref, watchEffect } from 'vue'
+import { useNow } from '@vueuse/core'
+import { computed } from 'vue'
 
 interface Row {
   header: string
@@ -34,21 +34,13 @@ interface Props {
 const props = defineProps<Props>()
 
 const NOW_REFRESH_INTERVAL = 1000
-const timeToMaxString = ref(
-  toDateDifferenceString(new Date(), props.crossing.maxValueTime, {
+const now = useNow({ interval: NOW_REFRESH_INTERVAL })
+
+const timeToMaxString = computed(() =>
+  toDateDifferenceString(now.value, props.crossing.maxValueTime, {
     excludeSeconds: true,
   }),
 )
-useIntervalFn(updateTimeToMaxString, NOW_REFRESH_INTERVAL)
-
-watchEffect(updateTimeToMaxString)
-function updateTimeToMaxString() {
-  timeToMaxString.value = toDateDifferenceString(
-    new Date(),
-    props.crossing.maxValueTime,
-    { excludeSeconds: true },
-  )
-}
 
 const tableData = computed<Row[]>(() => {
   return [

--- a/src/components/general/ThresholdDataTable.vue
+++ b/src/components/general/ThresholdDataTable.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script setup lang="ts">
-import { toDateDifferenceString } from '@/lib/date'
+import { toDateAbsDifferenceString } from '@/lib/date'
 import { LevelThresholdCrossings } from '@deltares/fews-pi-requests'
 import { useNow } from '@vueuse/core'
 import { computed } from 'vue'
@@ -37,10 +37,16 @@ const NOW_REFRESH_INTERVAL = 1000
 const now = useNow({ interval: NOW_REFRESH_INTERVAL })
 
 const timeToMaxString = computed(() =>
-  toDateDifferenceString(now.value, props.crossing.maxValueTime, {
+  toDateAbsDifferenceString(now.value, props.crossing.maxValueTime, {
     excludeSeconds: true,
   }),
 )
+
+const isMaxValueInFuture = computed(() => {
+  const diff =
+    new Date(props.crossing.maxValueTime ?? '').getTime() - now.value.getTime()
+  return diff > 0
+})
 
 const tableData = computed<Row[]>(() => {
   return [
@@ -49,8 +55,10 @@ const tableData = computed<Row[]>(() => {
       value: props.crossing.warningLevelName,
     },
     {
-      header: 'Max value reached in:',
-      value: timeToMaxString.value,
+      header: 'Max value:',
+      value: isMaxValueInFuture.value
+        ? `in ${timeToMaxString.value}`
+        : `${timeToMaxString.value} ago`,
     },
     {
       header: 'Parameter:',

--- a/src/components/general/ThresholdDataTable.vue
+++ b/src/components/general/ThresholdDataTable.vue
@@ -22,12 +22,12 @@ import { useNow } from '@vueuse/core'
 import { computed } from 'vue'
 
 interface Row {
-  header: string
+  header: string | undefined | null
   value: string | undefined | null
 }
 
 interface Props {
-  crossing: LevelThresholdCrossings
+  crossing: Omit<LevelThresholdCrossings, 'locationId'>
 }
 
 const props = defineProps<Props>()
@@ -50,7 +50,7 @@ const tableData = computed<Row[]>(() => {
     },
     {
       header: 'Max value:',
-      value: timeToMaxString.value,
+      value: `${props.crossing.maxValue}, ${timeToMaxString.value}`,
     },
     {
       header: 'Parameter:',

--- a/src/components/general/ThresholdItem.vue
+++ b/src/components/general/ThresholdItem.vue
@@ -33,7 +33,6 @@
           v-if="expanded"
           v-for="levelCrossing in crossing.crossings"
           :key="levelCrossing.parameterId"
-          class="ms-2"
           :crossing="levelCrossing"
         />
       </v-card-text>

--- a/src/components/general/ThresholdItem.vue
+++ b/src/components/general/ThresholdItem.vue
@@ -26,7 +26,7 @@
           </div>
         </div>
         <ThresholdDataTable
-          v-if="isCrossingExpanded"
+          v-if="expanded"
           class="ms-2"
           :crossing="crossing"
         />
@@ -37,7 +37,7 @@
 
 <script setup lang="ts">
 import { LevelThresholdCrossings } from '@deltares/fews-pi-requests'
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
 import { toHumanReadableDate } from '@/lib/date'
 import { getContrastColor } from "@/lib/charts/styles"
 import ThresholdDataTable from '@/components/general/ThresholdDataTable.vue';
@@ -49,14 +49,17 @@ interface Props {
 
 const props = defineProps<Props>()
 
-const itemHeight = computed(() => {return props.itemHeight})
+const expanded = defineModel<boolean>('expanded', {
+  required: false,
+  default: false,
+})
 
-const isCrossingExpanded = ref(false)
+const itemHeight = computed(() => {return props.itemHeight})
 
 function toggleCrossingExpand() {
   // Only expand when no text is selected
   if (window.getSelection()?.toString() === '') {
-    isCrossingExpanded.value = !isCrossingExpanded.value
+    expanded.value = !expanded.value
   }
 }
 </script>

--- a/src/components/general/ThresholdItem.vue
+++ b/src/components/general/ThresholdItem.vue
@@ -2,7 +2,7 @@
   <div class="thresold-panel-card">
     <v-card
       border
-      :key="crossing.locationId"
+      :key="`${crossing.locationId}-${crossing.parameterId}`"
       flat
       density="compact"
       @click="toggleCrossingExpand"

--- a/src/components/general/ThresholdItem.vue
+++ b/src/components/general/ThresholdItem.vue
@@ -76,6 +76,6 @@ function toggleCrossingExpand() {
   display: flex;
   justify-content: center;
   align-items: center;
-  font-size: 0.75em;
+  font-size: 0.875em;
 }
 </style>

--- a/src/components/general/ThresholdItem.vue
+++ b/src/components/general/ThresholdItem.vue
@@ -2,7 +2,7 @@
   <div class="thresold-panel-card">
     <v-card
       border
-      :key="`${crossing.locationId}-${crossing.parameterId}`"
+      :key="crossing.locationId"
       flat
       density="compact"
       @click="toggleCrossingExpand"
@@ -16,20 +16,26 @@
               {{ location?.locationName ?? crossing.locationId }}
             </v-list-item-title>
             <v-card-subtitle class="pa-0">
-              {{ toHumanReadableDate(crossing.maxValueTime) }}
+              {{ toHumanReadableDate(crossing.crossings[0].maxValueTime) }}
             </v-card-subtitle>
           </div>
           <div
             class="max-value flex-shrink-0"
             :style="{
-              background: crossing.color,
-              color: getContrastColor(crossing.color),
+              background: crossing.crossings[0].color,
+              color: getContrastColor(crossing.crossings[0].color),
             }"
           >
-            {{ crossing.maxValue }}
+            {{ crossing.crossings[0].maxValue }}
           </div>
         </div>
-        <ThresholdDataTable v-if="expanded" class="ms-2" :crossing="crossing" />
+        <ThresholdDataTable
+          v-if="expanded"
+          v-for="levelCrossing in crossing.crossings"
+          :key="levelCrossing.parameterId"
+          class="ms-2"
+          :crossing="levelCrossing"
+        />
       </v-card-text>
     </v-card>
   </div>
@@ -43,8 +49,13 @@ import { getContrastColor } from '@/lib/charts/styles'
 import ThresholdDataTable from '@/components/general/ThresholdDataTable.vue'
 import type { Location } from '@deltares/fews-pi-requests'
 
+interface CrossingItem {
+  locationId: string
+  crossings: Omit<LevelThresholdCrossings, 'locationId'>[]
+}
+
 interface Props {
-  crossing: LevelThresholdCrossings
+  crossing: CrossingItem
   location?: Location
   itemHeight: string
 }

--- a/src/components/general/ThresholdItem.vue
+++ b/src/components/general/ThresholdItem.vue
@@ -9,10 +9,16 @@
       :ripple="false"
       class="w-100"
     >
-      <v-card-text class="pa-0 h-100">
-        <div class="d-flex align-center justify-space-between ga-2 h-100">
-          <div class="d-flex flex-column px-2 py-0 overflow-hidden">
-            <v-list-item-title>
+      <v-card-text class="pa-0 h-100 w-100">
+        <div
+          class="parameter-item d-flex align-center justify-space-between w-100"
+        >
+          <div class="d-flex flex-column ps-2 py-0 overflow-hidden w-100 pe-1">
+            <div class="d-flex">
+              <v-list-item-title>
+                {{ location?.locationName ?? crossing.locationId }}
+              </v-list-item-title>
+              <v-spacer />
               <v-chip
                 v-if="crossing.crossings.length > 1"
                 size="small"
@@ -21,20 +27,16 @@
               >
                 {{ crossing.crossings.length }}
               </v-chip>
-              {{ location?.locationName ?? crossing.locationId }}
-            </v-list-item-title>
-            <v-card-subtitle class="pa-0">
-              {{ toHumanReadableDate(crossing.crossings[0].maxValueTime) }}
-            </v-card-subtitle>
-          </div>
-          <div
-            class="max-value flex-shrink-0"
-            :style="{
-              background: crossing.crossings[0].color,
-              color: getContrastColor(crossing.crossings[0].color),
-            }"
-          >
-            {{ crossing.crossings[0].maxValue }}
+            </div>
+            <div class="d-flex">
+              <v-card-subtitle class="pa-0">
+                {{ toShortHumanReadableDate(mostSevereCrossing.maxValueTime) }}
+              </v-card-subtitle>
+              <v-spacer />
+              <v-card-subtitle class="pa-0">
+                {{ mostSevereCrossing.maxValue }} {{ parameterUnit }}
+              </v-card-subtitle>
+            </div>
           </div>
         </div>
         <ThresholdDataTable
@@ -51,10 +53,10 @@
 <script setup lang="ts">
 import { LevelThresholdCrossings } from '@deltares/fews-pi-requests'
 import { computed } from 'vue'
-import { toHumanReadableDate } from '@/lib/date'
-import { getContrastColor } from '@/lib/charts/styles'
+import { toShortHumanReadableDate } from '@/lib/date'
 import ThresholdDataTable from '@/components/general/ThresholdDataTable.vue'
 import type { Location } from '@deltares/fews-pi-requests'
+import { useParametersStore } from '@/stores/parameters'
 
 interface CrossingItem {
   locationId: string
@@ -84,20 +86,32 @@ function toggleCrossingExpand() {
     expanded.value = !expanded.value
   }
 }
+
+const mostSevereCrossing = computed(() => {
+  return props.crossing.crossings[0]
+})
+
+const crossingColor = computed(() => {
+  return mostSevereCrossing.value.color
+})
+
+const parameterStore = useParametersStore()
+const parameter = computed(() => {
+  return parameterStore.byId(mostSevereCrossing.value.parameterId)
+})
+
+const parameterUnit = computed(() => {
+  return parameter.value?.unit
+})
 </script>
 
 <style scoped>
-.max-value {
-  height: v-bind(itemHeight);
-  width: 50px;
-  text-align: center;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-size: 0.875em;
+.thresold-panel-card {
+  padding-bottom: 3px;
 }
 
-.thresold-panel-card {
-  padding-bottom: 2px;
+.parameter-item {
+  border-left: 5px solid v-bind(crossingColor);
+  height: v-bind(itemHeight);
 }
 </style>

--- a/src/components/general/ThresholdItem.vue
+++ b/src/components/general/ThresholdItem.vue
@@ -13,6 +13,14 @@
         <div class="d-flex align-center justify-space-between ga-2 h-100">
           <div class="d-flex flex-column px-2 py-0 overflow-hidden">
             <v-list-item-title>
+              <v-chip
+                v-if="crossing.crossings.length > 1"
+                size="small"
+                label
+                density="compact"
+              >
+                {{ crossing.crossings.length }}
+              </v-chip>
               {{ location?.locationName ?? crossing.locationId }}
             </v-list-item-title>
             <v-card-subtitle class="pa-0">

--- a/src/components/general/ThresholdItem.vue
+++ b/src/components/general/ThresholdItem.vue
@@ -15,7 +15,7 @@
             class="d-flex flex-column px-2 py-0 overflow-hidden"
           >
             <v-list-item-title>
-              {{ locationName }}
+              {{ location?.locationName ?? crossing.locationId }}
             </v-list-item-title>
             <v-card-subtitle class="pa-0">
               {{ toHumanReadableDate(crossing.maxValueTime) }}
@@ -41,12 +41,11 @@ import { computed } from 'vue';
 import { toHumanReadableDate } from '@/lib/date'
 import { getContrastColor } from "@/lib/charts/styles"
 import ThresholdDataTable from '@/components/general/ThresholdDataTable.vue';
-import { configManager } from '@/services/application-config';
-import { fetchSingleLocationsByLocationId } from '@/lib/topology/locations';
-import { computedAsync } from '@vueuse/core'
+import type { Location } from '@deltares/fews-pi-requests'
 
 interface Props {
   crossing: LevelThresholdCrossings
+  location?: Location
   itemHeight: string
 }
 
@@ -58,14 +57,6 @@ const expanded = defineModel<boolean>('expanded', {
 })
 
 const itemHeight = computed(() => {return props.itemHeight})
-
-const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
-
-const locationName = computedAsync(async () => {
-  const locationGeosJson = await fetchSingleLocationsByLocationId(baseUrl, props.crossing.locationId)
-  return locationGeosJson.features[0].properties.locationName ?? props.crossing.locationId
-})
-
 
 function toggleCrossingExpand() {
   // Only expand when no text is selected

--- a/src/components/general/ThresholdItem.vue
+++ b/src/components/general/ThresholdItem.vue
@@ -78,4 +78,8 @@ function toggleCrossingExpand() {
   align-items: center;
   font-size: 0.875em;
 }
+
+.thresold-panel-card {
+  padding-bottom: 2px;
+}
 </style>

--- a/src/components/general/ThresholdItem.vue
+++ b/src/components/general/ThresholdItem.vue
@@ -1,0 +1,74 @@
+<template>
+  <div class="thresold-panel-card">
+    <v-card
+      border
+      :key="crossing.locationId"
+      flat
+      density="compact"
+      @click="toggleCrossingExpand"
+      :ripple="false"
+      class="w-100"
+    >
+      <v-card-text class="pa-0 h-100">
+        <div class="d-flex align-center justify-space-between ga-2 h-100">
+          <div
+            class="d-flex flex-column px-2 py-0 overflow-hidden"
+          >
+            <v-list-item-title>
+              {{ crossing.locationId }}
+            </v-list-item-title>
+            <v-card-subtitle class="pa-0">
+              {{ toHumanReadableDate(crossing.maxValueTime) }}
+            </v-card-subtitle>
+          </div>
+          <div class="max-value flex-shrink-0" :style="{background: crossing.color, color: getContrastColor(crossing.color)}">
+              {{ crossing.maxValue }}
+          </div>
+        </div>
+        <ThresholdDataTable
+          v-if="isCrossingExpanded"
+          class="ms-2"
+          :crossing="crossing"
+        />
+      </v-card-text>
+    </v-card>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { LevelThresholdCrossings } from '@deltares/fews-pi-requests'
+import { computed, ref } from 'vue';
+import { toHumanReadableDate } from '@/lib/date'
+import { getContrastColor } from "@/lib/charts/styles"
+import ThresholdDataTable from '@/components/general/ThresholdDataTable.vue';
+
+interface Props {
+  crossing: LevelThresholdCrossings
+  itemHeight: string
+}
+
+const props = defineProps<Props>()
+
+const itemHeight = computed(() => {return props.itemHeight})
+
+const isCrossingExpanded = ref(false)
+
+function toggleCrossingExpand() {
+  // Only expand when no text is selected
+  if (window.getSelection()?.toString() === '') {
+    isCrossingExpanded.value = !isCrossingExpanded.value
+  }
+}
+</script>
+
+<style scoped>
+.max-value {
+  height: v-bind(itemHeight);
+  width: 50px;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 0.75em;
+}
+</style>

--- a/src/components/general/ThresholdItem.vue
+++ b/src/components/general/ThresholdItem.vue
@@ -11,9 +11,7 @@
     >
       <v-card-text class="pa-0 h-100">
         <div class="d-flex align-center justify-space-between ga-2 h-100">
-          <div
-            class="d-flex flex-column px-2 py-0 overflow-hidden"
-          >
+          <div class="d-flex flex-column px-2 py-0 overflow-hidden">
             <v-list-item-title>
               {{ location?.locationName ?? crossing.locationId }}
             </v-list-item-title>
@@ -21,15 +19,17 @@
               {{ toHumanReadableDate(crossing.maxValueTime) }}
             </v-card-subtitle>
           </div>
-          <div class="max-value flex-shrink-0" :style="{background: crossing.color, color: getContrastColor(crossing.color)}">
-              {{ crossing.maxValue }}
+          <div
+            class="max-value flex-shrink-0"
+            :style="{
+              background: crossing.color,
+              color: getContrastColor(crossing.color),
+            }"
+          >
+            {{ crossing.maxValue }}
           </div>
         </div>
-        <ThresholdDataTable
-          v-if="expanded"
-          class="ms-2"
-          :crossing="crossing"
-        />
+        <ThresholdDataTable v-if="expanded" class="ms-2" :crossing="crossing" />
       </v-card-text>
     </v-card>
   </div>
@@ -37,10 +37,10 @@
 
 <script setup lang="ts">
 import { LevelThresholdCrossings } from '@deltares/fews-pi-requests'
-import { computed } from 'vue';
+import { computed } from 'vue'
 import { toHumanReadableDate } from '@/lib/date'
-import { getContrastColor } from "@/lib/charts/styles"
-import ThresholdDataTable from '@/components/general/ThresholdDataTable.vue';
+import { getContrastColor } from '@/lib/charts/styles'
+import ThresholdDataTable from '@/components/general/ThresholdDataTable.vue'
 import type { Location } from '@deltares/fews-pi-requests'
 
 interface Props {
@@ -56,7 +56,9 @@ const expanded = defineModel<boolean>('expanded', {
   default: false,
 })
 
-const itemHeight = computed(() => {return props.itemHeight})
+const itemHeight = computed(() => {
+  return props.itemHeight
+})
 
 function toggleCrossingExpand() {
   // Only expand when no text is selected

--- a/src/components/general/ThresholdItem.vue
+++ b/src/components/general/ThresholdItem.vue
@@ -15,7 +15,7 @@
             class="d-flex flex-column px-2 py-0 overflow-hidden"
           >
             <v-list-item-title>
-              {{ crossing.locationId }}
+              {{ locationName }}
             </v-list-item-title>
             <v-card-subtitle class="pa-0">
               {{ toHumanReadableDate(crossing.maxValueTime) }}
@@ -41,6 +41,9 @@ import { computed } from 'vue';
 import { toHumanReadableDate } from '@/lib/date'
 import { getContrastColor } from "@/lib/charts/styles"
 import ThresholdDataTable from '@/components/general/ThresholdDataTable.vue';
+import { configManager } from '@/services/application-config';
+import { fetchSingleLocationsByLocationId } from '@/lib/topology/locations';
+import { computedAsync } from '@vueuse/core'
 
 interface Props {
   crossing: LevelThresholdCrossings
@@ -55,6 +58,14 @@ const expanded = defineModel<boolean>('expanded', {
 })
 
 const itemHeight = computed(() => {return props.itemHeight})
+
+const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
+
+const locationName = computedAsync(async () => {
+  const locationGeosJson = await fetchSingleLocationsByLocationId(baseUrl, props.crossing.locationId)
+  return locationGeosJson.features[0].properties.locationName ?? props.crossing.locationId
+})
+
 
 function toggleCrossingExpand() {
   // Only expand when no text is selected

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -1,7 +1,7 @@
 <template>
   <template v-if="warningLevels?.length">
     <Teleport to="#threshold-summary-top" defer>
-      <v-btn @click="toggleThresholdPanel">
+      <v-btn class="ms-0 ps-0" @click="toggleThresholdPanel">
         <v-icon v-if="isPanelOpen">mdi-menu-close</v-icon>
         <v-icon v-else>mdi-menu-open</v-icon>
       </v-btn>

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -47,7 +47,7 @@
                         {{ toHumanReadableDate(crossing.raw.maxValueTime) }}
                       </v-card-subtitle>
                     </div>
-                    <div class="max-value" :style="{background: crossing.raw.color}">
+                      <div class="max-value" :style="{background: crossing.raw.color, color: getContrastColor(crossing.raw.color)}">
                         {{ crossing.raw.maxValue }}
                     </div>
                   </div>
@@ -77,6 +77,7 @@ import {
 } from '@/lib/date'
 import { LevelThresholdCrossings } from '@deltares/fews-pi-requests'
 import DataTable from '@/components/general/DataTable.vue'
+import { getContrastColor } from "@/lib/charts/styles"
 
 interface Props {
   nodeId?: string

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -120,10 +120,6 @@ function toggleThresholdPanel(): void {
   height: 100%;
 }
 
-.thresold-panel-card {
-  padding-bottom: 2px;
-}
-
 :deep(.v-list-item-title) {
   font-size: 0.875rem;
 }

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -9,11 +9,12 @@
       v-if="warningLevelsStore.showCrossingDetails"
       class="threshold-panel d-flex flex-column"
     >
-      <div class="threshold-panel-iterator ms-2 h-100">
+      <div class="threshold-panel-iterator h-100">
         <v-virtual-scroll
           :items="thresholdItems"
           :item-height="itemHeightPx"
           height="100%"
+          class="px-2 pt-2"
         >
           <template v-slot:default="{ item: crossing }">
             <ThresholdItem

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -5,14 +5,10 @@
       warningLevelsStore.thresholdCrossings.length
     "
   >
-    <Teleport to="#threshold-summary-top" defer>
-      <v-btn
-        @click="toggleThresholdPanel"
-        :disabled="warningLevelsStore.selectedThresholdCrossings.length === 0"
-        :icon="isPanelOpen ? 'mdi-menu-close' : 'mdi-menu-open'"
-      />
-    </Teleport>
-    <div v-if="isPanelOpen" class="threshold-panel d-flex flex-column">
+    <div
+      v-if="warningLevelsStore.showCrossingDetails"
+      class="threshold-panel d-flex flex-column"
+    >
       <div class="threshold-panel-iterator ms-2 h-100">
         <v-virtual-scroll
           :items="warningLevelsStore.selectedThresholdCrossings"
@@ -51,8 +47,6 @@ const expandedItems = ref<Record<string, boolean>>({})
 
 const warningLevelsStore = useWarningLevelsStore()
 
-const isPanelOpen = ref(false)
-
 const ITEM_HEIGHT = 50
 const itemHeightPx = `${ITEM_HEIGHT}px`
 const ITEMS_PER_PANEL = 6
@@ -60,10 +54,6 @@ const panelHeightPx = `${ITEM_HEIGHT * ITEMS_PER_PANEL}px`
 
 function getLocationById(locationId: string) {
   return props.locations?.find((location) => location.locationId === locationId)
-}
-
-function toggleThresholdPanel(): void {
-  isPanelOpen.value = !isPanelOpen.value
 }
 </script>
 

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -1,15 +1,17 @@
 <template>
   <template v-if="allThresholdCrossings.length">
     <Teleport to="#threshold-summary-top" defer>
-      <v-btn class="ms-0 ps-0" @click="toggleThresholdPanel" :disabled="thresholdCrossings.length === 0">
+      <v-btn
+        class="ms-0 ps-0"
+        @click="toggleThresholdPanel"
+        :disabled="thresholdCrossings.length === 0"
+      >
         <v-icon v-if="!isPanelOpen">mdi-menu-open</v-icon>
         <v-icon v-else>mdi-menu-close</v-icon>
       </v-btn>
     </Teleport>
     <div v-if="isPanelOpen" class="threshold-panel d-flex flex-column">
-      <div
-        class="threshold-panel-iterator ms-2 h-100"
-      >
+      <div class="threshold-panel-iterator ms-2 h-100">
         <v-virtual-scroll
           :items="thresholdCrossings"
           :item-height="itemHeightPx"
@@ -20,7 +22,9 @@
               :crossing="crossing"
               :location="getLocationById(crossing.locationId)"
               :item-height="itemHeightPx"
-              v-model:expanded="expandedItems[`${crossing.locationId}-${crossing.parameterId}`]"
+              v-model:expanded="
+                expandedItems[`${crossing.locationId}-${crossing.parameterId}`]
+              "
             />
           </template>
         </v-virtual-scroll>
@@ -45,9 +49,13 @@ interface Props {
 const props = defineProps<Props>()
 
 const expandedItems = ref<Record<string, boolean>>({})
-  
-const selectedLevels = ref<LevelThresholdWarningLevels[]>(inject('selectedWarningLevels', []))
-const selectedLevelIds = computed(() => selectedLevels.value.map((level) => level.id))
+
+const selectedLevels = ref<LevelThresholdWarningLevels[]>(
+  inject('selectedWarningLevels', []),
+)
+const selectedLevelIds = computed(() =>
+  selectedLevels.value.map((level) => level.id),
+)
 
 const isPanelOpen = ref(false)
 
@@ -55,7 +63,6 @@ const ITEM_HEIGHT = 40
 const itemHeightPx = `${ITEM_HEIGHT}px`
 const ITEMS_PER_PANEL = 6
 const panelHeightPx = `${ITEM_HEIGHT * ITEMS_PER_PANEL}px`
-  
 
 const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
 const { thresholds: thresholdsArray } = useTopologyThresholds(
@@ -65,23 +72,28 @@ const { thresholds: thresholdsArray } = useTopologyThresholds(
 
 const allThresholdCrossings = computed(() => {
   if (thresholdsArray.value === undefined || thresholdsArray.value.length === 0)
-  return []
+    return []
   return thresholdsArray.value[0].levelThresholdCrossings ?? []
 })
 
 const thresholdCrossings = computed(() => {
   let crossings = []
   if (selectedLevelIds.value.length === 0) {
-    crossings = allThresholdCrossings.value.sort((a, b) => b.severity - a.severity)
-  }
-  else {
-    crossings = allThresholdCrossings.value?.filter((crossing) => selectedLevelIds.value.includes(crossing.warningLevelId ?? ''))
+    crossings = allThresholdCrossings.value.sort(
+      (a, b) => b.severity - a.severity,
+    )
+  } else {
+    crossings = allThresholdCrossings.value?.filter((crossing) =>
+      selectedLevelIds.value.includes(crossing.warningLevelId ?? ''),
+    )
   }
   return crossings.sort((a, b) => b.severity - a.severity)
 })
 
 function getLocationById(locationId: string) {
-  return props.filteredLocations?.find((location) => location.locationId === locationId)
+  return props.filteredLocations?.find(
+    (location) => location.locationId === locationId,
+  )
 }
 
 function toggleThresholdPanel(): void {
@@ -96,7 +108,7 @@ function toggleThresholdPanel(): void {
   top: 5px;
   right: 5px;
   z-index: 1000;
-  height: v-bind(panelHeightPx)
+  height: v-bind(panelHeightPx);
 }
 
 .text-wrap {

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -16,7 +16,11 @@
           height="100%"
         >
           <template v-slot:default="{ item: crossing }">
-            <ThresholdItem :crossing="crossing" :item-height="itemHeightPx"/>
+            <ThresholdItem
+              :crossing="crossing"
+              :item-height="itemHeightPx"
+              v-model:expanded="expandedItems[crossing.locationId]"
+            />
           </template>
         </v-virtual-scroll>
       </div>
@@ -37,6 +41,8 @@ interface Props {
 
 const props = defineProps<Props>()
 
+const expandedItems = ref<Record<string, boolean>>({})
+  
 const selectedLevels = ref<LevelThresholdWarningLevels[]>(inject('selectedWarningLevels', []))
 const selectedLevelIds = computed(() => selectedLevels.value.map((level) => level.id))
 

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -71,13 +71,13 @@
 <script setup lang="ts">
 import { useTopologyThresholds } from '@/services/useTopologyThresholds'
 import { configManager } from '@/services/application-config'
-import { computed, ref } from 'vue'
+import { computed, inject, ref } from 'vue'
 import {
   toDateDifferenceString,
   toDateRangeString,
   toHumanReadableDate,
 } from '@/lib/date'
-import { LevelThresholdCrossings } from '@deltares/fews-pi-requests'
+import { LevelThresholdCrossings, LevelThresholdWarningLevels } from '@deltares/fews-pi-requests'
 import DataTable from '@/components/general/DataTable.vue'
 import { getContrastColor } from "@/lib/charts/styles"
 
@@ -86,6 +86,9 @@ interface Props {
 }
 
 const props = defineProps<Props>()
+
+const selectedLevels = ref<LevelThresholdWarningLevels[]>(inject('selectedWarningLevels', []))
+const selectedLevelIds = computed(() => selectedLevels.value.map((level) => level.id))
 
 const isPanelOpen = ref(false)
 
@@ -105,7 +108,7 @@ const thresholdCrossings = computed(() => {
   if (thresholdsArray.value === undefined || thresholdsArray.value.length === 0)
     return []
   const thresholds = thresholdsArray.value[0]
-  return thresholds.levelThresholdCrossings?.sort((a, b) => b.severity - a.severity)
+  return thresholds.levelThresholdCrossings?.filter((crossing) => selectedLevelIds.value.includes(crossing.warningLevelId ?? '')).sort((a, b) => b.severity - a.severity)
 })
 
 function toTableDate(crossing: LevelThresholdCrossings) {

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -52,7 +52,7 @@
                           {{ crossing.raw.maxValue }}
                       </div>
                     </div>
-                    <DataTable
+                    <ThresholdDataTable
                       v-if="isCrossingExpanded(crossing)"
                       class="mt-2 ms-2"
                       :tableData="toTableDate(crossing.raw)"
@@ -73,12 +73,11 @@ import { useTopologyThresholds } from '@/services/useTopologyThresholds'
 import { configManager } from '@/services/application-config'
 import { computed, inject, ref } from 'vue'
 import {
-  toDateDifferenceString,
   toDateRangeString,
   toHumanReadableDate,
 } from '@/lib/date'
 import { LevelThresholdCrossings, LevelThresholdWarningLevels } from '@deltares/fews-pi-requests'
-import DataTable from '@/components/general/DataTable.vue'
+import ThresholdDataTable from '@/components/general/ThresholdDataTable.vue'
 import { getContrastColor } from "@/lib/charts/styles"
 
 interface Props {
@@ -106,7 +105,7 @@ const { thresholds: thresholdsArray } = useTopologyThresholds(
 
 const allThresholdCrossings = computed(() => {
   if (thresholdsArray.value === undefined || thresholdsArray.value.length === 0)
-    return []
+  return []
   return thresholdsArray.value[0].levelThresholdCrossings ?? []
 })
 
@@ -124,63 +123,21 @@ const thresholdCrossings = computed(() => {
 function toTableDate(crossing: LevelThresholdCrossings) {
   return [
     {
-      columns: [
-        {
-          header: 'Warning level',
-          value: crossing.warningLevelName
-        },
-      ],
+      header: 'Warning level',
+      value: crossing.warningLevelName,
     },
+  
     {
-      columns: [
-        {
-          header: 'First event time',
-          value: toHumanReadableDate(crossing.firstValueTime),
-        },
-        {
-          header: 'First event value',
-          value: crossing.firstValue?.toString(),
-        },
-      ],
+      header: 'Time to event',
+      value: crossing.firstValueTime,
     },
+  
     {
-      columns: [
-        {
-          header: 'Max. event time',
-          value: toHumanReadableDate(crossing.maxValueTime),
-        },
-        {
-          header: 'Max. event value',
-          value: crossing.maxValue?.toString(),
-        },
-      ],
-    },
-    {
-      columns: [
-        {
-          header: 'Last event time',
-          value: toHumanReadableDate(crossing.lastValueTime),
-        },
-        {
-          header: 'Last event value',
-          value: crossing.lastValue?.toString(),
-        },
-      ],
-    },
-    {
-      columns: [
-        {
-          header: 'Event duration',
-          subHeader: toDateDifferenceString(
-            crossing.firstValueTime,
-            crossing.lastValueTime,
-          ),
-          value: toDateRangeString(
-            crossing.firstValueTime,
-            crossing.lastValueTime,
-          ),
-        },
-      ],
+      header: 'Event duration',
+      value: toDateRangeString(
+        crossing.firstValueTime,
+        crossing.lastValueTime,
+      ),
     },
   ]
 }

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -223,5 +223,14 @@ function toggleThresholdPanel(): void {
   display: flex;
   justify-content: center;
   align-items: center;
+  font-size: 0.75em;
+}
+
+:deep(.v-list-item-title) {
+  font-size: 0.8em;
+}
+
+:deep(.v-card-subtitle) {
+  font-size: 0.75em;
 }
 </style>

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -2,13 +2,10 @@
   <template v-if="allThresholdCrossings.length">
     <Teleport to="#threshold-summary-top" defer>
       <v-btn
-        class="ms-0 ps-0"
         @click="toggleThresholdPanel"
         :disabled="thresholdCrossings.length === 0"
-      >
-        <v-icon v-if="!isPanelOpen">mdi-menu-open</v-icon>
-        <v-icon v-else>mdi-menu-close</v-icon>
-      </v-btn>
+        :icon="isPanelOpen ? 'mdi-menu-close' : 'mdi-menu-open'"
+      />
     </Teleport>
     <div v-if="isPanelOpen" class="threshold-panel d-flex flex-column">
       <div class="threshold-panel-iterator ms-2 h-100">

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -6,7 +6,7 @@
         <v-icon v-else>mdi-menu-open</v-icon>
       </v-btn>
     </Teleport>
-    <div v-if="isPanelOpen" class="threshold-panel d-flex flex-column h-50">
+    <div v-if="isPanelOpen" class="threshold-panel d-flex flex-column">
       <v-data-iterator
         :items="thresholdCrossings"
         items-per-page="-1"
@@ -22,7 +22,7 @@
         >
           <v-virtual-scroll
             :items="crossings"
-            item-height="50px"
+            :item-height="item_height_px"
             height="100%"
           >
             <template v-slot:default="{ item: crossing }">
@@ -35,29 +35,25 @@
                 :ripple="false"
                 class="w-100"
               >
-                <v-card-text class="py-2 h-100">
-                  <div
-                    class="d-flex flex-column user-select-text cursor-pointer"
-                  >
-                    <div class="d-flex align-center ga-2">
+                <v-card-text class="pa-0 h-100">
+                  <div class="d-flex align-center justify-space-between ga-2 h-100">
+                    <div
+                      class="d-flex flex-column pa-2 user-select-text cursor-pointer"
+                    >
                       <v-list-item-title>
                         {{ crossing.raw.locationId }}
                       </v-list-item-title>
-                      <v-card-subtitle class="pa-0"
-                        >from
-                        {{
-                          toHumanReadableDate(crossing.raw.firstValueTime)
-                        }}</v-card-subtitle
-                      >
+                      <v-card-subtitle class="pa-0">
+                        {{ toHumanReadableDate(crossing.raw.maxValueTime) }}
+                      </v-card-subtitle>
                     </div>
-                    <v-card-subtitle class="pa-0">
-                      Max: {{ crossing.raw.maxValue }} @
-                      {{ toHumanReadableDate(crossing.raw.maxValueTime) }}
-                    </v-card-subtitle>
+                    <div class="max-value" :style="{background: crossing.raw.color}">
+                        {{ crossing.raw.maxValue }}
+                    </div>
                   </div>
                   <DataTable
                     v-if="isCrossingExpanded(crossing)"
-                    class="mt-4"
+                    class="mt-2 ms-2"
                     :tableData="toTableDate(crossing.raw)"
                   />
                 </v-card-text>
@@ -89,6 +85,12 @@ interface Props {
 const props = defineProps<Props>()
 
 const isPanelOpen = ref(false)
+
+const ITEM_HEIGHT = 56
+const item_height_px = `${ITEM_HEIGHT}px`
+const ITEMS_PER_PANEL = 6
+const panel_height_px = `${ITEM_HEIGHT * ITEMS_PER_PANEL}px`
+  
 
 const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
 const { thresholds: thresholdsArray } = useTopologyThresholds(
@@ -166,11 +168,12 @@ function toggleThresholdPanel(): void {
 
 <style scoped>
 .threshold-panel {
-  width: 350px;
+  width: 300px;
   position: absolute;
   top: 95px;
   right: 5px;
   z-index: 1000;
+  height: v-bind(panel_height_px)
 }
 
 .text-wrap {
@@ -187,5 +190,14 @@ function toggleThresholdPanel(): void {
 
 .threshold-panel-iterator > * {
   height: 100%;
+}
+
+.max-value {
+  height: v-bind(item_height_px);
+  width: 50px;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 </style>

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -59,7 +59,7 @@ const selectedLevelIds = computed(() =>
 
 const isPanelOpen = ref(false)
 
-const ITEM_HEIGHT = 40
+const ITEM_HEIGHT = 50
 const itemHeightPx = `${ITEM_HEIGHT}px`
 const ITEMS_PER_PANEL = 6
 const panelHeightPx = `${ITEM_HEIGHT * ITEMS_PER_PANEL}px`
@@ -132,10 +132,10 @@ function toggleThresholdPanel(): void {
 }
 
 :deep(.v-list-item-title) {
-  font-size: 0.8em;
+  font-size: 0.875rem;
 }
 
 :deep(.v-card-subtitle) {
-  font-size: 0.75em;
+  font-size: 0.875rem;
 }
 </style>

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -42,7 +42,7 @@ import type { Location } from '@deltares/fews-pi-requests'
 import { useWarningLevelsStore } from '@/stores/warningLevels'
 
 interface Props {
-  filteredLocations?: Location[]
+  locations?: Location[]
 }
 
 const props = defineProps<Props>()
@@ -59,9 +59,7 @@ const ITEMS_PER_PANEL = 6
 const panelHeightPx = `${ITEM_HEIGHT * ITEMS_PER_PANEL}px`
 
 function getLocationById(locationId: string) {
-  return props.filteredLocations?.find(
-    (location) => location.locationId === locationId,
-  )
+  return props.locations?.find((location) => location.locationId === locationId)
 }
 
 function toggleThresholdPanel(): void {

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -113,6 +113,14 @@ function toTableDate(crossing: LevelThresholdCrossings) {
     {
       columns: [
         {
+          header: 'Warning level',
+          value: crossing.warningLevelName
+        },
+      ],
+    },
+    {
+      columns: [
+        {
           header: 'First event time',
           value: toHumanReadableDate(crossing.firstValueTime),
         },

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -51,7 +51,7 @@ const isPanelOpen = ref(false)
 const ITEM_HEIGHT = 40
 const itemHeightPx = `${ITEM_HEIGHT}px`
 const ITEMS_PER_PANEL = 6
-const panel_height_px = `${ITEM_HEIGHT * ITEMS_PER_PANEL}px`
+const panelHeightPx = `${ITEM_HEIGHT * ITEMS_PER_PANEL}px`
   
 
 const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
@@ -89,7 +89,7 @@ function toggleThresholdPanel(): void {
   top: 5px;
   right: 5px;
   z-index: 1000;
-  height: v-bind(panel_height_px)
+  height: v-bind(panelHeightPx)
 }
 
 .text-wrap {

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -184,7 +184,7 @@ function toggleThresholdPanel(): void {
 .threshold-panel {
   width: 300px;
   position: absolute;
-  top: 95px;
+  top: 5px;
   right: 5px;
   z-index: 1000;
   height: v-bind(panel_height_px)

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -26,38 +26,40 @@
             height="100%"
           >
             <template v-slot:default="{ item: crossing }">
-              <v-card
-                border
-                :key="crossing.raw.locationId"
-                flat
-                density="compact"
-                @click="() => toggleCrossingExpand(crossing)"
-                :ripple="false"
-                class="w-100"
-              >
-                <v-card-text class="pa-0 h-100">
-                  <div class="d-flex align-center justify-space-between ga-2 h-100">
-                    <div
-                      class="d-flex flex-column pa-2 user-select-text cursor-pointer"
-                    >
-                      <v-list-item-title>
-                        {{ crossing.raw.locationId }}
-                      </v-list-item-title>
-                      <v-card-subtitle class="pa-0">
-                        {{ toHumanReadableDate(crossing.raw.maxValueTime) }}
-                      </v-card-subtitle>
-                    </div>
+              <div class="pb-1">
+                <v-card
+                  border
+                  :key="crossing.raw.locationId"
+                  flat
+                  density="compact"
+                  @click="() => toggleCrossingExpand(crossing)"
+                  :ripple="false"
+                  class="w-100"
+                >
+                  <v-card-text class="pa-0 h-100">
+                    <div class="d-flex align-center justify-space-between ga-2 h-100">
+                      <div
+                        class="d-flex flex-column pa-2 user-select-text cursor-pointer"
+                      >
+                        <v-list-item-title>
+                          {{ crossing.raw.locationId }}
+                        </v-list-item-title>
+                        <v-card-subtitle class="pa-0">
+                          {{ toHumanReadableDate(crossing.raw.maxValueTime) }}
+                        </v-card-subtitle>
+                      </div>
                       <div class="max-value" :style="{background: crossing.raw.color, color: getContrastColor(crossing.raw.color)}">
-                        {{ crossing.raw.maxValue }}
+                          {{ crossing.raw.maxValue }}
+                      </div>
                     </div>
-                  </div>
-                  <DataTable
-                    v-if="isCrossingExpanded(crossing)"
-                    class="mt-2 ms-2"
-                    :tableData="toTableDate(crossing.raw)"
-                  />
-                </v-card-text>
-              </v-card>
+                    <DataTable
+                      v-if="isCrossingExpanded(crossing)"
+                      class="mt-2 ms-2"
+                      :tableData="toTableDate(crossing.raw)"
+                    />
+                  </v-card-text>
+                </v-card>
+              </div>
             </template>
           </v-virtual-scroll>
         </template>

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -39,7 +39,7 @@
                   <v-card-text class="pa-0 h-100">
                     <div class="d-flex align-center justify-space-between ga-2 h-100">
                       <div
-                        class="d-flex flex-column pa-2 user-select-text cursor-pointer"
+                        class="d-flex flex-column pa-2"
                       >
                         <v-list-item-title>
                           {{ crossing.raw.locationId }}

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -1,123 +1,69 @@
 <template>
-  <template v-if="warningLevels?.length">
+  <template v-if="thresholdCrossings?.length">
     <Teleport to="#threshold-summary-top" defer>
       <v-btn class="ms-0 ps-0" @click="toggleThresholdPanel">
         <v-icon v-if="isPanelOpen">mdi-menu-close</v-icon>
         <v-icon v-else>mdi-menu-open</v-icon>
       </v-btn>
     </Teleport>
-    <div v-if="isPanelOpen" class="threshold-panel d-flex flex-column">
+    <div v-if="isPanelOpen" class="threshold-panel d-flex flex-column h-50">
       <v-data-iterator
-        :items="warningLevels"
+        :items="thresholdCrossings"
         items-per-page="-1"
-        :key="nodeId"
-        class="threshold-panel-iterator h-100"
+        item-value="locationId"
+        class="threshold-panel-iterator ms-2 h-100"
       >
         <template
           v-slot:default="{
-            items: warningLevels,
-            isExpanded: isLevelExpanded,
-            toggleExpand: toggleLevelExpand,
+            items: crossings,
+            isExpanded: isCrossingExpanded,
+            toggleExpand: toggleCrossingExpand,
           }"
         >
-          <template
-            v-for="warningLevel in warningLevels"
-            :key="warningLevel.raw.id"
+          <v-virtual-scroll
+            :items="crossings"
+            item-height="50px"
+            height="100%"
           >
-            <v-card
-              border
-              flat
-              density="compact"
-              :disabled="warningLevel.raw.thresholdCrossing?.length === 0"
-              @click="() => toggleLevelExpand(warningLevel)"
-              :ripple="false"
-            >
-              <v-card-text class="py-2 h-100">
-                <div class="d-flex w-100">
-                  <div class="d-flex align-center ga-1 w-100">
-                    <v-avatar
-                      start
-                      :image="warningLevel.raw.icon"
-                      rounded
-                      class="me-1 flex-0-0"
-                      size="20"
-                    ></v-avatar>
-                    <div class="flex-1-1 overflow-hidden">
-                      <div
-                        :class="{ 'text-wrap': isLevelExpanded(warningLevel) }"
-                      >
-                        {{ warningLevel.raw.name }}
-                      </div>
-                    </div>
-                    <v-avatar
-                      end
-                      :text="`${warningLevel.raw.count}`"
-                    ></v-avatar>
-                  </div>
-                </div>
-              </v-card-text>
-            </v-card>
-            <v-data-iterator
-              v-if="isLevelExpanded(warningLevel)"
-              :items="warningLevel.raw.thresholdCrossing"
-              items-per-page="-1"
-              item-value="locationId"
-              class="threshold-panel-iterator ms-2 h-50"
-            >
-              <template
-                v-slot:default="{
-                  items: crossings,
-                  isExpanded: isCrossingExpanded,
-                  toggleExpand: toggleCrossingExpand,
-                }"
+            <template v-slot:default="{ item: crossing }">
+              <v-card
+                border
+                :key="crossing.raw.locationId"
+                flat
+                density="compact"
+                @click="() => toggleCrossingExpand(crossing)"
+                :ripple="false"
+                class="w-100"
               >
-                <v-virtual-scroll
-                  :items="crossings"
-                  item-height="50px"
-                  height="100%"
-                >
-                  <template v-slot:default="{ item: crossing }">
-                    <v-card
-                      border
-                      :key="crossing.raw.locationId"
-                      flat
-                      density="compact"
-                      @click="() => toggleCrossingExpand(crossing)"
-                      :ripple="false"
-                      class="w-100"
-                    >
-                      <v-card-text class="py-2 h-100">
-                        <div
-                          class="d-flex flex-column user-select-text cursor-pointer"
-                        >
-                          <div class="d-flex align-center ga-2">
-                            <v-list-item-title>
-                              {{ crossing.raw.locationId }}
-                            </v-list-item-title>
-                            <v-card-subtitle class="pa-0"
-                              >from
-                              {{
-                                toHumanReadableDate(crossing.raw.firstValueTime)
-                              }}</v-card-subtitle
-                            >
-                          </div>
-                          <v-card-subtitle class="pa-0">
-                            Max: {{ crossing.raw.maxValue }} @
-                            {{ toHumanReadableDate(crossing.raw.maxValueTime) }}
-                          </v-card-subtitle>
-                        </div>
-                        <DataTable
-                          v-if="isCrossingExpanded(crossing)"
-                          class="mt-4"
-                          :tableData="toTableDate(crossing.raw)"
-                        />
-                      </v-card-text>
-                    </v-card>
-                  </template>
-                </v-virtual-scroll>
-              </template>
-            </v-data-iterator>
-          </template>
+                <v-card-text class="py-2 h-100">
+                  <div
+                    class="d-flex flex-column user-select-text cursor-pointer"
+                  >
+                    <div class="d-flex align-center ga-2">
+                      <v-list-item-title>
+                        {{ crossing.raw.locationId }}
+                      </v-list-item-title>
+                      <v-card-subtitle class="pa-0"
+                        >from
+                        {{
+                          toHumanReadableDate(crossing.raw.firstValueTime)
+                        }}</v-card-subtitle
+                      >
+                    </div>
+                    <v-card-subtitle class="pa-0">
+                      Max: {{ crossing.raw.maxValue }} @
+                      {{ toHumanReadableDate(crossing.raw.maxValueTime) }}
+                    </v-card-subtitle>
+                  </div>
+                  <DataTable
+                    v-if="isCrossingExpanded(crossing)"
+                    class="mt-4"
+                    :tableData="toTableDate(crossing.raw)"
+                  />
+                </v-card-text>
+              </v-card>
+            </template>
+          </v-virtual-scroll>
         </template>
       </v-data-iterator>
     </div>
@@ -127,14 +73,13 @@
 <script setup lang="ts">
 import { useTopologyThresholds } from '@/services/useTopologyThresholds'
 import { configManager } from '@/services/application-config'
-import { getResourcesIconsUrl } from '@/lib/fews-config'
 import { computed, ref } from 'vue'
 import {
   toDateDifferenceString,
   toDateRangeString,
   toHumanReadableDate,
 } from '@/lib/date'
-import { AggregatedLevelThresholdCrossings } from '@deltares/fews-pi-requests'
+import { LevelThresholdCrossings } from '@deltares/fews-pi-requests'
 import DataTable from '@/components/general/DataTable.vue'
 
 interface Props {
@@ -151,28 +96,14 @@ const { thresholds: thresholdsArray } = useTopologyThresholds(
   () => props.nodeId,
 )
 
-const warningLevels = computed(() => {
+const thresholdCrossings = computed(() => {
   if (thresholdsArray.value === undefined || thresholdsArray.value.length === 0)
     return []
   const thresholds = thresholdsArray.value[0]
-  return thresholds.aggregatedLevelThresholdWarningLevels
-    ?.map((warningLevel) => {
-      return {
-        ...warningLevel,
-        ...{
-          icon: warningLevel.icon
-            ? getResourcesIconsUrl(warningLevel.icon)
-            : undefined,
-        },
-        thresholdCrossing: thresholds.aggregatedLevelThresholdCrossings?.filter(
-          (crossing) => crossing.warningLevelId == warningLevel.id,
-        ),
-      }
-    })
-    .sort((a, b) => b.severity - a.severity)
+  return thresholds.levelThresholdCrossings?.sort((a, b) => b.severity - a.severity)
 })
 
-function toTableDate(crossing: AggregatedLevelThresholdCrossings) {
+function toTableDate(crossing: LevelThresholdCrossings) {
   return [
     {
       columns: [

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -1,126 +1,134 @@
 <template>
-  <div v-if="warningLevels?.length" class="threshold-panel d-flex flex-column">
-    <v-data-iterator
-      :items="warningLevels"
-      items-per-page="-1"
-      :key="nodeId"
-      class="threshold-panel-iterator h-100"
-    >
-      <template
-        v-slot:default="{
-          items: warningLevels,
-          isExpanded: isLevelExpanded,
-          toggleExpand: toggleLevelExpand,
-        }"
+  <template v-if="warningLevels?.length">
+    <Teleport to="#threshold-summary-top" defer>
+      <v-btn @click="toggleThresholdPanel">
+        <v-icon v-if="isPanelOpen">mdi-menu-close</v-icon>
+        <v-icon v-else>mdi-menu-open</v-icon>
+      </v-btn>
+    </Teleport>
+    <div v-if="isPanelOpen" class="threshold-panel d-flex flex-column">
+      <v-data-iterator
+        :items="warningLevels"
+        items-per-page="-1"
+        :key="nodeId"
+        class="threshold-panel-iterator h-100"
       >
         <template
-          v-for="warningLevel in warningLevels"
-          :key="warningLevel.raw.id"
+          v-slot:default="{
+            items: warningLevels,
+            isExpanded: isLevelExpanded,
+            toggleExpand: toggleLevelExpand,
+          }"
         >
-          <v-card
-            border
-            flat
-            density="compact"
-            :disabled="warningLevel.raw.thresholdCrossing?.length === 0"
-            @click="() => toggleLevelExpand(warningLevel)"
-            :ripple="false"
+          <template
+            v-for="warningLevel in warningLevels"
+            :key="warningLevel.raw.id"
           >
-            <v-card-text class="py-2 h-100">
-              <div class="d-flex w-100">
-                <div class="d-flex align-center ga-1 w-100">
-                  <v-avatar
-                    start
-                    :image="warningLevel.raw.icon"
-                    rounded
-                    class="me-1 flex-0-0"
-                    size="20"
-                  ></v-avatar>
-                  <div class="flex-1-1 overflow-hidden">
-                    <div
-                      :class="{ 'text-wrap': isLevelExpanded(warningLevel) }"
-                    >
-                      {{ warningLevel.raw.name }}
-                    </div>
-                  </div>
-                  <v-avatar
-                    end
-                    :text="`${warningLevel.raw.count}`"
-                  ></v-avatar>
-                </div>
-              </div>
-            </v-card-text>
-          </v-card>
-          <v-data-iterator
-            v-if="isLevelExpanded(warningLevel)"
-            :items="warningLevel.raw.thresholdCrossing"
-            items-per-page="-1"
-            item-value="locationId"
-            class="threshold-panel-iterator ms-2 h-50"
-          >
-            <template
-              v-slot:default="{
-                items: crossings,
-                isExpanded: isCrossingExpanded,
-                toggleExpand: toggleCrossingExpand,
-              }"
+            <v-card
+              border
+              flat
+              density="compact"
+              :disabled="warningLevel.raw.thresholdCrossing?.length === 0"
+              @click="() => toggleLevelExpand(warningLevel)"
+              :ripple="false"
             >
-              <v-virtual-scroll
-                :items="crossings"
-                item-height="50px"
-                height="100%"
-              >
-                <template v-slot:default="{ item: crossing }">
-                  <v-card
-                    border
-                    :key="crossing.raw.locationId"
-                    flat
-                    density="compact"
-                    @click="() => toggleCrossingExpand(crossing)"
-                    :ripple="false"
-                    class="w-100"
-                  >
-                    <v-card-text class="py-2 h-100">
+              <v-card-text class="py-2 h-100">
+                <div class="d-flex w-100">
+                  <div class="d-flex align-center ga-1 w-100">
+                    <v-avatar
+                      start
+                      :image="warningLevel.raw.icon"
+                      rounded
+                      class="me-1 flex-0-0"
+                      size="20"
+                    ></v-avatar>
+                    <div class="flex-1-1 overflow-hidden">
                       <div
-                        class="d-flex flex-column user-select-text cursor-pointer"
+                        :class="{ 'text-wrap': isLevelExpanded(warningLevel) }"
                       >
-                        <div class="d-flex align-center ga-2">
-                          <v-list-item-title>
-                            {{ crossing.raw.locationId }}
-                          </v-list-item-title>
-                          <v-card-subtitle class="pa-0"
-                            >from
-                            {{
-                              toHumanReadableDate(crossing.raw.firstValueTime)
-                            }}</v-card-subtitle
-                          >
-                        </div>
-                        <v-card-subtitle class="pa-0">
-                          Max: {{ crossing.raw.maxValue }} @
-                          {{ toHumanReadableDate(crossing.raw.maxValueTime) }}
-                        </v-card-subtitle>
+                        {{ warningLevel.raw.name }}
                       </div>
-                      <DataTable
-                        v-if="isCrossingExpanded(crossing)"
-                        class="mt-4"
-                        :tableData="toTableDate(crossing.raw)"
-                      />
-                    </v-card-text>
-                  </v-card>
-                </template>
-              </v-virtual-scroll>
-            </template>
-          </v-data-iterator>
+                    </div>
+                    <v-avatar
+                      end
+                      :text="`${warningLevel.raw.count}`"
+                    ></v-avatar>
+                  </div>
+                </div>
+              </v-card-text>
+            </v-card>
+            <v-data-iterator
+              v-if="isLevelExpanded(warningLevel)"
+              :items="warningLevel.raw.thresholdCrossing"
+              items-per-page="-1"
+              item-value="locationId"
+              class="threshold-panel-iterator ms-2 h-50"
+            >
+              <template
+                v-slot:default="{
+                  items: crossings,
+                  isExpanded: isCrossingExpanded,
+                  toggleExpand: toggleCrossingExpand,
+                }"
+              >
+                <v-virtual-scroll
+                  :items="crossings"
+                  item-height="50px"
+                  height="100%"
+                >
+                  <template v-slot:default="{ item: crossing }">
+                    <v-card
+                      border
+                      :key="crossing.raw.locationId"
+                      flat
+                      density="compact"
+                      @click="() => toggleCrossingExpand(crossing)"
+                      :ripple="false"
+                      class="w-100"
+                    >
+                      <v-card-text class="py-2 h-100">
+                        <div
+                          class="d-flex flex-column user-select-text cursor-pointer"
+                        >
+                          <div class="d-flex align-center ga-2">
+                            <v-list-item-title>
+                              {{ crossing.raw.locationId }}
+                            </v-list-item-title>
+                            <v-card-subtitle class="pa-0"
+                              >from
+                              {{
+                                toHumanReadableDate(crossing.raw.firstValueTime)
+                              }}</v-card-subtitle
+                            >
+                          </div>
+                          <v-card-subtitle class="pa-0">
+                            Max: {{ crossing.raw.maxValue }} @
+                            {{ toHumanReadableDate(crossing.raw.maxValueTime) }}
+                          </v-card-subtitle>
+                        </div>
+                        <DataTable
+                          v-if="isCrossingExpanded(crossing)"
+                          class="mt-4"
+                          :tableData="toTableDate(crossing.raw)"
+                        />
+                      </v-card-text>
+                    </v-card>
+                  </template>
+                </v-virtual-scroll>
+              </template>
+            </v-data-iterator>
+          </template>
         </template>
-      </template>
-    </v-data-iterator>
-  </div>
+      </v-data-iterator>
+    </div>
+  </template>
 </template>
 
 <script setup lang="ts">
 import { useTopologyThresholds } from '@/services/useTopologyThresholds'
 import { configManager } from '@/services/application-config'
 import { getResourcesIconsUrl } from '@/lib/fews-config'
-import { computed } from 'vue'
+import { computed, ref } from 'vue'
 import {
   toDateDifferenceString,
   toDateRangeString,
@@ -134,6 +142,8 @@ interface Props {
 }
 
 const props = defineProps<Props>()
+
+const isPanelOpen = ref(false)
 
 const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
 const { thresholds: thresholdsArray } = useTopologyThresholds(
@@ -216,6 +226,10 @@ function toTableDate(crossing: AggregatedLevelThresholdCrossings) {
       ],
     },
   ]
+}
+
+function toggleThresholdPanel(): void {
+  isPanelOpen.value = !isPanelOpen.value
 }
 </script>
 

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -1,136 +1,126 @@
 <template>
-  <v-btn
-    icon="mdi-alert-outline"
-    :active="isPanelOpen"
-    @click="toggleThresholdPanel"
-  >
-  </v-btn>
-  <Teleport to="#main-side-panel-left" defer>
-    <div v-if="isPanelOpen" class="threshold-panel h-100 d-flex flex-column">
-      <v-data-iterator
-        v-if="warningLevels?.length"
-        :items="warningLevels"
-        items-per-page="-1"
-        :key="nodeId"
-        class="threshold-panel-iterator h-100"
+  <div v-if="warningLevels?.length" class="threshold-panel d-flex flex-column">
+    <v-data-iterator
+      :items="warningLevels"
+      items-per-page="-1"
+      :key="nodeId"
+      class="threshold-panel-iterator h-100"
+    >
+      <template
+        v-slot:default="{
+          items: warningLevels,
+          isExpanded: isLevelExpanded,
+          toggleExpand: toggleLevelExpand,
+        }"
       >
         <template
-          v-slot:default="{
-            items: warningLevels,
-            isExpanded: isLevelExpanded,
-            toggleExpand: toggleLevelExpand,
-          }"
+          v-for="warningLevel in warningLevels"
+          :key="warningLevel.raw.id"
         >
-          <template
-            v-for="warningLevel in warningLevels"
-            :key="warningLevel.raw.id"
+          <v-card
+            border
+            flat
+            density="compact"
+            :disabled="warningLevel.raw.thresholdCrossing?.length === 0"
+            @click="() => toggleLevelExpand(warningLevel)"
+            :ripple="false"
           >
-            <v-card
-              border
-              flat
-              density="compact"
-              :disabled="warningLevel.raw.thresholdCrossing?.length === 0"
-              @click="() => toggleLevelExpand(warningLevel)"
-              :ripple="false"
-            >
-              <v-card-text class="py-2 h-100">
-                <div class="d-flex w-100">
-                  <div class="d-flex align-center ga-1 w-100">
-                    <v-avatar
-                      start
-                      :image="warningLevel.raw.icon"
-                      rounded
-                      class="me-1 flex-0-0"
-                      size="20"
-                    ></v-avatar>
-                    <div class="flex-1-1 overflow-hidden">
-                      <div
-                        :class="{ 'text-wrap': isLevelExpanded(warningLevel) }"
-                      >
-                        {{ warningLevel.raw.name }}
-                      </div>
-                    </div>
-                    <v-avatar
-                      end
-                      :text="`${warningLevel.raw.count}`"
-                    ></v-avatar>
-                  </div>
-                </div>
-              </v-card-text>
-            </v-card>
-            <v-data-iterator
-              v-if="isLevelExpanded(warningLevel)"
-              :items="warningLevel.raw.thresholdCrossing"
-              items-per-page="-1"
-              item-value="locationId"
-              class="threshold-panel-iterator ms-2 h-50"
-            >
-              <template
-                v-slot:default="{
-                  items: crossings,
-                  isExpanded: isCrossingExpanded,
-                  toggleExpand: toggleCrossingExpand,
-                }"
-              >
-                <v-virtual-scroll
-                  :items="crossings"
-                  item-height="50px"
-                  height="100%"
-                >
-                  <template v-slot:default="{ item: crossing }">
-                    <v-card
-                      border
-                      :key="crossing.raw.locationId"
-                      flat
-                      density="compact"
-                      @click="() => toggleCrossingExpand(crossing)"
-                      :ripple="false"
-                      class="w-100"
+            <v-card-text class="py-2 h-100">
+              <div class="d-flex w-100">
+                <div class="d-flex align-center ga-1 w-100">
+                  <v-avatar
+                    start
+                    :image="warningLevel.raw.icon"
+                    rounded
+                    class="me-1 flex-0-0"
+                    size="20"
+                  ></v-avatar>
+                  <div class="flex-1-1 overflow-hidden">
+                    <div
+                      :class="{ 'text-wrap': isLevelExpanded(warningLevel) }"
                     >
-                      <v-card-text class="py-2 h-100">
-                        <div
-                          class="d-flex flex-column user-select-text cursor-pointer"
-                        >
-                          <div class="d-flex align-center ga-2">
-                            <v-list-item-title>
-                              {{ crossing.raw.locationId }}
-                            </v-list-item-title>
-                            <v-card-subtitle class="pa-0"
-                              >from
-                              {{
-                                toHumanReadableDate(crossing.raw.firstValueTime)
-                              }}</v-card-subtitle
-                            >
-                          </div>
-                          <v-card-subtitle class="pa-0">
-                            Max: {{ crossing.raw.maxValue }} @
-                            {{ toHumanReadableDate(crossing.raw.maxValueTime) }}
-                          </v-card-subtitle>
+                      {{ warningLevel.raw.name }}
+                    </div>
+                  </div>
+                  <v-avatar
+                    end
+                    :text="`${warningLevel.raw.count}`"
+                  ></v-avatar>
+                </div>
+              </div>
+            </v-card-text>
+          </v-card>
+          <v-data-iterator
+            v-if="isLevelExpanded(warningLevel)"
+            :items="warningLevel.raw.thresholdCrossing"
+            items-per-page="-1"
+            item-value="locationId"
+            class="threshold-panel-iterator ms-2 h-50"
+          >
+            <template
+              v-slot:default="{
+                items: crossings,
+                isExpanded: isCrossingExpanded,
+                toggleExpand: toggleCrossingExpand,
+              }"
+            >
+              <v-virtual-scroll
+                :items="crossings"
+                item-height="50px"
+                height="100%"
+              >
+                <template v-slot:default="{ item: crossing }">
+                  <v-card
+                    border
+                    :key="crossing.raw.locationId"
+                    flat
+                    density="compact"
+                    @click="() => toggleCrossingExpand(crossing)"
+                    :ripple="false"
+                    class="w-100"
+                  >
+                    <v-card-text class="py-2 h-100">
+                      <div
+                        class="d-flex flex-column user-select-text cursor-pointer"
+                      >
+                        <div class="d-flex align-center ga-2">
+                          <v-list-item-title>
+                            {{ crossing.raw.locationId }}
+                          </v-list-item-title>
+                          <v-card-subtitle class="pa-0"
+                            >from
+                            {{
+                              toHumanReadableDate(crossing.raw.firstValueTime)
+                            }}</v-card-subtitle
+                          >
                         </div>
-                        <DataTable
-                          v-if="isCrossingExpanded(crossing)"
-                          class="mt-4"
-                          :tableData="toTableDate(crossing.raw)"
-                        />
-                      </v-card-text>
-                    </v-card>
-                  </template>
-                </v-virtual-scroll>
-              </template>
-            </v-data-iterator>
-          </template>
+                        <v-card-subtitle class="pa-0">
+                          Max: {{ crossing.raw.maxValue }} @
+                          {{ toHumanReadableDate(crossing.raw.maxValueTime) }}
+                        </v-card-subtitle>
+                      </div>
+                      <DataTable
+                        v-if="isCrossingExpanded(crossing)"
+                        class="mt-4"
+                        :tableData="toTableDate(crossing.raw)"
+                      />
+                    </v-card-text>
+                  </v-card>
+                </template>
+              </v-virtual-scroll>
+            </template>
+          </v-data-iterator>
         </template>
-      </v-data-iterator>
-      <div v-else>No warning level crossings</div>
-    </div>
-  </Teleport>
+      </template>
+    </v-data-iterator>
+  </div>
 </template>
 
 <script setup lang="ts">
 import { useTopologyThresholds } from '@/services/useTopologyThresholds'
 import { configManager } from '@/services/application-config'
 import { getResourcesIconsUrl } from '@/lib/fews-config'
-import { computed, ref } from 'vue'
+import { computed } from 'vue'
 import {
   toDateDifferenceString,
   toDateRangeString,
@@ -144,8 +134,6 @@ interface Props {
 }
 
 const props = defineProps<Props>()
-
-const isPanelOpen = ref(false)
 
 const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
 const { thresholds: thresholdsArray } = useTopologyThresholds(
@@ -229,15 +217,15 @@ function toTableDate(crossing: AggregatedLevelThresholdCrossings) {
     },
   ]
 }
-
-function toggleThresholdPanel(): void {
-  isPanelOpen.value = !isPanelOpen.value
-}
 </script>
 
 <style scoped>
 .threshold-panel {
-  width: 450px;
+  width: 350px;
+  position: absolute;
+  top: 95px;
+  right: 5px;
+  z-index: 1000;
 }
 
 .text-wrap {

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -74,16 +74,12 @@ const allThresholdCrossings = computed(() => {
 })
 
 const thresholdCrossings = computed(() => {
-  let crossings = []
-  if (selectedLevelIds.value.length === 0) {
-    crossings = allThresholdCrossings.value.sort(
-      (a, b) => b.severity - a.severity,
-    )
-  } else {
-    crossings = allThresholdCrossings.value?.filter((crossing) =>
-      selectedLevelIds.value.includes(crossing.warningLevelId ?? ''),
-    )
-  }
+  const crossings =
+    selectedLevelIds.value.length === 0
+      ? allThresholdCrossings.value
+      : allThresholdCrossings.value?.filter((crossing) =>
+          selectedLevelIds.value.includes(crossing.warningLevelId ?? ''),
+        )
   return crossings.sort((a, b) => b.severity - a.severity)
 })
 

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -91,8 +91,8 @@ const thresholdItems = computed<CrossingItem[]>(() => {
 .threshold-panel {
   width: 230px;
   position: absolute;
-  top: 5px;
-  right: 5px;
+  top: 2px;
+  right: 2px;
   z-index: 1000;
   height: v-bind(panelHeightPx);
 }

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -19,7 +19,7 @@
             <ThresholdItem
               :crossing="crossing"
               :item-height="itemHeightPx"
-              v-model:expanded="expandedItems[crossing.locationId]"
+              v-model:expanded="expandedItems[`${crossing.locationId}-${crossing.parameterId}`]"
             />
           </template>
         </v-virtual-scroll>

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -26,7 +26,7 @@
             height="100%"
           >
             <template v-slot:default="{ item: crossing }">
-              <div class="pb-1">
+              <div class="thresold-panel-card">
                 <v-card
                   border
                   :key="crossing.raw.locationId"
@@ -39,7 +39,7 @@
                   <v-card-text class="pa-0 h-100">
                     <div class="d-flex align-center justify-space-between ga-2 h-100">
                       <div
-                        class="d-flex flex-column pa-2 overflow-hidden"
+                        class="d-flex flex-column px-2 py-0 overflow-hidden"
                       >
                         <v-list-item-title>
                           {{ crossing.raw.locationId }}
@@ -54,7 +54,7 @@
                     </div>
                     <ThresholdDataTable
                       v-if="isCrossingExpanded(crossing)"
-                      class="mt-2 ms-2"
+                      class="ms-2"
                       :tableData="toTableDate(crossing.raw)"
                     />
                   </v-card-text>
@@ -91,7 +91,7 @@ const selectedLevelIds = computed(() => selectedLevels.value.map((level) => leve
 
 const isPanelOpen = ref(false)
 
-const ITEM_HEIGHT = 56
+const ITEM_HEIGHT = 40
 const item_height_px = `${ITEM_HEIGHT}px`
 const ITEMS_PER_PANEL = 6
 const panel_height_px = `${ITEM_HEIGHT * ITEMS_PER_PANEL}px`
@@ -149,7 +149,7 @@ function toggleThresholdPanel(): void {
 
 <style scoped>
 .threshold-panel {
-  width: 300px;
+  width: 230px;
   position: absolute;
   top: 5px;
   right: 5px;
@@ -171,6 +171,10 @@ function toggleThresholdPanel(): void {
 
 .threshold-panel-iterator > * {
   height: 100%;
+}
+
+.thresold-panel-card {
+  padding-bottom: 2px;
 }
 
 .max-value {

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -1,9 +1,9 @@
 <template>
-  <template v-if="thresholdCrossings?.length">
+  <template v-if="allThresholdCrossings.length">
     <Teleport to="#threshold-summary-top" defer>
-      <v-btn class="ms-0 ps-0" @click="toggleThresholdPanel">
-        <v-icon v-if="isPanelOpen">mdi-menu-close</v-icon>
-        <v-icon v-else>mdi-menu-open</v-icon>
+      <v-btn class="ms-0 ps-0" @click="toggleThresholdPanel" :disabled="thresholdCrossings.length === 0">
+        <v-icon v-if="!isPanelOpen">mdi-menu-open</v-icon>
+        <v-icon v-else>mdi-menu-close</v-icon>
       </v-btn>
     </Teleport>
     <div v-if="isPanelOpen" class="threshold-panel d-flex flex-column">
@@ -104,11 +104,21 @@ const { thresholds: thresholdsArray } = useTopologyThresholds(
   () => props.nodeId,
 )
 
-const thresholdCrossings = computed(() => {
+const allThresholdCrossings = computed(() => {
   if (thresholdsArray.value === undefined || thresholdsArray.value.length === 0)
     return []
-  const thresholds = thresholdsArray.value[0]
-  return thresholds.levelThresholdCrossings?.filter((crossing) => selectedLevelIds.value.includes(crossing.warningLevelId ?? '')).sort((a, b) => b.severity - a.severity)
+  return thresholdsArray.value[0].levelThresholdCrossings ?? []
+})
+
+const thresholdCrossings = computed(() => {
+  let crossings = []
+  if (selectedLevelIds.value.length === 0) {
+    crossings = allThresholdCrossings.value.sort((a, b) => b.severity - a.severity)
+  }
+  else {
+    crossings = allThresholdCrossings.value?.filter((crossing) => selectedLevelIds.value.includes(crossing.warningLevelId ?? ''))
+  }
+  return crossings.sort((a, b) => b.severity - a.severity)
 })
 
 function toTableDate(crossing: LevelThresholdCrossings) {

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -18,6 +18,7 @@
           <template v-slot:default="{ item: crossing }">
             <ThresholdItem
               :crossing="crossing"
+              :location="getLocationById(crossing.locationId)"
               :item-height="itemHeightPx"
               v-model:expanded="expandedItems[`${crossing.locationId}-${crossing.parameterId}`]"
             />
@@ -34,9 +35,11 @@ import { configManager } from '@/services/application-config'
 import { computed, inject, ref } from 'vue'
 import { LevelThresholdWarningLevels } from '@deltares/fews-pi-requests'
 import ThresholdItem from '@/components/general/ThresholdItem.vue'
+import type { Location } from '@deltares/fews-pi-requests'
 
 interface Props {
   nodeId?: string
+  filteredLocations?: Location[]
 }
 
 const props = defineProps<Props>()
@@ -76,6 +79,10 @@ const thresholdCrossings = computed(() => {
   }
   return crossings.sort((a, b) => b.severity - a.severity)
 })
+
+function getLocationById(locationId: string) {
+  return props.filteredLocations?.find((location) => location.locationId === locationId)
+}
 
 function toggleThresholdPanel(): void {
   isPanelOpen.value = !isPanelOpen.value

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -55,7 +55,7 @@
                     <ThresholdDataTable
                       v-if="isCrossingExpanded(crossing)"
                       class="ms-2"
-                      :tableData="toTableDate(crossing.raw)"
+                      :crossing="crossing.raw"
                     />
                   </v-card-text>
                 </v-card>
@@ -72,11 +72,8 @@
 import { useTopologyThresholds } from '@/services/useTopologyThresholds'
 import { configManager } from '@/services/application-config'
 import { computed, inject, ref } from 'vue'
-import {
-  toDateRangeString,
-  toHumanReadableDate,
-} from '@/lib/date'
-import { LevelThresholdCrossings, LevelThresholdWarningLevels } from '@deltares/fews-pi-requests'
+import { toHumanReadableDate } from '@/lib/date'
+import { LevelThresholdWarningLevels } from '@deltares/fews-pi-requests'
 import ThresholdDataTable from '@/components/general/ThresholdDataTable.vue'
 import { getContrastColor } from "@/lib/charts/styles"
 
@@ -119,28 +116,6 @@ const thresholdCrossings = computed(() => {
   }
   return crossings.sort((a, b) => b.severity - a.severity)
 })
-
-function toTableDate(crossing: LevelThresholdCrossings) {
-  return [
-    {
-      header: 'Warning level',
-      value: crossing.warningLevelName,
-    },
-  
-    {
-      header: 'Time to event',
-      value: crossing.firstValueTime,
-    },
-  
-    {
-      header: 'Event duration',
-      value: toDateRangeString(
-        crossing.firstValueTime,
-        crossing.lastValueTime,
-      ),
-    },
-  ]
-}
 
 function toggleThresholdPanel(): void {
   isPanelOpen.value = !isPanelOpen.value

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -39,7 +39,7 @@
                   <v-card-text class="pa-0 h-100">
                     <div class="d-flex align-center justify-space-between ga-2 h-100">
                       <div
-                        class="d-flex flex-column pa-2"
+                        class="d-flex flex-column pa-2 overflow-hidden"
                       >
                         <v-list-item-title>
                           {{ crossing.raw.locationId }}
@@ -48,7 +48,7 @@
                           {{ toHumanReadableDate(crossing.raw.maxValueTime) }}
                         </v-card-subtitle>
                       </div>
-                      <div class="max-value" :style="{background: crossing.raw.color, color: getContrastColor(crossing.raw.color)}">
+                      <div class="max-value flex-shrink-0" :style="{background: crossing.raw.color, color: getContrastColor(crossing.raw.color)}">
                           {{ crossing.raw.maxValue }}
                       </div>
                     </div>

--- a/src/components/general/ThresholdPanel.vue
+++ b/src/components/general/ThresholdPanel.vue
@@ -7,63 +7,19 @@
       </v-btn>
     </Teleport>
     <div v-if="isPanelOpen" class="threshold-panel d-flex flex-column">
-      <v-data-iterator
-        :items="thresholdCrossings"
-        items-per-page="-1"
-        item-value="locationId"
+      <div
         class="threshold-panel-iterator ms-2 h-100"
       >
-        <template
-          v-slot:default="{
-            items: crossings,
-            isExpanded: isCrossingExpanded,
-            toggleExpand: toggleCrossingExpand,
-          }"
+        <v-virtual-scroll
+          :items="thresholdCrossings"
+          :item-height="itemHeightPx"
+          height="100%"
         >
-          <v-virtual-scroll
-            :items="crossings"
-            :item-height="item_height_px"
-            height="100%"
-          >
-            <template v-slot:default="{ item: crossing }">
-              <div class="thresold-panel-card">
-                <v-card
-                  border
-                  :key="crossing.raw.locationId"
-                  flat
-                  density="compact"
-                  @click="() => toggleCrossingExpand(crossing)"
-                  :ripple="false"
-                  class="w-100"
-                >
-                  <v-card-text class="pa-0 h-100">
-                    <div class="d-flex align-center justify-space-between ga-2 h-100">
-                      <div
-                        class="d-flex flex-column px-2 py-0 overflow-hidden"
-                      >
-                        <v-list-item-title>
-                          {{ crossing.raw.locationId }}
-                        </v-list-item-title>
-                        <v-card-subtitle class="pa-0">
-                          {{ toHumanReadableDate(crossing.raw.maxValueTime) }}
-                        </v-card-subtitle>
-                      </div>
-                      <div class="max-value flex-shrink-0" :style="{background: crossing.raw.color, color: getContrastColor(crossing.raw.color)}">
-                          {{ crossing.raw.maxValue }}
-                      </div>
-                    </div>
-                    <ThresholdDataTable
-                      v-if="isCrossingExpanded(crossing)"
-                      class="ms-2"
-                      :crossing="crossing.raw"
-                    />
-                  </v-card-text>
-                </v-card>
-              </div>
-            </template>
-          </v-virtual-scroll>
-        </template>
-      </v-data-iterator>
+          <template v-slot:default="{ item: crossing }">
+            <ThresholdItem :crossing="crossing" :item-height="itemHeightPx"/>
+          </template>
+        </v-virtual-scroll>
+      </div>
     </div>
   </template>
 </template>
@@ -72,10 +28,8 @@
 import { useTopologyThresholds } from '@/services/useTopologyThresholds'
 import { configManager } from '@/services/application-config'
 import { computed, inject, ref } from 'vue'
-import { toHumanReadableDate } from '@/lib/date'
 import { LevelThresholdWarningLevels } from '@deltares/fews-pi-requests'
-import ThresholdDataTable from '@/components/general/ThresholdDataTable.vue'
-import { getContrastColor } from "@/lib/charts/styles"
+import ThresholdItem from '@/components/general/ThresholdItem.vue'
 
 interface Props {
   nodeId?: string
@@ -89,7 +43,7 @@ const selectedLevelIds = computed(() => selectedLevels.value.map((level) => leve
 const isPanelOpen = ref(false)
 
 const ITEM_HEIGHT = 40
-const item_height_px = `${ITEM_HEIGHT}px`
+const itemHeightPx = `${ITEM_HEIGHT}px`
 const ITEMS_PER_PANEL = 6
 const panel_height_px = `${ITEM_HEIGHT * ITEMS_PER_PANEL}px`
   
@@ -150,16 +104,6 @@ function toggleThresholdPanel(): void {
 
 .thresold-panel-card {
   padding-bottom: 2px;
-}
-
-.max-value {
-  height: v-bind(item_height_px);
-  width: 50px;
-  text-align: center;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-size: 0.75em;
 }
 
 :deep(.v-list-item-title) {

--- a/src/components/general/ThresholdSummary.vue
+++ b/src/components/general/ThresholdSummary.vue
@@ -3,7 +3,12 @@
     <div v-if="warningLevels?.length" class="threshold-summary-container">
       <div class="threshold-summary-top" id="threshold-summary-top">
       </div>
-      <v-list v-model:selected="selectedLevelIds" select-strategy="leaf" class="threshold-summary-center">
+      <v-list
+        v-model:selected="selectedLevelIds"
+        select-strategy="leaf"
+        class="threshold-summary-center"
+        lines="two"
+      >
         <v-list-item
           v-for="warningLevel in warningLevels"
           :key="warningLevel.id"
@@ -11,7 +16,7 @@
           label
           size="small"
           density="compact"
-          class="ma-0 py-1 px-0 w-100 flex-nowrap"
+          class="ma-0 py-1 px-0 w-100 flex-nowrap overflow-hidden"
         >
           <div class="d-flex align-center flex-column flex-nowrap w-100">
             <v-badge
@@ -24,9 +29,9 @@
             >
               <v-img width="30px" :src="warningLevel.icon"></v-img>
             </v-badge>
-            <span class="warning-label" style="width: 65px;">
+            <v-list-item-subtitle>
               {{ warningLevel.name }}
-            </span>
+            </v-list-item-subtitle>
           </div>
         </v-list-item>
       </v-list>
@@ -115,14 +120,10 @@ const warningLevels = computed(() => {
   text-align: center;
 }
 
-.warning-label {
-  width: 100%;
-  text-align: center;
-  font-size: 0.875em;
-  overflow-wrap: unset !important;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
+.v-list-item-subtitle {
+  font-size: 0.8em;
+  color: var(--v-theme-on-surface);
+  opacity: 1;
 }
 
 :deep(.v-list-item__content) {

--- a/src/components/general/ThresholdSummary.vue
+++ b/src/components/general/ThresholdSummary.vue
@@ -92,7 +92,7 @@ const showButton = computed(() => {
   // We check the route to check if the map display tab is selected.
   const isMapVisible =
     nodeHasMap(topologyNode) &&
-    route.name?.toString().includes('SpatialDisplay')
+    /Spatial.*Display/.test(route.name?.toString() ?? '')
   return isMapVisible
 })
 </script>

--- a/src/components/general/ThresholdSummary.vue
+++ b/src/components/general/ThresholdSummary.vue
@@ -16,9 +16,9 @@
           label
           size="small"
           density="compact"
-          class="ma-0 py-1 px-0 w-100 flex-nowrap overflow-hidden"
+          class="ma-0 py-3 px-0 w-100 flex-nowrap overflow-hidden"
         >
-          <div class="d-flex align-center flex-column flex-nowrap w-100">
+          <div class="d-flex align-center flex-column flex-nowrap px-1">
             <v-badge
               color="#dcdddc"
               :model-value="(warningLevel.count ?? 0) > 0"

--- a/src/components/general/ThresholdSummary.vue
+++ b/src/components/general/ThresholdSummary.vue
@@ -82,7 +82,7 @@ const aggregatedWarningLevels = computed(() => {
     return []
   const aggregatedLevels =
     thresholdsArray.value[0]?.aggregatedLevelThresholdWarningLevels
-  return aggregatedLevels !== undefined ? aggregatedLevels : []
+  return aggregatedLevels ?? []
 })
 
 const warningLevels = computed(() => {

--- a/src/components/general/ThresholdSummary.vue
+++ b/src/components/general/ThresholdSummary.vue
@@ -20,13 +20,15 @@
         >
           <div class="d-flex align-center flex-column flex-nowrap px-1">
             <v-badge
-              color="#dcdddc"
               :model-value="(warningLevel.count ?? 0) > 0"
-              :content="warningLevel.count"
-              location="top start"
-              offset-x="8"
+              location="top end"
+              offset-x="5"
               offset-y="1"
+              color="transparent"
             >
+            <template #badge>
+              <v-chip size="small" density="compact" class="pa-0 px-1">{{ warningLevel.count }}</v-chip>
+            </template>
               <v-img width="30px" :src="warningLevel.icon"></v-img>
             </v-badge>
             <v-list-item-subtitle>

--- a/src/components/general/ThresholdSummary.vue
+++ b/src/components/general/ThresholdSummary.vue
@@ -116,6 +116,8 @@ const warningLevels = computed(() => {
 .threshold-summary-top {
   grid-row: 1;
   height: 36px;
+  display: flex;
+  justify-content: center;
 }
 
 .threshold-summary-center {

--- a/src/components/general/ThresholdSummary.vue
+++ b/src/components/general/ThresholdSummary.vue
@@ -1,7 +1,7 @@
 <template>
-  <Teleport to="#main-side-panel-left">
+  <Teleport to="#main-side-panel">
     <div v-if="warningLevels?.length" class="threshold-summary h-100 d-flex justify-center flex-column flex-wrap">
-      <div class="align-self-end flex-0-0" id="threshold-summary-top">
+      <div class="align-self-start flex-0-0" id="threshold-summary-top">
       </div>
       <div class="d-flex flex-1-0 flex-column justify-center">
         <v-list-item

--- a/src/components/general/ThresholdSummary.vue
+++ b/src/components/general/ThresholdSummary.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="#main-side-panel">
+  <Teleport to="#secondary-side-panel-end">
     <div v-if="warningLevels?.length" class="threshold-summary-container">
       <div class="threshold-summary-top" id="threshold-summary-top">
       </div>

--- a/src/components/general/ThresholdSummary.vue
+++ b/src/components/general/ThresholdSummary.vue
@@ -2,7 +2,7 @@
   <Teleport to="#secondary-side-panel-end" defer>
     <div
       v-if="warningLevelsStore.warningLevels.length"
-      class="threshold-summary-container border-s"
+      class="threshold-summary-container"
     >
       <div v-show="showButton" class="threshold-summary-top">
         <v-btn

--- a/src/components/general/ThresholdSummary.vue
+++ b/src/components/general/ThresholdSummary.vue
@@ -49,8 +49,9 @@ const warningLevels = computed(() => {
   if (thresholdsArray.value === undefined || thresholdsArray.value.length === 0)
     return []
   const thresholds = thresholdsArray.value[0]
-  return thresholds.aggregatedLevelThresholdWarningLevels
-    ?.map((warningLevel) => {
+  if (thresholds.aggregatedLevelThresholdWarningLevels === undefined) return []
+  const levels = thresholds.aggregatedLevelThresholdWarningLevels
+    .map((warningLevel) => {
       return {
         ...warningLevel,
         ...{
@@ -61,6 +62,10 @@ const warningLevels = computed(() => {
       }
     })
     .sort((a, b) => b.severity - a.severity)
+  // The warning level with the lowest severity is always the default "no thresholds" level.
+  // That level should not be shown in list of warning levels
+  levels.pop()
+  return levels
 })
 </script>
 

--- a/src/components/general/ThresholdSummary.vue
+++ b/src/components/general/ThresholdSummary.vue
@@ -1,8 +1,7 @@
 <template>
   <Teleport to="#secondary-side-panel-end">
     <div v-if="warningLevels?.length" class="threshold-summary-container">
-      <div class="threshold-summary-top" id="threshold-summary-top">
-      </div>
+      <div class="threshold-summary-top" id="threshold-summary-top"></div>
       <v-list
         v-model:selected="selectedLevelIds"
         select-strategy="leaf"
@@ -26,9 +25,11 @@
               offset-y="1"
               color="transparent"
             >
-            <template #badge>
-              <v-chip size="small" density="compact" class="pa-0 px-1">{{ warningLevel.count }}</v-chip>
-            </template>
+              <template #badge>
+                <v-chip size="small" density="compact" class="pa-0 px-1">{{
+                  warningLevel.count
+                }}</v-chip>
+              </template>
               <v-img width="30px" :src="warningLevel.icon"></v-img>
             </v-badge>
             <v-list-item-subtitle>
@@ -62,20 +63,25 @@ const { thresholds: thresholdsArray } = useTopologyThresholds(
 
 const selectedLevelIds = ref<string[]>([])
 
-const selectedLevels = defineModel<LevelThresholdWarningLevels[]>({default: () => [] })
+const selectedLevels = defineModel<LevelThresholdWarningLevels[]>({
+  default: () => [],
+})
 
 watch(selectedLevelIds, () => {
   if (selectedLevelIds.value.length === 0) {
     selectedLevels.value = aggregatedWarningLevels.value
   } else {
-    selectedLevels.value = aggregatedWarningLevels.value.filter((level) => selectedLevelIds.value.includes(level.id))
+    selectedLevels.value = aggregatedWarningLevels.value.filter((level) =>
+      selectedLevelIds.value.includes(level.id),
+    )
   }
 })
 
 const aggregatedWarningLevels = computed(() => {
   if (thresholdsArray.value === undefined || thresholdsArray.value.length === 0)
     return []
-  const aggregatedLevels = thresholdsArray.value[0]?.aggregatedLevelThresholdWarningLevels
+  const aggregatedLevels =
+    thresholdsArray.value[0]?.aggregatedLevelThresholdWarningLevels
   return aggregatedLevels !== undefined ? aggregatedLevels : []
 })
 

--- a/src/components/general/ThresholdSummary.vue
+++ b/src/components/general/ThresholdSummary.vue
@@ -1,30 +1,32 @@
 <template>
   <Teleport to="#main-side-panel">
     <div v-if="warningLevels?.length" class="threshold-summary h-100 d-flex justify-center flex-column flex-wrap">
-      <div class="align-self-start flex-0-0" id="threshold-summary-top">
+      <div class="align-self-start flex-0-0 w-100" id="threshold-summary-top">
       </div>
-      <div class="d-flex flex-1-0 flex-column justify-center">
+      <div class="d-flex flex-1-0 flex-column justify-center w-100">
         <v-list-item
           v-for="warningLevel in warningLevels"
           :key="warningLevel.id"
           label
           size="small"
           density="compact"
-          class="ma-0 pa-1 w-100"
+          class="ma-0 py-1 px-0 w-100 flex-nowrap"
         >
-          <div class="d-flex align-center flex-column">
-            <v-list-item-title>
-              <v-img width="40px" :src="warningLevel.icon"></v-img>
-            </v-list-item-title>
-            <v-list-item-subtitle>
+          <div class="d-flex align-center flex-column flex-nowrap w-100">
+            <v-badge
+              color="#dcdddc"
+              :model-value="(warningLevel.count ?? 0) > 0"
+              :content="warningLevel.count"
+              location="top start"
+              offset-x="8"
+              offset-y="1"
+            >
+              <v-img width="30px" :src="warningLevel.icon"></v-img>
+            </v-badge>
+            <span class="warning-label" style="width: 65px;">
               {{ warningLevel.name }}
-            </v-list-item-subtitle>
+            </span>
           </div>
-          <template v-slot:append>
-            <v-list-item-subtitle>
-              {{ warningLevel.count }}
-            </v-list-item-subtitle>
-          </template>
         </v-list-item>
       </div>
     </div>
@@ -75,6 +77,28 @@ const warningLevels = computed(() => {
 
 <style scoped>
 .threshold-summary {
-  width: 80px;
+  width: 65px;
+}
+
+.warning-count {
+  text-align: center;
+}
+
+.warning-label {
+  width: 100%;
+  text-align: center;
+  font-size: 0.875em;
+  overflow-wrap: unset !important;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+:deep(.v-list-item__content) {
+  overflow: visible !important;
+}
+
+:deep(.v-chip__content) {
+  width: 100%;
 }
 </style>

--- a/src/components/general/ThresholdSummary.vue
+++ b/src/components/general/ThresholdSummary.vue
@@ -59,6 +59,7 @@
 import { computed, watch } from 'vue'
 import { useWarningLevelsStore } from '@/stores/warningLevels'
 import { useTopologyNodesStore } from '@/stores/topologyNodes'
+import { useParametersStore } from '@/stores/parameters'
 import { nodeHasMap } from '@/lib/topology/nodes'
 import { useRoute } from 'vue-router'
 interface Props {
@@ -68,6 +69,7 @@ interface Props {
 const props = defineProps<Props>()
 const warningLevelsStore = useWarningLevelsStore()
 const topologyNodesStore = useTopologyNodesStore()
+useParametersStore()
 
 watch(
   () => props.nodeId,

--- a/src/components/general/ThresholdSummary.vue
+++ b/src/components/general/ThresholdSummary.vue
@@ -1,28 +1,33 @@
 <template>
   <Teleport to="#main-side-panel-left" defer>
-    <div v-if="warningLevels?.length" class="threshold-summary h-100 flex-wrap">
-      <v-list-item
-        v-for="warningLevel in warningLevels"
-        :key="warningLevel.id"
-        label
-        size="small"
-        density="compact"
-        class="ma-0 pa-1"
-      >
-        <div class="d-flex align-center flex-column">
-          <v-list-item-title>
-            <v-img width="40px" :src="warningLevel.icon"></v-img>
-          </v-list-item-title>
-          <v-list-item-subtitle>
-            {{ warningLevel.name }}
-          </v-list-item-subtitle>
-        </div>
-        <template v-slot:append>
-          <v-list-item-subtitle>
-            {{ warningLevel.count }}
-          </v-list-item-subtitle>
-        </template>
-      </v-list-item>
+    <div v-if="warningLevels?.length" class="threshold-summary h-100 d-flex justify-center flex-column flex-wrap">
+      <div class="align-self-end flex-0-0">
+        <v-btn disabled icon="mdi-menu-open"></v-btn>
+      </div>
+      <div class="d-flex flex-1-0 flex-column justify-center">
+        <v-list-item
+          v-for="warningLevel in warningLevels"
+          :key="warningLevel.id"
+          label
+          size="small"
+          density="compact"
+          class="ma-0 pa-1 w-100"
+        >
+          <div class="d-flex align-center flex-column">
+            <v-list-item-title>
+              <v-img width="40px" :src="warningLevel.icon"></v-img>
+            </v-list-item-title>
+            <v-list-item-subtitle>
+              {{ warningLevel.name }}
+            </v-list-item-subtitle>
+          </div>
+          <template v-slot:append>
+            <v-list-item-subtitle>
+              {{ warningLevel.count }}
+            </v-list-item-subtitle>
+          </template>
+        </v-list-item>
+      </div>
     </div>
   </Teleport>
 </template>
@@ -72,9 +77,5 @@ const warningLevels = computed(() => {
 <style scoped>
 .threshold-summary {
   width: 80px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  flex: 0 0 auto;
 }
 </style>

--- a/src/components/general/ThresholdSummary.vue
+++ b/src/components/general/ThresholdSummary.vue
@@ -30,7 +30,7 @@
           density="compact"
           class="ma-0 py-3 px-0 w-100 flex-nowrap overflow-hidden"
         >
-          <div class="d-flex align-center flex-column flex-nowrap px-1">
+          <div class="d-flex align-center flex-column flex-nowrap px-1 w-100">
             <v-badge
               :model-value="(warningLevel.count ?? 0) > 0"
               location="top end"
@@ -126,10 +126,13 @@ const showButton = computed(() => {
   font-size: 0.8em;
   color: var(--v-theme-on-surface);
   opacity: 1;
+  width: 100%;
+  text-align:center;
 }
 
 :deep(.v-list-item__content) {
   overflow: visible !important;
+  width: 65px;
 }
 
 :deep(.v-chip__content) {

--- a/src/components/general/ThresholdSummary.vue
+++ b/src/components/general/ThresholdSummary.vue
@@ -1,6 +1,9 @@
 <template>
   <Teleport to="#secondary-side-panel-end">
-    <div v-if="warningLevels?.length" class="threshold-summary-container">
+    <div
+      v-if="warningLevels?.length"
+      class="threshold-summary-container border-s"
+    >
       <div class="threshold-summary-top" id="threshold-summary-top"></div>
       <v-list
         v-model:selected="selectedLevelIds"

--- a/src/components/general/ThresholdSummary.vue
+++ b/src/components/general/ThresholdSummary.vue
@@ -1,9 +1,9 @@
 <template>
   <Teleport to="#main-side-panel">
-    <div v-if="warningLevels?.length" class="threshold-summary h-100 d-flex justify-center flex-column flex-wrap">
-      <div class="align-self-start flex-0-0 w-100" id="threshold-summary-top">
+    <div v-if="warningLevels?.length" class="threshold-summary-container">
+      <div class="threshold-summary-top" id="threshold-summary-top">
       </div>
-      <v-list v-model:selected="selectedLevelIds" select-strategy="leaf" class="d-flex flex-1-0 flex-column justify-center w-100 pa-0 overflow-hidden">
+      <v-list v-model:selected="selectedLevelIds" select-strategy="leaf" class="threshold-summary-center">
         <v-list-item
           v-for="warningLevel in warningLevels"
           :key="warningLevel.id"
@@ -93,8 +93,22 @@ const warningLevels = computed(() => {
 </script>
 
 <style scoped>
-.threshold-summary {
+.threshold-summary-container {
   width: 65px;
+  display: grid;
+  grid-template-rows: 1fr auto 1fr;
+  height: 100%;
+}
+
+.threshold-summary-top {
+  grid-row: 1;
+  height: 36px;
+}
+
+.threshold-summary-center {
+  grid-row: 2;
+  height: 100%;
+  align-self: center;
 }
 
 .warning-count {

--- a/src/components/general/ThresholdSummary.vue
+++ b/src/components/general/ThresholdSummary.vue
@@ -1,8 +1,7 @@
 <template>
-  <Teleport to="#main-side-panel-left" defer>
+  <Teleport to="#main-side-panel-left">
     <div v-if="warningLevels?.length" class="threshold-summary h-100 d-flex justify-center flex-column flex-wrap">
-      <div class="align-self-end flex-0-0">
-        <v-btn disabled icon="mdi-menu-open"></v-btn>
+      <div class="align-self-end flex-0-0" id="threshold-summary-top">
       </div>
       <div class="d-flex flex-1-0 flex-column justify-center">
         <v-list-item

--- a/src/components/general/ThresholdSummary.vue
+++ b/src/components/general/ThresholdSummary.vue
@@ -127,7 +127,7 @@ const showButton = computed(() => {
   color: var(--v-theme-on-surface);
   opacity: 1;
   width: 100%;
-  text-align:center;
+  text-align: center;
 }
 
 :deep(.v-list-item__content) {

--- a/src/components/general/ThresholdSummary.vue
+++ b/src/components/general/ThresholdSummary.vue
@@ -1,6 +1,6 @@
 <template>
   <Teleport to="#main-side-panel-left" defer>
-    <div class="threshold-summary h-100 flex-wrap">
+    <div v-if="warningLevels?.length" class="threshold-summary h-100 flex-wrap">
       <v-list-item
         v-for="warningLevel in warningLevels"
         :key="warningLevel.id"

--- a/src/components/general/TreeMenuItem.vue
+++ b/src/components/general/TreeMenuItem.vue
@@ -8,7 +8,7 @@
               <v-badge
                 color="#00BBF0"
                 :model-value="(item.thresholdCount ?? 0) > 0"
-                :content="item.thresholdCount"
+                content="!"
               >
                 <v-icon
                   :icon="
@@ -63,7 +63,7 @@
           <v-badge
             color="#00BBF0"
             :model-value="(item.thresholdCount ?? 0) > 0"
-            :content="item.thresholdCount"
+            content="!"
           >
             <v-icon :icon="item.icon ?? toCharacterIcon(item.name)"></v-icon>
           </v-badge>

--- a/src/components/general/TreeMenuItem.vue
+++ b/src/components/general/TreeMenuItem.vue
@@ -105,7 +105,6 @@ const props = withDefaults(defineProps<Props>(), {
 /* To counter act being moved by the above border */
 .tree-menu--list-item > :deep(.v-list-item__prepend) {
   margin-left: -4px;
-  align-self: flex-start;
 }
 
 .tree-menu--list-group :deep(.v-list-group__items .v-list-item) {
@@ -142,12 +141,5 @@ const props = withDefaults(defineProps<Props>(), {
   .v-list-group__items
   .v-list-group {
   --prepend-width: 0px;
-}
-
-.v-navigation-drawer--rail:not(.v-navigation-drawer--is-hovering)
-  .threshold-summary--list-item {
-  padding-left: 0px;
-  padding-right: 0px;
-  padding-inline-start: 2px !important;
 }
 </style>

--- a/src/components/general/TreeMenuItem.vue
+++ b/src/components/general/TreeMenuItem.vue
@@ -8,7 +8,7 @@
               <v-badge
                 color="#00BBF0"
                 :model-value="(item.thresholdCount ?? 0) > 0"
-                content="!"
+                :content="(item.thresholdCount ?? 0) > 0 ? '!' : undefined"
               >
                 <v-icon
                   :icon="
@@ -63,7 +63,7 @@
           <v-badge
             color="#00BBF0"
             :model-value="(item.thresholdCount ?? 0) > 0"
-            content="!"
+            :content="(item.thresholdCount ?? 0) > 0 ? '!' : undefined"
           >
             <v-icon :icon="item.icon ?? toCharacterIcon(item.name)"></v-icon>
           </v-badge>

--- a/src/components/general/TreeMenuItem.vue
+++ b/src/components/general/TreeMenuItem.vue
@@ -5,17 +5,20 @@
         <template v-slot:activator="{ props }">
           <v-list-item v-bind="props">
             <template v-slot:prepend>
-              <v-badge
-                color="#00BBF0"
-                :model-value="(item.thresholdCount ?? 0) > 0"
-                :content="(item.thresholdCount ?? 0) > 0 ? '!' : undefined"
-              >
+              <div class="icon-container">
                 <v-icon
                   :icon="
                     item.icon ?? toCharacterIcon(item.name, '-circle-outline')
                   "
                 ></v-icon>
-              </v-badge>
+                <v-icon
+                  v-if="(item.thresholdCount ?? 0) > 0"
+                  class="alert-icon"
+                  size="x-small"
+                  color="#00BBF0"
+                  icon="mdi-alert-circle"
+                ></v-icon>
+              </div>
             </template>
             <v-list-item-title>{{ item.name }}</v-list-item-title>
             <template v-slot:append="{ isActive }">
@@ -60,13 +63,16 @@
         class="tree-menu--list-item"
       >
         <template v-slot:prepend>
-          <v-badge
-            color="#00BBF0"
-            :model-value="(item.thresholdCount ?? 0) > 0"
-            :content="(item.thresholdCount ?? 0) > 0 ? '!' : undefined"
-          >
+          <div class="icon-container">
             <v-icon :icon="item.icon ?? toCharacterIcon(item.name)"></v-icon>
-          </v-badge>
+            <v-icon
+              v-if="(item.thresholdCount ?? 0) > 0"
+              class="alert-icon"
+              size="x-small"
+              color="#00BBF0"
+              icon="mdi-alert-circle"
+            ></v-icon>
+          </div>
         </template>
         <v-list-item-title>{{ item.name }}</v-list-item-title>
         <template v-slot:append>
@@ -115,6 +121,24 @@ const props = withDefaults(defineProps<Props>(), {
 
 :deep(.v-list-item__spacer) {
   width: 12px !important;
+}
+
+.icon-container {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.alert-icon {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background-color: rgba(
+    var(--v-theme-surface),
+    var(--v-high-emphasis-opacity)
+  );
+  border-radius: 50%;
 }
 </style>
 

--- a/src/components/logdisplay/TaskRunItem.vue
+++ b/src/components/logdisplay/TaskRunItem.vue
@@ -61,7 +61,7 @@ import {
 } from '@/lib/log'
 import { computed } from 'vue'
 import {
-  toDateDifferenceString,
+  toDateAbsDifferenceString,
   toDateRangeString,
   toHumanReadableDate,
 } from '@/lib/date'
@@ -123,7 +123,7 @@ const tableData = computed(() => [
     columns: [
       {
         header: `Output time span`,
-        subHeader: toDateDifferenceString(
+        subHeader: toDateAbsDifferenceString(
           props.taskRun?.outputStartTime,
           props.taskRun?.outputEndTime,
         ),
@@ -138,7 +138,7 @@ const tableData = computed(() => [
     columns: [
       {
         header: 'Task duration',
-        subHeader: toDateDifferenceString(
+        subHeader: toDateAbsDifferenceString(
           props.taskRun?.dispatchTime,
           props.taskRun?.completionTime,
         ),

--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -18,9 +18,7 @@
         @update:current-time="currentTime = $event"
         @coordinate-click="onCoordinateClick"
       ></SpatialDisplayComponent>
-      <ThresholdPanel
-        :filteredLocations="filteredLocations"
-      ></ThresholdPanel>
+      <ThresholdPanel :locations="locations"></ThresholdPanel>
     </div>
     <div v-if="showChartPanel" class="child-container">
       <SpatialTimeSeriesDisplay

--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -18,7 +18,7 @@
         @update:current-time="currentTime = $event"
         @coordinate-click="onCoordinateClick"
       ></SpatialDisplayComponent>
-      <ThresholdPanel :nodeId="topologyNode?.id"></ThresholdPanel>
+      <ThresholdPanel :nodeId="topologyNode?.id" :filteredLocations="filteredLocations"></ThresholdPanel>
     </div>
     <div v-if="showChartPanel" class="child-container">
       <SpatialTimeSeriesDisplay

--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -18,7 +18,10 @@
         @update:current-time="currentTime = $event"
         @coordinate-click="onCoordinateClick"
       ></SpatialDisplayComponent>
-      <ThresholdPanel :nodeId="topologyNode?.id" :filteredLocations="filteredLocations"></ThresholdPanel>
+      <ThresholdPanel
+        :nodeId="topologyNode?.id"
+        :filteredLocations="filteredLocations"
+      ></ThresholdPanel>
     </div>
     <div v-if="showChartPanel" class="child-container">
       <SpatialTimeSeriesDisplay
@@ -112,15 +115,25 @@ const { layerCapabilities, times } = useWmsLayerCapabilities(
 )
 const { locations, geojson } = useFilterLocations(baseUrl, filterIds)
 
-const selectedWarningLevelSeverity = computed(() => selectedWarningLevels.value.map((level) => level.severity))
+const selectedWarningLevelSeverity = computed(() =>
+  selectedWarningLevels.value.map((level) => level.severity),
+)
 const filteredLocations = computed(() => {
   if (selectedWarningLevelSeverity.value.length === 0) return locations.value
-  return locations.value?.filter((location) => selectedWarningLevelSeverity.value.includes(location.thresholdSeverity ?? 0))
+  return locations.value?.filter((location) =>
+    selectedWarningLevelSeverity.value.includes(
+      location.thresholdSeverity ?? 0,
+    ),
+  )
 })
 const filteredGeojson = computed(() => {
   if (selectedWarningLevelSeverity.value.length === 0) return geojson.value
-  const filteredFeatures = geojson.value.features.filter((feature) => selectedWarningLevelSeverity.value.includes(feature.properties.thresholdSeverity ?? 0))
-  return {...geojson.value, ...{features: filteredFeatures}}
+  const filteredFeatures = geojson.value.features.filter((feature) =>
+    selectedWarningLevelSeverity.value.includes(
+      feature.properties.thresholdSeverity ?? 0,
+    ),
+  )
+  return { ...geojson.value, ...{ features: filteredFeatures } }
 })
 
 const start = computed(() => {

--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -112,26 +112,15 @@ const { layerCapabilities, times } = useWmsLayerCapabilities(
 )
 const { locations, geojson } = useFilterLocations(baseUrl, filterIds)
 
-// FIXME: Use the 'severity' instead of the icon, once the backend return the 'severity' with the locations
-const selectedWarningLevelIcons = computed(() =>
-  selectedWarningLevels.value.map((level) => level.icon ?? 'no-threshold-icon'),
-)
+const selectedWarningLevelSeverity = computed(() => selectedWarningLevels.value.map((level) => level.severity))
 const filteredLocations = computed(() => {
-  if (selectedWarningLevelIcons.value.length === 0) return locations.value
-  return locations.value?.filter((location) =>
-    selectedWarningLevelIcons.value.includes(
-      location.thresholdIconName ?? 'no-threshold-icon',
-    ),
-  )
+  if (selectedWarningLevelSeverity.value.length === 0) return locations.value
+  return locations.value?.filter((location) => selectedWarningLevelSeverity.value.includes(location.thresholdSeverity ?? 0))
 })
 const filteredGeojson = computed(() => {
-  if (selectedWarningLevelIcons.value.length === 0) return geojson.value
-  const filteredFeatures = geojson.value.features.filter((feature) =>
-    selectedWarningLevelIcons.value.includes(
-      feature.properties.thresholdIconName ?? 'no-threshold-icon',
-    ),
-  )
-  return { ...geojson.value, ...{ features: filteredFeatures } }
+  if (selectedWarningLevelSeverity.value.length === 0) return geojson.value
+  const filteredFeatures = geojson.value.features.filter((feature) => selectedWarningLevelSeverity.value.includes(feature.properties.thresholdSeverity ?? 0))
+  return {...geojson.value, ...{features: filteredFeatures}}
 })
 
 const start = computed(() => {

--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -19,7 +19,6 @@
         @coordinate-click="onCoordinateClick"
       ></SpatialDisplayComponent>
       <ThresholdPanel
-        :nodeId="topologyNode?.id"
         :filteredLocations="filteredLocations"
       ></ThresholdPanel>
     </div>
@@ -43,7 +42,6 @@ import {
   ref,
   useTemplateRef,
   watch,
-  inject,
 } from 'vue'
 import SpatialDisplayComponent from '@/components/spatialdisplay/SpatialDisplayComponent.vue'
 import { useDisplay } from 'vuetify'
@@ -55,7 +53,6 @@ import {
 import {
   filterActionsFilter,
   LocationsTooltipFilter,
-  LevelThresholdWarningLevels,
   timeSeriesGridActionsFilter,
   type TopologyNode,
 } from '@deltares/fews-pi-requests'
@@ -73,6 +70,7 @@ import { useElementSize } from '@vueuse/core'
 import { useDateRegistry } from '@/services/useDateRegistry'
 import type { NavigateRoute } from '@/lib/router'
 import ThresholdPanel from '@/components/general/ThresholdPanel.vue'
+import { useWarningLevelsStore } from '@/stores/warningLevels'
 
 const SpatialTimeSeriesDisplay = defineAsyncComponent(
   () => import('@/components/spatialdisplay/SpatialTimeSeriesDisplay.vue'),
@@ -97,9 +95,7 @@ interface Emits {
 }
 const emit = defineEmits<Emits>()
 
-const selectedWarningLevels = ref<LevelThresholdWarningLevels[]>(
-  inject('selectedWarningLevels', []),
-)
+const warningLevelsStore = useWarningLevelsStore()
 
 const { thresholds } = useDisplay()
 const containerRef = useTemplateRef('container')
@@ -116,7 +112,7 @@ const { layerCapabilities, times } = useWmsLayerCapabilities(
 const { locations, geojson } = useFilterLocations(baseUrl, filterIds)
 
 const selectedWarningLevelSeverity = computed(() =>
-  selectedWarningLevels.value.map((level) => level.severity),
+  warningLevelsStore.selectedWarningLevels.map((level) => level.severity),
 )
 const filteredLocations = computed(() => {
   if (selectedWarningLevelSeverity.value.length === 0) return locations.value

--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -18,6 +18,7 @@
         @update:current-time="currentTime = $event"
         @coordinate-click="onCoordinateClick"
       ></SpatialDisplayComponent>
+      <ThresholdPanel :nodeId="topologyNode?.id"></ThresholdPanel>
     </div>
     <div v-if="showChartPanel" class="child-container">
       <SpatialTimeSeriesDisplay
@@ -60,6 +61,8 @@ import {
 import { useElementSize } from '@vueuse/core'
 import { useDateRegistry } from '@/services/useDateRegistry'
 import type { NavigateRoute } from '@/lib/router'
+import ThresholdPanel from '@/components/general/ThresholdPanel.vue'
+
 const SpatialTimeSeriesDisplay = defineAsyncComponent(
   () => import('@/components/spatialdisplay/SpatialTimeSeriesDisplay.vue'),
 )

--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -34,13 +34,7 @@
 </template>
 
 <script setup lang="ts">
-import {
-  computed,
-  defineAsyncComponent,
-  ref,
-  useTemplateRef,
-  watch,
-} from 'vue'
+import { computed, defineAsyncComponent, ref, useTemplateRef, watch } from 'vue'
 import SpatialDisplayComponent from '@/components/spatialdisplay/SpatialDisplayComponent.vue'
 import { useDisplay } from 'vuetify'
 import { configManager } from '@/services/application-config'

--- a/src/components/tasks/TaskRunSummary.vue
+++ b/src/components/tasks/TaskRunSummary.vue
@@ -62,7 +62,7 @@ import { computed } from 'vue'
 import TaskRunProgress from './TaskRunProgress.vue'
 import DataTable from '@/components/general/DataTable.vue'
 import {
-  toDateDifferenceString,
+  toDateAbsDifferenceString,
   toDateRangeString,
   toHumanReadableDate,
 } from '@/lib/date'
@@ -157,7 +157,7 @@ const taskDurationString = computed(() =>
 )
 
 const taskDurtionDifferenceString = computed(() =>
-  toDateDifferenceString(
+  toDateAbsDifferenceString(
     props.task.dispatchTimestamp,
     props.task.completionTimestamp,
   ),
@@ -171,7 +171,7 @@ const outputTimeString = computed(() =>
 )
 
 const outputTimeDifferenceString = computed(() =>
-  toDateDifferenceString(
+  toDateAbsDifferenceString(
     props.task.outputStartTimestamp,
     props.task.outputEndTimestamp,
   ),

--- a/src/components/tasks/TaskRunsControl.vue
+++ b/src/components/tasks/TaskRunsControl.vue
@@ -4,7 +4,7 @@
     :active="isPanelOpen"
     @click="toggleTasksPanel"
   />
-  <Teleport to="#main-side-panel" defer>
+  <Teleport to="#secondary-side-panel-start" defer>
     <TaskRunsPanel v-if="isPanelOpen" />
   </Teleport>
 </template>

--- a/src/components/thresholds/ThresholdsButton.vue
+++ b/src/components/thresholds/ThresholdsButton.vue
@@ -1,0 +1,67 @@
+<template>
+  <v-btn icon class="thresholds-button">
+    <v-badge :content="badgeCount">
+      <v-icon>mdi-alert</v-icon>
+      <template
+        v-for="level in warningLevelsStore.warningLevels"
+        :key="level.id"
+      >
+        <img
+          v-if="level.icon && level.count"
+          class="thresholds-button__img"
+          :src="getResourcesIconsUrl(level.icon)"
+          alt="Threshold Icon"
+        />
+      </template>
+    </v-badge>
+  </v-btn>
+</template>
+
+<script lang="ts" setup>
+import { computed, watch } from 'vue'
+import { getResourcesIconsUrl } from '@/lib/fews-config'
+import { useWarningLevelsStore } from '@/stores/warningLevels'
+import { onMounted } from 'vue'
+
+const warningLevelsStore = useWarningLevelsStore()
+
+onMounted(() => {
+  console.log(warningLevelsStore.warningLevels)
+})
+
+watch(
+  () => warningLevelsStore.warningLevels,
+  () => {
+    console.log(warningLevelsStore.warningLevels)
+  },
+)
+
+const badgeCount = computed(() => {
+  return warningLevelsStore.warningLevels.reduce((a, b) => {
+    return a + b.count
+  }, 0)
+})
+</script>
+
+<style scoped>
+.thresholds-button__img {
+  position: absolute;
+  top: 1px;
+  left: 0px;
+  height: 24px;
+}
+
+img.thresholds-button__img:nth-of-type(2) {
+  top: -1px;
+  left: 5px;
+  height: 22px;
+  z-index: -1;
+}
+
+img.thresholds-button__img:nth-of-type(3) {
+  top: -2px;
+  left: 6px;
+  height: 20px;
+  z-index: -2;
+}
+</style>

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -146,10 +146,7 @@
         </div>
         <div class="border-s h-100 d-flex flex-row" id="main-side-panel">
           <div class="flex-1-1 h-100" id="secondary-side-panel-start"></div>
-          <div
-            class="border-s flex-1-1 h-100"
-            id="secondary-side-panel-end"
-          ></div>
+          <div class="flex-1-1 h-100" id="secondary-side-panel-end"></div>
         </div>
       </div>
       <div class="alerts__container" v-if="alertsStore.hasAlerts">

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -144,7 +144,10 @@
             <router-view></router-view>
           </Suspense>
         </div>
-        <div class="border-s flex-0-0 h-100" id="main-side-panel"></div>
+        <div class="border-s h-100 d-flex flex-row" id="main-side-panel">
+          <div class="flex-1-1 h-100" id="secondary-side-panel-start"></div>
+          <div class="border-s flex-1-1 h-100" id="secondary-side-panel-end"></div>
+        </div>
       </div>
       <div class="alerts__container" v-if="alertsStore.hasAlerts">
         <v-alert

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -146,7 +146,10 @@
         </div>
         <div class="border-s h-100 d-flex flex-row" id="main-side-panel">
           <div class="flex-1-1 h-100" id="secondary-side-panel-start"></div>
-          <div class="border-s flex-1-1 h-100" id="secondary-side-panel-end"></div>
+          <div
+            class="border-s flex-1-1 h-100"
+            id="secondary-side-panel-end"
+          ></div>
         </div>
       </div>
       <div class="alerts__container" v-if="alertsStore.hasAlerts">

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -139,13 +139,12 @@
     </v-navigation-drawer>
     <v-main id="main">
       <div class="w-100 h-100 d-flex flex-row">
-        <div class="border-s flex-0-0 h-100" id="main-side-panel-left"></div>
         <div class="flex-1-1 overflow-hidden">
           <Suspense>
             <router-view></router-view>
           </Suspense>
         </div>
-        <div class="border-s flex-0-0 h-100" id="main-side-panel-right"></div>
+        <div class="border-s flex-0-0 h-100" id="main-side-panel"></div>
       </div>
       <div class="alerts__container" v-if="alertsStore.hasAlerts">
         <v-alert

--- a/src/lib/charts/styles.ts
+++ b/src/lib/charts/styles.ts
@@ -32,6 +32,19 @@ function hexToRGB(hex: string, alpha?: string | number) {
 }
 
 /**
+ * Determines the contrast color to a hexadecimal color
+ * @param hex - The hexadecimal color code to convert.
+ * @returns 'black' or 'white'.
+ */
+export function getContrastColor(hex: string) {
+  var r = parseInt(hex.slice(1, 3), 16),
+    g = parseInt(hex.slice(3, 5), 16),
+    b = parseInt(hex.slice(5, 7), 16)
+  const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+  return brightness > 128 ? 'black' : 'white';
+}
+
+/**
  * Converts the FEWS line properties to SVG style properties.
  * @param item - The FEWS line style properties.
  * @returns The SVG style properties.

--- a/src/lib/charts/styles.ts
+++ b/src/lib/charts/styles.ts
@@ -40,8 +40,8 @@ export function getContrastColor(hex: string) {
   var r = parseInt(hex.slice(1, 3), 16),
     g = parseInt(hex.slice(3, 5), 16),
     b = parseInt(hex.slice(5, 7), 16)
-  const brightness = (r * 299 + g * 587 + b * 114) / 1000;
-  return brightness > 128 ? 'black' : 'white';
+  const brightness = (r * 299 + g * 587 + b * 114) / 1000
+  return brightness > 128 ? 'black' : 'white'
 }
 
 /**

--- a/src/lib/date/index.ts
+++ b/src/lib/date/index.ts
@@ -108,7 +108,15 @@ export function toDateRangeString(
   return `${toHumanReadableDate(startDate)} → ${toHumanReadableDate(endDate)}`
 }
 
-export function toDateDifferenceString(
+/**
+ * Determines the absolute difference between to dates, and returns it as a human readable string.
+ * Only the two largest units are returned, e.g. 2w 4d.
+ *
+ * @param startDate - The first date
+ * @param endDate - The second date
+ * @returns The absolute difference between the datas as a human readable string
+ */
+export function toDateAbsDifferenceString(
   startDate: Date | string | number | undefined | null,
   endDate: Date | string | number | undefined | null,
   options?: { excludeSeconds?: boolean },
@@ -121,11 +129,10 @@ export function toDateDifferenceString(
   ) {
     return '—'
   }
-
   const startDateObj = new Date(startDate)
   const endDateObj = new Date(endDate)
 
-  const duration = endDateObj.getTime() - startDateObj.getTime()
+  const duration = Math.abs(endDateObj.getTime() - startDateObj.getTime())
   const seconds = Math.floor(duration / 1000)
   const minutes = Math.floor(seconds / 60)
   const hours = Math.floor(minutes / 60)
@@ -149,5 +156,5 @@ export function toDateSpanString(
   startDate: Date | string | number | undefined | null,
   endDate: Date | string | number | undefined | null,
 ) {
-  return `${toDateRangeString(startDate, endDate)} (${toDateDifferenceString(startDate, endDate)})`
+  return `${toDateRangeString(startDate, endDate)} (${toDateAbsDifferenceString(startDate, endDate)})`
 }

--- a/src/lib/date/index.ts
+++ b/src/lib/date/index.ts
@@ -111,7 +111,7 @@ export function toDateRangeString(
 export function toDateDifferenceString(
   startDate: Date | string | number | undefined | null,
   endDate: Date | string | number | undefined | null,
-  options? : {excludeSeconds?: boolean}
+  options?: { excludeSeconds?: boolean },
 ): string {
   if (
     startDate === undefined ||
@@ -137,10 +137,10 @@ export function toDateDifferenceString(
     days % 7 ? `${days % 7}d` : '',
     hours % 24 ? `${hours % 24}h` : '',
     minutes % 60 ? `${minutes % 60}m` : '',
-    (!options?.excludeSeconds && seconds % 60) ? `${seconds % 60}s` : '',
+    !options?.excludeSeconds && seconds % 60 ? `${seconds % 60}s` : '',
   ]
     .filter((part) => part)
-    .slice(0,2)
+    .slice(0, 2)
     .join(' ')
   return result ? result : '0s'
 }

--- a/src/lib/date/index.ts
+++ b/src/lib/date/index.ts
@@ -101,6 +101,24 @@ export function toHumanReadableDate(
   })
 }
 
+export function toShortHumanReadableDate(
+  date: Date | string | number | undefined | null,
+): string {
+  if (date === undefined || date === null) {
+    return '—'
+  }
+  if (typeof date === 'string' || typeof date === 'number') {
+    return toShortHumanReadableDate(new Date(date))
+  }
+  return date.toLocaleString('en-GB', {
+    day: '2-digit',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  })
+}
+
 export function toDateRangeString(
   startDate: Date | string | number | undefined | null,
   endDate: Date | string | number | undefined | null,

--- a/src/lib/date/index.ts
+++ b/src/lib/date/index.ts
@@ -109,17 +109,23 @@ export function toDateRangeString(
 }
 
 /**
- * Determines the absolute difference between to dates, and returns it as a human readable string.
- * Only the two largest units are returned, e.g. 2w 4d.
+ * Calculates the absolute difference between two dates and returns it
+ * as a human-readable string using the two largest time units.
  *
- * @param startDate - The first date
- * @param endDate - The second date
- * @returns The absolute difference between the datas as a human readable string
+ * For example, a difference of 18 days and 3 hours will be represented as "2w 4d".
+ *
+ * @param startDate - The starting date (can be a Date object, timestamp, or date string)
+ * @param endDate - The ending date (can be a Date object, timestamp, or date string)
+ * @param options - Optional settings:
+ *   - excludeSeconds: If true, seconds will not be included in the output
+ *   - relativeFormat: If true, formats the result as a relative time string (e.g. "in 2w 4d" or "2w 4d ago")
+ * @returns A human-readable string representing the absolute time difference,
+ *          or "—" if either date is invalid or missing
  */
 export function toDateAbsDifferenceString(
   startDate: Date | string | number | undefined | null,
   endDate: Date | string | number | undefined | null,
-  options?: { excludeSeconds?: boolean },
+  options?: { excludeSeconds?: boolean; relativeFormat?: boolean },
 ): string {
   if (
     startDate === undefined ||
@@ -139,7 +145,7 @@ export function toDateAbsDifferenceString(
   const days = Math.floor(hours / 24)
   const weeks = Math.floor(days / 7)
 
-  const result = [
+  const differenceString = [
     weeks ? `${weeks}w` : '',
     days % 7 ? `${days % 7}d` : '',
     hours % 24 ? `${hours % 24}h` : '',
@@ -149,7 +155,15 @@ export function toDateAbsDifferenceString(
     .filter((part) => part)
     .slice(0, 2)
     .join(' ')
-  return result ? result : '0s'
+
+  const result = differenceString ? differenceString : '0s'
+
+  if (options?.relativeFormat) {
+    return endDateObj.getTime() - startDateObj.getTime() < 0
+      ? `${result} ago`
+      : `in ${result}`
+  }
+  return result
 }
 
 export function toDateSpanString(

--- a/src/lib/date/index.ts
+++ b/src/lib/date/index.ts
@@ -1,3 +1,5 @@
+import { DateTime } from 'luxon'
+
 /**
  * Converts a date to a string in the format 'YYYY-MM-DDTHH:MM'.
  * @param date - The date to convert.
@@ -106,6 +108,23 @@ export function toDateRangeString(
   endDate: Date | string | number | undefined | null,
 ): string {
   return `${toHumanReadableDate(startDate)} → ${toHumanReadableDate(endDate)}`
+}
+
+export function toDateRelativeString(
+  date: Date | string | undefined | null,
+): string {
+  if (
+    date === undefined ||
+    date === null
+  ) {
+    return '—'
+  }
+
+  const dateObj = new Date(date)
+  const dateTime = DateTime.fromJSDate(dateObj)
+  const dateString = dateTime.toRelative()
+  if (dateString === null) return '—'
+  return dateString
 }
 
 export function toDateDifferenceString(

--- a/src/lib/date/index.ts
+++ b/src/lib/date/index.ts
@@ -1,5 +1,3 @@
-import { DateTime } from 'luxon'
-
 /**
  * Converts a date to a string in the format 'YYYY-MM-DDTHH:MM'.
  * @param date - The date to convert.
@@ -110,26 +108,10 @@ export function toDateRangeString(
   return `${toHumanReadableDate(startDate)} → ${toHumanReadableDate(endDate)}`
 }
 
-export function toDateRelativeString(
-  date: Date | string | undefined | null,
-): string {
-  if (
-    date === undefined ||
-    date === null
-  ) {
-    return '—'
-  }
-
-  const dateObj = new Date(date)
-  const dateTime = DateTime.fromJSDate(dateObj)
-  const dateString = dateTime.toRelative()
-  if (dateString === null) return '—'
-  return dateString
-}
-
 export function toDateDifferenceString(
   startDate: Date | string | number | undefined | null,
   endDate: Date | string | number | undefined | null,
+  options? : {excludeSeconds?: boolean}
 ): string {
   if (
     startDate === undefined ||
@@ -155,9 +137,10 @@ export function toDateDifferenceString(
     days % 7 ? `${days % 7}d` : '',
     hours % 24 ? `${hours % 24}h` : '',
     minutes % 60 ? `${minutes % 60}m` : '',
-    seconds % 60 ? `${seconds % 60}s` : '',
+    (!options?.excludeSeconds && seconds % 60) ? `${seconds % 60}s` : '',
   ]
     .filter((part) => part)
+    .slice(0,2)
     .join(' ')
   return result ? result : '0s'
 }

--- a/src/lib/topology/locations.ts
+++ b/src/lib/topology/locations.ts
@@ -117,3 +117,23 @@ export async function fetchLocationSetAsGeoJson(
   }
   return response
 }
+
+export async function fetchSingleLocationsByLocationId(
+  baseUrl: string,
+  locationId: string
+) {
+  const provider = new PiWebserviceProvider(baseUrl, {
+    transformRequestFn: createTransformRequestFn(),
+  })
+  const filter = {
+    documentFormat: DocumentFormat.GEO_JSON,
+    locationIds: locationId,
+    showParentLocations: false,
+    showThresholds: true,
+  }
+  const response = await provider.getLocations(filter)
+  if (!isFeatureCollection(response)) {
+    throw new Error('Expected GeoJSON FeatureCollection')
+  }
+  return response
+}

--- a/src/lib/topology/locations.ts
+++ b/src/lib/topology/locations.ts
@@ -117,23 +117,3 @@ export async function fetchLocationSetAsGeoJson(
   }
   return response
 }
-
-export async function fetchSingleLocationsByLocationId(
-  baseUrl: string,
-  locationId: string
-) {
-  const provider = new PiWebserviceProvider(baseUrl, {
-    transformRequestFn: createTransformRequestFn(),
-  })
-  const filter = {
-    documentFormat: DocumentFormat.GEO_JSON,
-    locationIds: locationId,
-    showParentLocations: false,
-    showThresholds: true,
-  }
-  const response = await provider.getLocations(filter)
-  if (!isFeatureCollection(response)) {
-    throw new Error('Expected GeoJSON FeatureCollection')
-  }
-  return response
-}

--- a/src/services/useFocusAwareInterval/index.ts
+++ b/src/services/useFocusAwareInterval/index.ts
@@ -20,7 +20,6 @@ export function useFocusAwareInterval(
   watch(visibility, (v) => {
     if (v === 'visible') {
       if (pausedByVisibility.value) {
-        callback()
         resume()
         pausedByVisibility.value = false
       }

--- a/src/services/useTasksRuns/index.ts
+++ b/src/services/useTasksRuns/index.ts
@@ -44,7 +44,7 @@ export function useTaskRuns(
 
   useFocusAwareInterval(() => {
     fetch().catch((error) => console.error(`Failed to fetch tasks: ${error}`))
-  }, refreshIntervalSeconds * 1000)
+  }, refreshIntervalSeconds * 1000, { immediateCallback: true })
 
   // Fetch taskruns if a new dispatch period is selected.
   watch(() => toValue(dispatchPeriod), fetch)

--- a/src/services/useTasksRuns/index.ts
+++ b/src/services/useTasksRuns/index.ts
@@ -42,9 +42,13 @@ export function useTaskRuns(
   const allTaskRuns = ref<TaskRun[]>([])
   const filteredTaskRuns = computed<TaskRun[]>(filterTasks)
 
-  useFocusAwareInterval(() => {
-    fetch().catch((error) => console.error(`Failed to fetch tasks: ${error}`))
-  }, refreshIntervalSeconds * 1000, { immediateCallback: true })
+  useFocusAwareInterval(
+    () => {
+      fetch().catch((error) => console.error(`Failed to fetch tasks: ${error}`))
+    },
+    refreshIntervalSeconds * 1000,
+    { immediateCallback: true },
+  )
 
   // Fetch taskruns if a new dispatch period is selected.
   watch(() => toValue(dispatchPeriod), fetch)

--- a/src/services/useTimeSeries/index.ts
+++ b/src/services/useTimeSeries/index.ts
@@ -205,7 +205,7 @@ export function useTimeSeries(
   const interval = useFocusAwareInterval(
     loadTimeSeries,
     TIMESERIES_POLLING_INTERVAL,
-    { immediateCallback: true }
+    { immediateCallback: true },
   )
 
   onUnmounted(() => {

--- a/src/services/useTimeSeries/index.ts
+++ b/src/services/useTimeSeries/index.ts
@@ -205,6 +205,7 @@ export function useTimeSeries(
   const interval = useFocusAwareInterval(
     loadTimeSeries,
     TIMESERIES_POLLING_INTERVAL,
+    { immediateCallback: true }
   )
 
   onUnmounted(() => {

--- a/src/services/useTopologyThresholds/index.ts
+++ b/src/services/useTopologyThresholds/index.ts
@@ -53,6 +53,7 @@ export function useTopologyThresholds(
   const interval = useFocusAwareInterval(
     loadTopologyThresholds,
     THRESHOLDS_POLLING_INTERVAL,
+    { immediateCallback: true }
   )
 
   watch(

--- a/src/services/useTopologyThresholds/index.ts
+++ b/src/services/useTopologyThresholds/index.ts
@@ -53,7 +53,7 @@ export function useTopologyThresholds(
   const interval = useFocusAwareInterval(
     loadTopologyThresholds,
     THRESHOLDS_POLLING_INTERVAL,
-    { immediateCallback: true }
+    { immediateCallback: true },
   )
 
   watch(

--- a/src/stores/parameters.ts
+++ b/src/stores/parameters.ts
@@ -1,0 +1,48 @@
+import { ref } from 'vue'
+import { defineStore } from 'pinia'
+import {
+  DocumentFormat,
+  PiWebserviceProvider,
+  type TimeSeriesParameter,
+} from '@deltares/fews-pi-requests'
+import { configManager } from '@/services/application-config'
+import { createTransformRequestFn } from '@/lib/requests/transformRequest'
+
+export const useParametersStore = defineStore('parameters', () => {
+  const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
+  const piProvider = new PiWebserviceProvider(baseUrl, {
+    transformRequestFn: createTransformRequestFn(),
+  })
+
+  const parameters = ref<TimeSeriesParameter[]>([])
+  const isLoading = ref(false)
+
+  function byId(
+    parameterId: string | undefined,
+  ): TimeSeriesParameter | undefined {
+    return parameters.value.find((parameter) => parameter.id === parameterId)
+  }
+
+  async function fetch() {
+    isLoading.value = true
+    try {
+      const response = await piProvider.getParameters({
+        documentFormat: DocumentFormat.PI_JSON,
+      })
+      parameters.value = response.timeSeriesParameters
+    } catch (error) {
+      console.error('Failed to fetch available parameters.', error)
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  fetch()
+
+  return {
+    parameters,
+    isLoading,
+    byId,
+    fetch,
+  }
+})

--- a/src/stores/warningLevels.ts
+++ b/src/stores/warningLevels.ts
@@ -1,0 +1,97 @@
+import { defineStore } from 'pinia'
+import { ref, computed, watch } from 'vue'
+import { LevelThresholdWarningLevels } from '@deltares/fews-pi-requests'
+import { useTopologyThresholds } from '@/services/useTopologyThresholds'
+import { configManager } from '@/services/application-config'
+import { getResourcesIconsUrl } from '@/lib/fews-config'
+
+export const useWarningLevelsStore = defineStore('warningLevels', () => {
+  const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
+  const nodeId = ref<string | undefined>(undefined)
+  const selectedWarningLevelIds = ref<string[]>([])
+  const selectedWarningLevels = ref<LevelThresholdWarningLevels[]>([])
+
+  const { thresholds } = useTopologyThresholds(baseUrl, () => nodeId.value)
+
+  const aggregatedWarningLevels = computed(() => {
+    if (thresholds.value === undefined || thresholds.value.length === 0)
+      return []
+    const aggregatedLevels =
+      thresholds.value[0]?.aggregatedLevelThresholdWarningLevels
+    return aggregatedLevels ?? []
+  })
+
+  const warningLevels = computed(() => {
+    const levels = aggregatedWarningLevels.value
+      .map((warningLevel) => {
+        return {
+          ...warningLevel,
+          ...{
+            icon: warningLevel.icon
+              ? getResourcesIconsUrl(warningLevel.icon)
+              : undefined,
+          },
+        }
+      })
+      .sort((a, b) => b.severity - a.severity)
+    // The warning level with the lowest severity is always the default "no thresholds" level.
+    // That level should not be shown in list of warning levels
+    if (levels.length > 0) {
+      levels.pop()
+    }
+    return levels
+  })
+
+  const thresholdCrossings = computed(() => {
+    if (thresholds.value === undefined || thresholds.value.length === 0)
+      return []
+    return thresholds.value[0].levelThresholdCrossings ?? []
+  })
+
+  const selectedThresholdCrossings = computed(() => {
+    const crossings =
+      selectedWarningLevelIds.value.length === 0
+        ? thresholdCrossings.value
+        : thresholdCrossings.value?.filter((crossing) =>
+            selectedWarningLevelIds.value.includes(
+              crossing.warningLevelId ?? '',
+            ),
+          )
+    return crossings.sort((a, b) => b.severity - a.severity)
+  })
+
+  watch([selectedWarningLevelIds, aggregatedWarningLevels], () => {
+    updateSelectedLevels()
+  })
+
+  watch(aggregatedWarningLevels, () => {
+    updateSelectedLevels()
+  })
+
+  // Update the selected levels based on selected IDs
+  function updateSelectedLevels() {
+    if (selectedWarningLevelIds.value.length === 0) {
+      selectedWarningLevels.value = aggregatedWarningLevels.value
+    } else {
+      selectedWarningLevels.value = aggregatedWarningLevels.value.filter(
+        (level) => selectedWarningLevelIds.value.includes(level.id),
+      )
+    }
+  }
+
+  function setTopologyNodeId(id: string | undefined) {
+    nodeId.value = id
+  }
+
+  return {
+    nodeId,
+    selectedWarningLevelIds,
+    selectedWarningLevels,
+    warningLevels,
+    aggregatedWarningLevels,
+    thresholds,
+    thresholdCrossings,
+    selectedThresholdCrossings,
+    setTopologyNodeId,
+  }
+})

--- a/src/stores/warningLevels.ts
+++ b/src/stores/warningLevels.ts
@@ -61,6 +61,24 @@ export const useWarningLevelsStore = defineStore('warningLevels', () => {
     return crossings.sort((a, b) => b.severity - a.severity)
   })
 
+  const aggregatedThresholdCrossings = computed(() => {
+    if (thresholds.value === undefined || thresholds.value.length === 0)
+      return []
+    return thresholds.value[0].aggregatedLevelThresholdCrossings ?? []
+  })
+
+  const selectedAggregatedThresholdCrossings = computed(() => {
+    const crossings =
+      selectedWarningLevelIds.value.length === 0
+        ? aggregatedThresholdCrossings.value
+        : aggregatedThresholdCrossings.value?.filter((crossing) =>
+            selectedWarningLevelIds.value.includes(
+              crossing.warningLevelId ?? '',
+            ),
+          )
+    return crossings.sort((a, b) => b.severity - a.severity)
+  })
+
   watch([selectedWarningLevelIds, aggregatedWarningLevels], () => {
     updateSelectedLevels()
   })
@@ -93,6 +111,8 @@ export const useWarningLevelsStore = defineStore('warningLevels', () => {
     thresholds,
     thresholdCrossings,
     selectedThresholdCrossings,
+    aggregatedThresholdCrossings,
+    selectedAggregatedThresholdCrossings,
     showCrossingDetails,
     setTopologyNodeId,
   }

--- a/src/stores/warningLevels.ts
+++ b/src/stores/warningLevels.ts
@@ -10,6 +10,7 @@ export const useWarningLevelsStore = defineStore('warningLevels', () => {
   const nodeId = ref<string | undefined>(undefined)
   const selectedWarningLevelIds = ref<string[]>([])
   const selectedWarningLevels = ref<LevelThresholdWarningLevels[]>([])
+  const showCrossingDetails = ref(false)
 
   const { thresholds } = useTopologyThresholds(baseUrl, () => nodeId.value)
 
@@ -92,6 +93,7 @@ export const useWarningLevelsStore = defineStore('warningLevels', () => {
     thresholds,
     thresholdCrossings,
     selectedThresholdCrossings,
+    showCrossingDetails,
     setTopologyNodeId,
   }
 })

--- a/src/stores/warningLevels.ts
+++ b/src/stores/warningLevels.ts
@@ -46,7 +46,16 @@ export const useWarningLevelsStore = defineStore('warningLevels', () => {
   const thresholdCrossings = computed(() => {
     if (thresholds.value === undefined || thresholds.value.length === 0)
       return []
-    return thresholds.value[0].levelThresholdCrossings ?? []
+    return (thresholds.value[0].levelThresholdCrossings ?? []).map(
+      (crossing) => {
+        return {
+          ...crossing,
+          ...{
+            icon: crossing.icon ? getResourcesIconsUrl(crossing.icon) : '',
+          },
+        }
+      },
+    )
   })
 
   const selectedThresholdCrossings = computed(() => {

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -30,7 +30,6 @@
     </v-toolbar-items>
   </Teleport>
   <Teleport to="#app-bar-content-end">
-    <ThresholdPanel :nodeId="topologyNode?.id"></ThresholdPanel>
     <v-menu bottom left>
       <template v-slot:activator="{ props }">
         <v-btn icon v-bind="props">
@@ -91,7 +90,6 @@
 import HierarchicalMenu from '@/components/general/HierarchicalMenu.vue'
 import WorkflowsControl from '@/components/workflows/WorkflowsControl.vue'
 import LeafNodeButtons from '@/components/general/LeafNodeButtons.vue'
-import ThresholdPanel from '@/components/general/ThresholdPanel.vue'
 import ThresholdSummary from '@/components/general/ThresholdSummary.vue'
 
 import type { ColumnItem } from '@/components/general/ColumnItem'

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -62,10 +62,7 @@
     </v-menu>
   </Teleport>
   <div class="d-flex w-100 h-100">
-    <ThresholdSummary
-      :nodeId="topologyNode?.id"
-      v-model="selectedWarningLevels"
-    ></ThresholdSummary>
+    <ThresholdSummary :nodeId="topologyNode?.id"></ThresholdSummary>
     <router-view v-slot="{ Component }">
       <keep-alive include="SpatialDisplay">
         <component
@@ -100,21 +97,10 @@ import { useConfigStore } from '@/stores/config'
 import { useUserSettingsStore } from '@/stores/userSettings'
 import { useWorkflowsStore } from '@/stores/workflows'
 
-import type {
-  LevelThresholdWarningLevels,
-  TopologyNode,
-} from '@deltares/fews-pi-requests'
+import type { TopologyNode } from '@deltares/fews-pi-requests'
 import type { WebOcTopologyDisplayConfig } from '@deltares/fews-pi-requests'
 
-import {
-  computed,
-  onUnmounted,
-  provide,
-  ref,
-  StyleValue,
-  watch,
-  watchEffect,
-} from 'vue'
+import { computed, onUnmounted, ref, StyleValue, watch, watchEffect } from 'vue'
 import {
   onBeforeRouteUpdate,
   RouteLocationNormalized,
@@ -474,9 +460,6 @@ function reroute(to: RouteLocationNormalized, from?: RouteLocationNormalized) {
     }
   }
 }
-
-const selectedWarningLevels = ref<LevelThresholdWarningLevels[]>([])
-provide('selectedWarningLevels', selectedWarningLevels)
 </script>
 
 <style scoped>

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -62,7 +62,7 @@
     </v-menu>
   </Teleport>
   <div class="d-flex w-100 h-100">
-    <ThresholdSummary :nodeId="topologyNode?.id"></ThresholdSummary>
+    <ThresholdSummary :nodeId="topologyNode?.id" v-model="selectedWarningLevels"></ThresholdSummary>
     <router-view v-slot="{ Component }">
       <keep-alive include="SpatialDisplay">
         <component
@@ -97,10 +97,10 @@ import { useConfigStore } from '@/stores/config'
 import { useUserSettingsStore } from '@/stores/userSettings'
 import { useWorkflowsStore } from '@/stores/workflows'
 
-import type { TopologyNode } from '@deltares/fews-pi-requests'
+import type { LevelThresholdWarningLevels, TopologyNode } from '@deltares/fews-pi-requests'
 import type { WebOcTopologyDisplayConfig } from '@deltares/fews-pi-requests'
 
-import { computed, onUnmounted, ref, StyleValue, watch, watchEffect } from 'vue'
+import { computed, onUnmounted, provide, ref, StyleValue, watch, watchEffect } from 'vue'
 import {
   onBeforeRouteUpdate,
   RouteLocationNormalized,
@@ -460,6 +460,9 @@ function reroute(to: RouteLocationNormalized, from?: RouteLocationNormalized) {
     }
   }
 }
+
+const selectedWarningLevels = ref<LevelThresholdWarningLevels[]>([])
+provide('selectedWarningLevels', selectedWarningLevels)
 </script>
 
 <style scoped>

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -62,7 +62,10 @@
     </v-menu>
   </Teleport>
   <div class="d-flex w-100 h-100">
-    <ThresholdSummary :nodeId="topologyNode?.id" v-model="selectedWarningLevels"></ThresholdSummary>
+    <ThresholdSummary
+      :nodeId="topologyNode?.id"
+      v-model="selectedWarningLevels"
+    ></ThresholdSummary>
     <router-view v-slot="{ Component }">
       <keep-alive include="SpatialDisplay">
         <component
@@ -97,10 +100,21 @@ import { useConfigStore } from '@/stores/config'
 import { useUserSettingsStore } from '@/stores/userSettings'
 import { useWorkflowsStore } from '@/stores/workflows'
 
-import type { LevelThresholdWarningLevels, TopologyNode } from '@deltares/fews-pi-requests'
+import type {
+  LevelThresholdWarningLevels,
+  TopologyNode,
+} from '@deltares/fews-pi-requests'
 import type { WebOcTopologyDisplayConfig } from '@deltares/fews-pi-requests'
 
-import { computed, onUnmounted, provide, ref, StyleValue, watch, watchEffect } from 'vue'
+import {
+  computed,
+  onUnmounted,
+  provide,
+  ref,
+  StyleValue,
+  watch,
+  watchEffect,
+} from 'vue'
 import {
   onBeforeRouteUpdate,
   RouteLocationNormalized,


### PR DESCRIPTION
### Description

Add the threshold event widget. In case a topology nodes has any thresholds, a summary of those thresholds are shown in a panel on the right of the screen. In case the topology node has a map, a panel with more detailed information can be opened.

Clicking on one or more of summary icons allows for filtering of the information of the detailed panel and filtering of the locations shown on the map.

The panel with details belongs to the map, whereas the summary overview belong to a topology node. Therefore, the summary will always be shown on the right of the entire app, and the details panel will be shown at the right of the map. That means that is a chart or the task run panel is opened, it will be between the details panel and the summary.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [ ] Update tests.
