### PR TITLE
Move refresh from timeseries to actions

### DIFF
--- a/src/components/timeseries/TimeSeriesComponent.vue
+++ b/src/components/timeseries/TimeSeriesComponent.vue
@@ -155,7 +155,6 @@ const props = withDefaults(defineProps<Props>(), {
 
 const { selectedDate } = useSelectedDate(() => props.currentTime)
 const store = useSystemTimeStore()
-const lastUpdated = ref<Date>(new Date())
 const isEditing = ref(false)
 const confirmationDialog = ref(false)
 const { xs } = useDisplay()
@@ -178,14 +177,14 @@ const {
   series,
   loadingSeriesIds,
   interval: useTimeSeriesInterval,
-} = useTimeSeries(baseUrl, () => props.config.requests, lastUpdated, options)
+  refresh: refreshTimeSeries,
+} = useTimeSeries(baseUrl, () => props.config.requests, options)
 const {
   series: elevationChartSeries,
   loadingSeriesIds: elevationLoadingSeriesIds,
 } = useTimeSeries(
   baseUrl,
   () => props.elevationChartConfig.requests,
-  lastUpdated,
   options,
   selectedDate,
 )
@@ -208,7 +207,7 @@ async function onDataChange(newData: Record<string, TimeSeriesEvent[]>) {
     seriesHeader.version ?? '',
     seriesHeader.timeZone ?? '',
   )
-  lastUpdated.value = new Date()
+  refreshTimeSeries()
 }
 
 const subplots = computed(() => {

--- a/src/components/timeseries/TimeSeriesComponent.vue
+++ b/src/components/timeseries/TimeSeriesComponent.vue
@@ -170,13 +170,13 @@ const options = computed<UseTimeSeriesOptions>(() => {
     startTime: store.startTime,
     endTime: store.endTime,
     thinning: false,
+    enabled: !isEditing.value,
   }
 })
 const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
 const {
   series,
   loadingSeriesIds,
-  interval: useTimeSeriesInterval,
   refresh: refreshTimeSeries,
 } = useTimeSeries(baseUrl, () => props.config.requests, options)
 const {
@@ -259,11 +259,6 @@ watch(
 )
 
 watch(isEditing, () => {
-  if (isEditing.value) {
-    useTimeSeriesInterval.pause()
-  } else {
-    useTimeSeriesInterval.resume()
-  }
   // Can't set a custom message in modern browsers
   window.onbeforeunload = isEditing.value ? () => true : null
 })

--- a/src/lib/actions/index.ts
+++ b/src/lib/actions/index.ts
@@ -1,0 +1,59 @@
+import type { ActionsResponse } from '@deltares/fews-pi-requests'
+import type { DisplayConfig } from '@/lib/display/DisplayConfig'
+import { convertFewsPiDateTimeToJsDate } from '@/lib/date'
+import { timeSeriesDisplayToChartConfig } from '@/lib/charts/timeSeriesDisplayToChartConfig'
+
+/**
+ * Converts the actions response to an array of display configurations.
+ * @param actionsResponse The actions response object.
+ * @returns An array of display configurations.
+ */
+export function actionsResponseToDisplayConfig(
+  actionsResponse: ActionsResponse,
+  nodeId: string | undefined,
+  startTime?: Date,
+  endTime?: Date,
+): DisplayConfig[] {
+  const displays: DisplayConfig[] = []
+  for (const result of actionsResponse.results) {
+    if (result.config === undefined) continue
+    const title = result.config.timeSeriesDisplay.title ?? ''
+    const timeSeriesDisplayIndex = result.config.timeSeriesDisplay.index
+    const period = result.config.timeSeriesDisplay.period
+    const plotId = result.config.timeSeriesDisplay.plotId
+
+    // The period is always specified in UTC.
+    const timeZoneOffsetString = 'Z'
+    let configPeriod: [Date, Date]
+    if (period) {
+      const periodStart = convertFewsPiDateTimeToJsDate(
+        period.startDate,
+        timeZoneOffsetString,
+      )
+      const periodEnd = convertFewsPiDateTimeToJsDate(
+        period.endDate,
+        timeZoneOffsetString,
+      )
+      configPeriod = [startTime ?? periodStart, endTime ?? periodEnd]
+    }
+
+    const subplots =
+      result.config.timeSeriesDisplay.subplots?.map((subPlot) => {
+        return timeSeriesDisplayToChartConfig(subPlot, configPeriod)
+      }) ?? []
+    const display: DisplayConfig = {
+      id: title,
+      title,
+      forecastLegend: result.config.timeSeriesDisplay.forecastLegend,
+      plotId,
+      nodeId: nodeId,
+      class: 'singles',
+      index: timeSeriesDisplayIndex,
+      requests: result.requests,
+      period: result.config.timeSeriesDisplay.period,
+      subplots,
+    }
+    displays.push(display)
+  }
+  return displays
+}

--- a/src/services/useFocusAwareInterval/index.ts
+++ b/src/services/useFocusAwareInterval/index.ts
@@ -20,6 +20,10 @@ export function useFocusAwareInterval(
   watch(visibility, (v) => {
     if (v === 'visible') {
       if (pausedByVisibility.value) {
+        // Always call the callback when the document becomes visible again
+        if (options?.immediateCallback === false) {
+          callback()
+        }
         resume()
         pausedByVisibility.value = false
       }

--- a/src/services/useTasksRuns/index.ts
+++ b/src/services/useTasksRuns/index.ts
@@ -46,7 +46,7 @@ export function useTaskRuns(
       fetch().catch((error) => console.error(`Failed to fetch tasks: ${error}`))
     },
     refreshIntervalSeconds * 1000,
-    { immediateCallback: true },
+    { immediate: true },
   )
 
   // Fetch taskruns if a new dispatch period is selected.

--- a/src/services/useTimeSeries/index.ts
+++ b/src/services/useTimeSeries/index.ts
@@ -22,6 +22,7 @@ export interface UseTimeSeriesReturn {
   isLoading: Ref<boolean>
   loadingSeriesIds: Ref<string[]>
   interval: Pausable
+  refresh: () => void
 }
 
 const TIMESERIES_POLLING_INTERVAL = 1000 * 30
@@ -45,7 +46,6 @@ function timeZoneOffsetString(offset: number): string {
 export function useTimeSeries(
   baseUrl: string,
   requests: MaybeRefOrGetter<ActionRequest[]>,
-  lastUpdated: MaybeRefOrGetter<Date | undefined>,
   options: MaybeRefOrGetter<UseTimeSeriesOptions>,
   selectedTime?: MaybeRefOrGetter<Date | undefined>,
 ): UseTimeSeriesReturn {
@@ -55,7 +55,7 @@ export function useTimeSeries(
   const loadingSeriesIds = ref<string[]>([])
   const isLoading = computed(() => loadingSeriesIds.value.length > 0)
 
-  watch([lastUpdated, selectedTime ?? ref(), requests, options], () => {
+  watch([selectedTime ?? ref(), requests, options], () => {
     loadTimeSeries()
   })
 
@@ -209,6 +209,7 @@ export function useTimeSeries(
     isLoading,
     loadingSeriesIds,
     interval,
+    refresh: loadTimeSeries,
   }
 }
 

--- a/src/services/useTimeSeries/index.ts
+++ b/src/services/useTimeSeries/index.ts
@@ -14,24 +14,20 @@ import { createTransformRequestFn } from '@/lib/requests/transformRequest'
 import { difference } from 'lodash-es'
 import { SeriesData } from '@/lib/timeseries/types/SeriesData'
 import { convertFewsPiDateTimeToJsDate } from '@/lib/date'
-import { type Pausable } from '@vueuse/core'
-import { useFocusAwareInterval } from '@/services/useFocusAwareInterval'
 
 export interface UseTimeSeriesReturn {
   series: ShallowRef<Record<string, Series>>
   isLoading: Ref<boolean>
   loadingSeriesIds: Ref<string[]>
-  interval: Pausable
   refresh: () => void
 }
-
-const TIMESERIES_POLLING_INTERVAL = 1000 * 30
 
 export interface UseTimeSeriesOptions {
   startTime?: Date | null
   endTime?: Date | null
   thinning?: boolean
   showVerticalProfile?: boolean
+  enabled?: boolean
 }
 
 function timeZoneOffsetString(offset: number): string {
@@ -68,6 +64,8 @@ export function useTimeSeries(
     const _requests = toValue(requests)
     const _options = toValue(options)
     const _selectedTime = toValue(selectedTime)
+
+    if (!_options?.enabled) return
 
     const currentSeriesIds = Object.keys(series.value)
     const updatedSeriesIds: string[] = []
@@ -194,12 +192,6 @@ export function useTimeSeries(
     }
   }
 
-  const interval = useFocusAwareInterval(
-    loadTimeSeries,
-    TIMESERIES_POLLING_INTERVAL,
-    { immediateCallback: true },
-  )
-
   onUnmounted(() => {
     controller.abort('useTimeSeries unmounted.')
   })
@@ -208,7 +200,6 @@ export function useTimeSeries(
     series,
     isLoading,
     loadingSeriesIds,
-    interval,
     refresh: loadTimeSeries,
   }
 }

--- a/src/services/useTopologyThresholds/index.ts
+++ b/src/services/useTopologyThresholds/index.ts
@@ -4,9 +4,15 @@ import {
   type TopologyThresholdFilter,
   type TopologyThresholdNode,
 } from '@deltares/fews-pi-requests'
-import { type Pausable } from '@vueuse/core'
-import type { MaybeRefOrGetter, Ref, ShallowRef } from 'vue'
-import { ref, shallowRef, toValue, watch } from 'vue'
+import {
+  type MaybeRefOrGetter,
+  type Ref,
+  type ShallowRef,
+  ref,
+  shallowRef,
+  toValue,
+  watch,
+} from 'vue'
 import { useFocusAwareInterval } from '../useFocusAwareInterval'
 
 export interface UseTopologyThresholdsReturn {
@@ -14,7 +20,6 @@ export interface UseTopologyThresholdsReturn {
   thresholds: ShallowRef<TopologyThresholdNode[] | undefined>
   isReady: Ref<boolean>
   isLoading: Ref<boolean>
-  interval: Pausable
 }
 
 const THRESHOLDS_POLLING_INTERVAL = 1000 * 30
@@ -53,7 +58,9 @@ export function useTopologyThresholds(
   const interval = useFocusAwareInterval(
     loadTopologyThresholds,
     THRESHOLDS_POLLING_INTERVAL,
-    { immediateCallback: true },
+    {
+      immediateCallback: true,
+    },
   )
 
   watch(
@@ -69,6 +76,5 @@ export function useTopologyThresholds(
     isReady,
     isLoading,
     error,
-    interval,
   }
 }


### PR DESCRIPTION
### Description
Since timeseries ids now have taskruns it can be that we don't show the most current graph without refreshing the actions.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
