### PR TITLE
Fix spurious "interpolation" of missing data with unreliable flag

### DIFF
--- a/src/lib/charts/dataFromResources.ts
+++ b/src/lib/charts/dataFromResources.ts
@@ -1,8 +1,9 @@
 import type { Series } from '../timeseries/timeSeries'
-import type {
-  SeriesArrayData,
-  SeriesData,
-  TimeSeriesData,
+import {
+  isSeriesArrayData,
+  type SeriesArrayData,
+  type SeriesData,
+  type TimeSeriesData,
 } from '@/lib/timeseries/types/SeriesData'
 
 /**
@@ -110,10 +111,16 @@ export function dataFromResources(
 }
 
 /**
- * Filters out unreliable data from a list of SeriesData or SeriesArrayData objects.
+ * Replaces unreliable data with null values from a list of SeriesData or SeriesArrayData objects.
  * @param data - An array of SeriesData or SeriesArrayData objects.
  * @returns An array of SeriesData or SeriesArrayData objects with unreliable data removed.
  */
 export function removeUnreliableData(data: (SeriesArrayData | SeriesData)[]) {
-  return data.filter(isReliableData)
+  return data.map((event) => {
+    if (isReliableData(event)) return { ...event }
+    return {
+      ...event,
+      y: isSeriesArrayData(event) ? new Array(event.y.length).fill(null) : null,
+    }
+  })
 }

--- a/src/lib/timeseries/types/SeriesData.ts
+++ b/src/lib/timeseries/types/SeriesData.ts
@@ -15,3 +15,9 @@ export interface SeriesArrayData
 export interface TimeSeriesData extends SeriesData {
   x: Date
 }
+
+export function isSeriesArrayData(
+  data: SeriesData | SeriesArrayData,
+): data is SeriesArrayData {
+  return Array.isArray(data.y)
+}


### PR DESCRIPTION
## Pull Request Template

### Description
Time series events with a missing value or null value which were also flagged as unreliable would be removed completely. In this case, no null event would remain between two reliable points causing them to be connected with a line.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes
