### PR TITLE
Remove artifacts between bars in bar charts

### DIFF
--- a/src/lib/charts/styles.ts
+++ b/src/lib/charts/styles.ts
@@ -114,6 +114,21 @@ export function cssStyleFromFewsArea(item: {
 }
 
 /**
+ * Converts FEWS bar properties to SVG CSS styles.
+ * @param item - The FEWS area properties.
+ * @returns The SVG CSS styles.
+ */
+export function cssStyleFromFewsBar(item: {
+  lineStyle?: string
+  color?: string
+  opaquenessPercentage?: number
+}): SvgPropertiesHyphen {
+  const style = cssStyleFromFewsArea(item)
+  style['shape-rendering'] = 'crispEdges'
+  return style
+}
+
+/**
  * Converts a FEWS line style to CSS style properties for an SVG element.
  * @param lineStyle - The FEWS line style to convert.
  * @returns The CSS style properties for the SVG element.

--- a/src/lib/charts/timeSeriesDisplayToChartConfig.ts
+++ b/src/lib/charts/timeSeriesDisplayToChartConfig.ts
@@ -10,6 +10,7 @@ import {
   cssStyleFromFewsLine,
   cssStyleFromFewsMarker,
   chartMarkerFromFews,
+  cssStyleFromFewsBar,
 } from './styles'
 import {
   AxisOptions,
@@ -145,10 +146,18 @@ function getChartSeries(
           }) ?? 0,
       },
     },
-    style:
-      seriesType === 'area' || seriesType === 'bar'
-        ? cssStyleFromFewsArea(items[0])
-        : cssStyleFromFewsLine(items[0]),
+    style: getChartStyle(seriesType, items[0]),
+  }
+}
+
+function getChartStyle(seriesType: string, item: TimeSeriesDisplaySubplotItem) {
+  switch (seriesType) {
+    case 'area':
+      return cssStyleFromFewsArea(item)
+    case 'bar':
+      return cssStyleFromFewsBar(item)
+    default:
+      return cssStyleFromFewsLine(item)
   }
 }
 


### PR DESCRIPTION
### Description
Add crispEdges to bar charts to fix artifacts between bars

### Screenshots
# Before
![image](https://github.com/user-attachments/assets/8442d009-8c91-4944-9bdb-e98ecfeb1407)
# After
![image](https://github.com/user-attachments/assets/2f19b777-cfd0-4be2-ac57-4fe67c8787a2)

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
