### PR TITLE
Make time series not deeply reactive

### DIFF
--- a/src/services/useTimeSeries/index.ts
+++ b/src/services/useTimeSeries/index.ts
@@ -18,9 +18,7 @@ import { type Pausable } from '@vueuse/core'
 import { useFocusAwareInterval } from '@/services/useFocusAwareInterval'
 
 export interface UseTimeSeriesReturn {
-  error: Ref<any>
   series: ShallowRef<Record<string, Series>>
-  isReady: Ref<boolean>
   isLoading: Ref<boolean>
   loadingSeriesIds: Ref<string[]>
   interval: Pausable
@@ -52,7 +50,6 @@ export function useTimeSeries(
   selectedTime?: MaybeRefOrGetter<Date | undefined>,
 ): UseTimeSeriesReturn {
   let controller = new AbortController()
-  const isReady = ref(false)
   const series = shallowRef<Record<string, Series>>({})
   const MAX_SERIES = 20
   const loadingSeriesIds = ref<string[]>([])
@@ -208,10 +205,8 @@ export function useTimeSeries(
 
   return {
     series,
-    isReady,
     isLoading,
     loadingSeriesIds,
-    error,
     interval,
   }
 }

--- a/src/services/useTimeSeries/index.ts
+++ b/src/services/useTimeSeries/index.ts
@@ -5,7 +5,7 @@ import {
   DomainAxisEventValuesStringArray,
 } from '@deltares/fews-pi-requests'
 import { computed, onUnmounted, ref, shallowRef, toValue, watch } from 'vue'
-import type { MaybeRefOrGetter, Ref } from 'vue'
+import type { MaybeRefOrGetter, Ref, ShallowRef } from 'vue'
 import { absoluteUrl } from '../../lib/utils/absoluteUrl'
 import { DateTime, Interval } from 'luxon'
 import { Series } from '../../lib/timeseries/timeSeries'
@@ -19,7 +19,7 @@ import { useFocusAwareInterval } from '@/services/useFocusAwareInterval'
 
 export interface UseTimeSeriesReturn {
   error: Ref<any>
-  series: Ref<Record<string, Series>>
+  series: ShallowRef<Record<string, Series>>
   isReady: Ref<boolean>
   isLoading: Ref<boolean>
   loadingSeriesIds: Ref<string[]>
@@ -53,8 +53,7 @@ export function useTimeSeries(
 ): UseTimeSeriesReturn {
   let controller = new AbortController()
   const isReady = ref(false)
-  const series = ref<Record<string, Series>>({})
-  const error = shallowRef<any | undefined>(undefined)
+  const series = shallowRef<Record<string, Series>>({})
   const MAX_SERIES = 20
   const loadingSeriesIds = ref<string[]>([])
   const isLoading = computed(() => loadingSeriesIds.value.length > 0)
@@ -183,7 +182,10 @@ export function useTimeSeries(
               }
               _series.lastUpdated = new Date()
             }
-            series.value[resourceId] = _series
+            series.value = {
+              ...series.value,
+              [resourceId]: _series,
+            }
           }
       })
     }

--- a/src/services/useTimeSeries/index.ts
+++ b/src/services/useTimeSeries/index.ts
@@ -44,13 +44,6 @@ function timeZoneOffsetString(offset: number): string {
     .padStart(2, '0')}`
 }
 
-/**
- * Reactive async state. Will not block your setup function and will trigger changes once
- * the promise is ready.
- *
- * @see https://vueuse.org/useAsyncState
- * @param url The initial state, used until the first evaluation finishes
- */
 export function useTimeSeries(
   baseUrl: string,
   requests: MaybeRefOrGetter<ActionRequest[]>,


### PR DESCRIPTION
## Pull Request Template

### Description
Previously, time series were deeply reactive, which may be quite expensive for long time series since every single event in the data array is a reactive object. This PR removes this unnecessary reactivity by only triggering reactivity for each time series as a whole.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes
