### PR TITLE
Fix grid download

### DIFF
--- a/src/components/download/TimeSeriesFileDownloadComponent.vue
+++ b/src/components/download/TimeSeriesFileDownloadComponent.vue
@@ -212,10 +212,20 @@ function determineViewPeriod() {
         .toISO({ suppressMilliseconds: true })
     }
   }
-  return {
-    startTime: startTime ?? undefined,
-    endTime: endTime ?? undefined,
+
+  const result: {
+    startDate?: string
+    endDate?: string
+  } = {}
+
+  if (startDate) {
+    result.startDate = startTime ?? undefined
   }
+  if (endDate) {
+    result.endDate = endTime ?? undefined
+  }
+
+  return result
 }
 
 const downloadFile = (downloadFormat: DocumentFormat) => {

--- a/src/services/useTopologyThresholds/index.ts
+++ b/src/services/useTopologyThresholds/index.ts
@@ -47,7 +47,7 @@ export function useTopologyThresholds(
   const interval = useFocusAwareInterval(
     loadTopologyThresholds,
     THRESHOLDS_POLLING_INTERVAL,
-    { immediate: true }
+    { immediate: true },
   )
   loadTopologyThresholds()
 


### PR DESCRIPTION
### Description
Fix download for grid data. 
Was a problem with js objects with undefined keys still overwriting start and endDate params of previous object.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
