### PR TITLE
Add ability to visualize task runs through the tasks menu

### DIFF
--- a/src/components/charts/ChartLegend.vue
+++ b/src/components/charts/ChartLegend.vue
@@ -42,6 +42,13 @@
             />
 
             <span class="text-truncate">{{ tag.name }}</span>
+
+            <v-tooltip
+              v-if="tag.tooltip"
+              activator="parent"
+              location="top"
+              :text="tag.tooltip"
+            />
           </v-chip>
         </v-chip-group>
       </div>
@@ -241,5 +248,9 @@ function onToggleExpand() {
 
 .overlay .hidden {
   opacity: 0;
+}
+
+.pre-line {
+  white-space: pre-line;
 }
 </style>

--- a/src/components/charts/TimeSeriesChart.vue
+++ b/src/components/charts/TimeSeriesChart.vue
@@ -44,7 +44,7 @@ import {
 } from '@/lib/charts/dataFromResources'
 import { extent } from 'd3'
 import { difference, uniq } from 'lodash-es'
-import type { Tag } from '@/lib/charts/tags'
+import { getMatchingIndexedString, type Tag } from '@/lib/charts/tags'
 import { type ChartsSettings } from '@/lib/topology/componentSettings'
 import { getAxisOptions } from '@/lib/charts/axisOptions'
 
@@ -55,6 +55,7 @@ interface Props {
   isLoading?: boolean
   zoomHandler?: ZoomHandler
   verticalProfile?: boolean
+  forecastLegend?: string
   settings: ChartsSettings['timeSeriesChart']
 }
 
@@ -338,12 +339,13 @@ const setTags = () => {
         }
       }
       legendSvg.appendChild(svgGroup)
-      const name = seriesData.find((s) => s.id === id)?.name || ''
+      const name = seriesData.find((s) => s.id === id)?.name ?? ''
       return {
-        id: id,
-        name: name || '',
+        id,
+        name,
         disabled: false,
         legendSvg: s.serializeToString(legendSvg),
+        tooltip: getMatchingIndexedString(name, props.forecastLegend),
       }
     })
   }

--- a/src/components/spatialdisplay/SpatialTimeSeriesDisplay.vue
+++ b/src/components/spatialdisplay/SpatialTimeSeriesDisplay.vue
@@ -32,6 +32,7 @@ import { computed } from 'vue'
 import { useSystemTimeStore } from '@/stores/systemTime'
 import { useLocationTooltip } from '@/services/useLocationTooltip'
 import type { ComponentSettings } from '@/lib/topology/componentSettings'
+import { useTaskRunsStore } from '@/stores/taskRuns'
 
 interface Props {
   filter?: filterActionsFilter | timeSeriesGridActionsFilter
@@ -42,6 +43,7 @@ interface Props {
 }
 
 const systemTimeStore = useSystemTimeStore()
+const taskRunsStore = useTaskRunsStore()
 
 const props = defineProps<Props>()
 const emit = defineEmits(['close'])
@@ -54,6 +56,7 @@ const { displayConfig } = useDisplayConfigFilter(
   filter,
   () => systemTimeStore.startTime,
   () => systemTimeStore.endTime,
+  () => taskRunsStore.selectedTaskRunIds
 )
 const { displayConfig: elevationChartDisplayconfig } = useDisplayConfigFilter(
   baseUrl,

--- a/src/components/spatialdisplay/SpatialTimeSeriesDisplay.vue
+++ b/src/components/spatialdisplay/SpatialTimeSeriesDisplay.vue
@@ -56,7 +56,7 @@ const { displayConfig } = useDisplayConfigFilter(
   filter,
   () => systemTimeStore.startTime,
   () => systemTimeStore.endTime,
-  () => taskRunsStore.selectedTaskRunIds
+  () => taskRunsStore.selectedTaskRunIds,
 )
 const { displayConfig: elevationChartDisplayconfig } = useDisplayConfigFilter(
   baseUrl,

--- a/src/components/spatialdisplay/SpatialTimeSeriesDisplay.vue
+++ b/src/components/spatialdisplay/SpatialTimeSeriesDisplay.vue
@@ -63,6 +63,7 @@ const { displayConfig: elevationChartDisplayconfig } = useDisplayConfigFilter(
   () => props.elevationChartFilter ?? {},
   () => systemTimeStore.startTime,
   () => systemTimeStore.endTime,
+  () => taskRunsStore.selectedTaskRunIds,
 )
 
 const { tooltip } = useLocationTooltip(

--- a/src/components/tasks/TaskRunProgress.vue
+++ b/src/components/tasks/TaskRunProgress.vue
@@ -51,9 +51,9 @@ function updateProgress(): void {
   // Compute expected fraction done.
   const fractionDone = currentDurationSeconds / props.expectedRuntimeSeconds
 
-  // If we are over 100%, set progress to null since we cannot predict our
+  // If we are over 100%, set progress to 100% and do not show the
   // progress anymore.
-  setProgress(fractionDone <= 1 ? fractionDone * 100 : null)
+  setProgress(fractionDone <= 1 ? fractionDone * 100 : 100)
 }
 
 function setProgress(newProgress: number | null): void {

--- a/src/components/tasks/TaskRunProgress.vue
+++ b/src/components/tasks/TaskRunProgress.vue
@@ -14,7 +14,7 @@
 <script setup lang="ts">
 import { useFocusAwareInterval } from '@/services/useFocusAwareInterval'
 import { Duration, DurationUnit } from 'luxon'
-import { ref } from 'vue'
+import { onMounted, ref } from 'vue'
 
 interface Props {
   dispatchTimestamp: number | null
@@ -29,6 +29,10 @@ const props = withDefaults(defineProps<Props>(), {
 const progress = ref(0)
 const isUnknownProgress = ref(false)
 const details = ref('')
+
+onMounted(() => {
+  updateProgress()
+})
 
 useFocusAwareInterval(updateProgress, () => props.updateIntervalSeconds, {
   immediate: true,

--- a/src/components/tasks/TaskRunSummary.vue
+++ b/src/components/tasks/TaskRunSummary.vue
@@ -36,6 +36,18 @@
                 {{ whatIfTemplate.name }}
               </v-list-item-subtitle>
             </div>
+            <v-checkbox-btn
+              class="flex-0-0"
+              density="compact"
+              trueIcon="mdi-chart-areaspline-variant"
+              falseIcon="mdi-chart-line"
+              color="primary"
+              :disabled="task.isCurrent"
+              :model-value="
+                taskRunsStore.taskRunIsSelected(task) || task.isCurrent
+              "
+              @click.stop="taskRunsStore.toggleTaskRun(task)"
+            />
           </div>
         </div>
       </div>
@@ -67,9 +79,11 @@ import {
   toHumanReadableDate,
 } from '@/lib/date'
 import { useAvailableWhatIfTemplatesStore } from '@/stores/availableWhatIfTemplates'
+import { useTaskRunsStore } from '@/stores/taskRuns'
 
 const availableWorkflowsStore = useAvailableWorkflowsStore()
 const availableWhatIfTemplatesStore = useAvailableWhatIfTemplatesStore()
+const taskRunsStore = useTaskRunsStore()
 
 interface Props {
   task: TaskRun

--- a/src/components/tasks/TaskRunSummary.vue
+++ b/src/components/tasks/TaskRunSummary.vue
@@ -46,7 +46,13 @@
               color="primary"
               :disabled="task.isCurrent"
               @click.stop="taskRunsStore.toggleTaskRun(task)"
-            />
+            >
+              <v-tooltip
+                text="Visualize task in graphs"
+                open-delay="500"
+                activator="parent"
+              />
+            </v-checkbox-btn>
           </div>
         </div>
       </div>

--- a/src/components/tasks/TaskRunSummary.vue
+++ b/src/components/tasks/TaskRunSummary.vue
@@ -37,7 +37,7 @@
               </v-list-item-subtitle>
             </div>
             <v-checkbox-btn
-              v-if="isCompleted"
+              v-if="isCompleted && canVisualize"
               v-model="selected"
               class="flex-0-0"
               density="compact"
@@ -88,6 +88,7 @@ const taskRunsStore = useTaskRunsStore()
 
 interface Props {
   task: TaskRun
+  canVisualize: boolean
 }
 const props = defineProps<Props>()
 

--- a/src/components/tasks/TaskRunSummary.vue
+++ b/src/components/tasks/TaskRunSummary.vue
@@ -37,6 +37,7 @@
               </v-list-item-subtitle>
             </div>
             <v-checkbox-btn
+              v-if="isCompleted"
               class="flex-0-0"
               density="compact"
               trueIcon="mdi-chart-areaspline-variant"
@@ -66,8 +67,10 @@ import {
   convertTaskStatusToString,
   getColorForTaskStatus,
   getIconForTaskStatus,
+  getTaskStatusCategory,
   TaskRun,
   TaskStatus,
+  TaskStatusCategory,
 } from '@/lib/taskruns'
 import { useAvailableWorkflowsStore } from '@/stores/availableWorkflows'
 import { computed } from 'vue'
@@ -212,6 +215,10 @@ const statusColor = computed(() =>
 const statusIcon = computed<string>(() =>
   getIconForTaskStatus(props.task.status),
 )
+const isCompleted = computed(() => {
+  const category = getTaskStatusCategory(props.task.status)
+  return category === TaskStatusCategory.Completed
+})
 
 function onExpansionPanelToggle() {
   // Only expand when no text is selected

--- a/src/components/tasks/TaskRunSummary.vue
+++ b/src/components/tasks/TaskRunSummary.vue
@@ -38,15 +38,13 @@
             </div>
             <v-checkbox-btn
               v-if="isCompleted"
+              v-model="selected"
               class="flex-0-0"
               density="compact"
               trueIcon="mdi-chart-areaspline-variant"
               falseIcon="mdi-chart-line"
               color="primary"
               :disabled="task.isCurrent"
-              :model-value="
-                taskRunsStore.taskRunIsSelected(task) || task.isCurrent
-              "
               @click.stop="taskRunsStore.toggleTaskRun(task)"
             />
           </div>
@@ -96,6 +94,17 @@ const props = defineProps<Props>()
 const expanded = defineModel<boolean>('expanded', {
   required: false,
   default: false,
+})
+
+// This should be done with :model-value but its internal watch sometimes
+// doesn't trigger when the value changes
+const selected = computed({
+  get() {
+    return taskRunsStore.taskRunIsSelected(props.task) || props.task.isCurrent
+  },
+  set(_) {
+    // No-op
+  },
 })
 
 const tableData = computed(() => [

--- a/src/components/tasks/TaskRunsControl.vue
+++ b/src/components/tasks/TaskRunsControl.vue
@@ -8,26 +8,26 @@
     <div v-if="isPanelOpen" class="d-flex flex-column h-100 w-100">
       <v-tabs v-model="selectedTab" density="compact" class="flex-0-0">
         <v-tab
-          value="tasks"
-          prepend-icon="mdi-clipboard-text"
-          class="text-none"
-        >
-          Tasks
-        </v-tab>
-        <v-tab
           value="visualize-tasks"
           prepend-icon="mdi-chart-line"
           class="text-none"
         >
-          Visualize Tasks
+          Visualize Data
+        </v-tab>
+        <v-tab
+          value="tasks"
+          prepend-icon="mdi-clipboard-text"
+          class="text-none"
+        >
+          All Tasks
         </v-tab>
       </v-tabs>
       <v-window v-model="selectedTab" class="flex-1-1">
-        <v-window-item value="tasks" class="h-100">
-          <TaskRunsPanel />
-        </v-window-item>
         <v-window-item value="visualize-tasks" class="h-100">
           <TaskRunsPanel :topologyNode="topologyNode" />
+        </v-window-item>
+        <v-window-item value="tasks" class="h-100">
+          <TaskRunsPanel />
         </v-window-item>
       </v-window>
     </div>

--- a/src/components/tasks/TaskRunsControl.vue
+++ b/src/components/tasks/TaskRunsControl.vue
@@ -5,12 +5,18 @@
     @click="toggleTasksPanel"
   />
   <Teleport to="#main-side-panel" defer>
-    <TaskRunsPanel v-if="isPanelOpen" />
+    <TaskRunsPanel v-if="isPanelOpen" :topologyNodeId="topologyNodeId" />
   </Teleport>
 </template>
 <script setup lang="ts">
 import { ref } from 'vue'
 import TaskRunsPanel from './TaskRunsPanel.vue'
+
+interface Props {
+  topologyNodeId?: string
+}
+
+defineProps<Props>()
 
 const isPanelOpen = ref(false)
 

--- a/src/components/tasks/TaskRunsControl.vue
+++ b/src/components/tasks/TaskRunsControl.vue
@@ -5,7 +5,32 @@
     @click="toggleTasksPanel"
   />
   <Teleport to="#main-side-panel" defer>
-    <TaskRunsPanel v-if="isPanelOpen" :topologyNode="topologyNode" />
+    <div v-if="isPanelOpen" class="d-flex flex-column h-100 w-100">
+      <v-tabs v-model="selectedTab" density="compact" class="flex-0-0">
+        <v-tab
+          value="tasks"
+          prepend-icon="mdi-clipboard-text"
+          class="text-none"
+        >
+          Tasks
+        </v-tab>
+        <v-tab
+          value="visualize-tasks"
+          prepend-icon="mdi-chart-line"
+          class="text-none"
+        >
+          Visualize Tasks
+        </v-tab>
+      </v-tabs>
+      <v-window v-model="selectedTab" class="flex-1-1">
+        <v-window-item value="tasks" class="h-100">
+          <TaskRunsPanel />
+        </v-window-item>
+        <v-window-item value="visualize-tasks" class="h-100">
+          <TaskRunsPanel :topologyNode="topologyNode" />
+        </v-window-item>
+      </v-window>
+    </div>
   </Teleport>
 </template>
 <script setup lang="ts">
@@ -20,6 +45,7 @@ interface Props {
 defineProps<Props>()
 
 const isPanelOpen = ref(false)
+const selectedTab = ref('tasks')
 
 function toggleTasksPanel(): void {
   isPanelOpen.value = !isPanelOpen.value
@@ -35,5 +61,16 @@ function toggleTasksPanel(): void {
   width: 450px;
   display: grid;
   grid-template-rows: auto 1fr auto auto;
+}
+
+.contain {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  height: 100%;
+  width: 100%;
+}
+
+:deep(.v-window__container) {
+  height: 100%;
 }
 </style>

--- a/src/components/tasks/TaskRunsControl.vue
+++ b/src/components/tasks/TaskRunsControl.vue
@@ -63,13 +63,6 @@ function toggleTasksPanel(): void {
   grid-template-rows: auto 1fr auto auto;
 }
 
-.contain {
-  display: grid;
-  grid-template-rows: auto 1fr;
-  height: 100%;
-  width: 100%;
-}
-
 :deep(.v-window__container) {
   height: 100%;
 }

--- a/src/components/tasks/TaskRunsControl.vue
+++ b/src/components/tasks/TaskRunsControl.vue
@@ -5,15 +5,16 @@
     @click="toggleTasksPanel"
   />
   <Teleport to="#main-side-panel" defer>
-    <TaskRunsPanel v-if="isPanelOpen" :topologyNodeId="topologyNodeId" />
+    <TaskRunsPanel v-if="isPanelOpen" :topologyNode="topologyNode" />
   </Teleport>
 </template>
 <script setup lang="ts">
 import { ref } from 'vue'
 import TaskRunsPanel from './TaskRunsPanel.vue'
+import type { TopologyNode } from '@deltares/fews-pi-requests'
 
 interface Props {
-  topologyNodeId?: string
+  topologyNode?: TopologyNode
 }
 
 defineProps<Props>()

--- a/src/components/tasks/TaskRunsPanel.vue
+++ b/src/components/tasks/TaskRunsPanel.vue
@@ -11,7 +11,11 @@
     </div>
     <div class="overflow-y-auto">
       <v-list-item v-if="sortedTasks.length === 0">
-        {{ 'No tasks available' }}
+        {{
+          props.topologyNode
+            ? 'No tasks with data to visualize for this display.'
+            : 'No tasks available.'
+        }}
       </v-list-item>
 
       <!-- Important to have item-height as it greatly improves performance -->
@@ -22,9 +26,15 @@
         :item-height="62"
       >
         <template #default="{ item: task }">
-          <div v-if="!isTaskRun(task)" class="mx-2">
+          <v-btn
+            v-if="!isTaskRun(task)"
+            class="mx-2 px-1 text-none"
+            variant="plain"
+            :append-icon="getIcon(task.label)"
+            @click="toggle(task.label)"
+          >
             {{ task.label }}
-          </div>
+          </v-btn>
           <div v-else class="mb-2 mx-2">
             <TaskRunSummary
               :task="task"
@@ -134,6 +144,8 @@ const {
 )
 
 const sortedTasks = computed(() => filteredTaskRuns.value.toSorted(sortTasks))
+const showCurrent = ref(true)
+const showNonCurrent = ref(true)
 
 const groupedTasks = computed(() => {
   const currentTasks = sortedTasks.value.filter((task) => task.isCurrent)
@@ -141,14 +153,37 @@ const groupedTasks = computed(() => {
 
   const result = []
   if (currentTasks.length) {
-    result.push({ isHeader: true, label: 'Current' }, ...currentTasks)
+    result.push({ isHeader: true, label: 'Current' })
+    if (showCurrent.value) {
+      result.push(...currentTasks)
+    }
   }
   if (nonCurrentTasks.length) {
-    result.push({ isHeader: true, label: 'Non Current' }, ...nonCurrentTasks)
+    result.push({ isHeader: true, label: 'Non Current' })
+    if (showNonCurrent.value) {
+      result.push(...nonCurrentTasks)
+    }
   }
 
   return result
 })
+
+function toggle(label: string) {
+  if (label === 'Current') {
+    showCurrent.value = !showCurrent.value
+  } else if (label === 'Non Current') {
+    showNonCurrent.value = !showNonCurrent.value
+  }
+}
+
+function getIcon(label: string) {
+  if (label === 'Current') {
+    return showCurrent.value ? 'mdi-chevron-down' : 'mdi-chevron-right'
+  } else if (label === 'Non Current') {
+    return showNonCurrent.value ? 'mdi-chevron-down' : 'mdi-chevron-right'
+  }
+  return ''
+}
 
 const lastUpdatedString = computed<string>(() => {
   const lastUpdated = lastUpdatedTimestamp.value

--- a/src/components/tasks/TaskRunsPanel.vue
+++ b/src/components/tasks/TaskRunsPanel.vue
@@ -149,7 +149,7 @@ const taskRuns = computed(() =>
     : filteredTaskRuns.value,
 )
 
-const sortedTasks = computed(() => taskRuns.value.sort(sortTasks))
+const sortedTasks = computed(() => taskRuns.value.toSorted(sortTasks))
 
 const groupedTasks = computed(() => {
   const currentTasks = sortedTasks.value.filter((task) => task.isCurrent)

--- a/src/components/tasks/TaskRunsPanel.vue
+++ b/src/components/tasks/TaskRunsPanel.vue
@@ -30,8 +30,8 @@
             v-if="!isTaskRun(task)"
             class="mx-2 px-1 text-none"
             variant="plain"
-            :append-icon="getIcon(task.label)"
-            @click="toggle(task.label)"
+            :append-icon="getTaskSectionIcon(task.label)"
+            @click="toggleTaskSection(task.label)"
           >
             {{ task.label }}
           </v-btn>
@@ -168,7 +168,7 @@ const groupedTasks = computed(() => {
   return result
 })
 
-function toggle(label: string) {
+function toggleTaskSection(label: string) {
   if (label === 'Current') {
     showCurrent.value = !showCurrent.value
   } else if (label === 'Non Current') {
@@ -176,7 +176,7 @@ function toggle(label: string) {
   }
 }
 
-function getIcon(label: string) {
+function getTaskSectionIcon(label: string) {
   if (label === 'Current') {
     return showCurrent.value ? 'mdi-chevron-down' : 'mdi-chevron-right'
   } else if (label === 'Non Current') {

--- a/src/components/tasks/TaskRunsPanel.vue
+++ b/src/components/tasks/TaskRunsPanel.vue
@@ -108,9 +108,9 @@ watch(
 // Select all task statuses by default.
 const selectedTaskStatuses = ref<TaskStatus[]>(Object.values(TaskStatus))
 
-// Look 2 hours back by default.
+// Look 1 day back by default.
 const period = ref<RelativePeriod | null>({
-  startOffsetSeconds: -2 * 60 * 60,
+  startOffsetSeconds: -24 * 60 * 60,
   endOffsetSeconds: 0,
 })
 

--- a/src/components/tasks/TaskRunsPanel.vue
+++ b/src/components/tasks/TaskRunsPanel.vue
@@ -64,6 +64,12 @@ import TaskRunSummary from './TaskRunSummary.vue'
 import WorkflowFilterControl from './WorkflowFilterControl.vue'
 import PeriodFilterControl from './PeriodFilterControl.vue'
 
+interface Props {
+  topologyNodeId?: string
+}
+
+const props = defineProps<Props>()
+
 const availableWorkflowsStore = useAvailableWorkflowsStore()
 
 const selectedWorkflowIds = ref<string[]>(availableWorkflowsStore.workflowIds)
@@ -114,6 +120,7 @@ const taskRuns = useTaskRuns(
   period,
   selectedWorkflowIds,
   selectedTaskStatuses,
+  () => props.topologyNodeId,
 )
 
 const sortedTasks = computed<TaskRun[]>(() => {

--- a/src/components/tasks/TaskStatusFilterControl.vue
+++ b/src/components/tasks/TaskStatusFilterControl.vue
@@ -17,7 +17,7 @@
           v-for="category in getAllTaskStatusCategories()"
           :key="category"
           :value="category"
-          @click="toggleStatusCategory(category)"
+          @click="updateSelectedTaskStatus"
         >
           {{ getTaskStatusCategoryName(category) }}
         </v-btn>
@@ -31,7 +31,7 @@ import { ref } from 'vue'
 import {
   getAllTaskStatusCategories,
   getCompleteTaskStatusCategories,
-  getTaskStatusesForCategory,
+  getTaskStatusesForCategories,
   getTaskStatusCategoryName,
   TaskStatus,
   TaskStatusCategory,
@@ -41,9 +41,6 @@ import BaseTaskFilterControl from '@/components/tasks/BaseTaskFilterControl.vue'
 
 const selectedTaskStatuses = defineModel<TaskStatus[]>({ required: true })
 const selectedCategories = ref<TaskStatusCategory[]>([])
-// Initialise the group selections based on the initially selected task
-// statuses.
-updateSelectedCategories(selectedTaskStatuses.value)
 
 interface TaskStatusItem {
   id: string
@@ -61,33 +58,28 @@ const taskStatusOptions: TaskStatusItem[] = Object.values(TaskStatus).map(
     }
   },
 )
+// Initialise the group selections based on the initially selected task
+// statuses.
+updateSelectedCategories(selectedTaskStatuses.value)
 
 // Update the selected task status groups when the user selects or deselects
 // individual statuses.
 function updateSelectedCategories(newStatuses: TaskStatus[]): void {
-  selectedCategories.value = getCompleteTaskStatusCategories(newStatuses)
+  if (newStatuses.length === taskStatusOptions.length) {
+    selectedCategories.value = []
+  } else {
+    selectedCategories.value = getCompleteTaskStatusCategories(newStatuses)
+  }
 }
 
-function toggleStatusCategory(category: TaskStatusCategory): void {
-  const isCurrentlySelected = selectedCategories.value.includes(category)
-
-  // This function is triggered _after_ the model value has been updated, so if
-  // we no longer have this category in the selected category, remove the
-  // associated statuses.
-  const doRemove = !isCurrentlySelected
-
-  const categoryStatuses = getTaskStatusesForCategory(category)
-  if (doRemove) {
-    // Remove statuses for this group from the current selection.
-    selectedTaskStatuses.value = selectedTaskStatuses.value.filter(
-      (status) => !categoryStatuses.includes(status),
-    )
-  } else {
-    // Add statuses for this group to the current selection.
-    selectedTaskStatuses.value = [
-      ...selectedTaskStatuses.value,
-      ...categoryStatuses,
-    ]
+function updateSelectedTaskStatus(): void {
+  if (selectedCategories.value.length === 0) {
+    selectedTaskStatuses.value = Object.values(TaskStatus)
+    return
   }
+
+  selectedTaskStatuses.value = getTaskStatusesForCategories(
+    selectedCategories.value,
+  )
 }
 </script>

--- a/src/components/timeseries/TimeSeriesComponent.vue
+++ b/src/components/timeseries/TimeSeriesComponent.vue
@@ -15,6 +15,7 @@
           :isLoading="isLoading(subplot, loadingSeriesIds)"
           :zoomHandler="sharedZoomHandler"
           :settings="settings.timeSeriesChart"
+          :forecast-legend="config.forecastLegend"
         >
         </TimeSeriesChart>
       </KeepAlive>
@@ -131,6 +132,7 @@ const props = withDefaults(defineProps<Props>(), {
       requests: [],
       subplots: [],
       period: undefined,
+      forecastLegend: undefined,
     }
   },
   elevationChartConfig: () => {
@@ -145,6 +147,7 @@ const props = withDefaults(defineProps<Props>(), {
       requests: [],
       subplots: [],
       period: undefined,
+      forecastLegend: undefined,
     }
   },
   settings: () => getDefaultSettings().charts,

--- a/src/components/timeseries/TimeSeriesComponent.vue
+++ b/src/components/timeseries/TimeSeriesComponent.vue
@@ -15,7 +15,7 @@
           :isLoading="isLoading(subplot, loadingSeriesIds)"
           :zoomHandler="sharedZoomHandler"
           :settings="settings.timeSeriesChart"
-          :forecast-legend="config.forecastLegend"
+          :forecastLegend="config.forecastLegend"
         >
         </TimeSeriesChart>
       </KeepAlive>

--- a/src/components/timeseries/TimeSeriesDisplay.vue
+++ b/src/components/timeseries/TimeSeriesDisplay.vue
@@ -42,6 +42,7 @@ import {
 } from '@/services/useDisplayConfig/index.ts'
 import { useUserSettingsStore } from '@/stores/userSettings'
 import { useSystemTimeStore } from '@/stores/systemTime'
+import { useTaskRunsStore } from '@/stores/taskRuns'
 import {
   type ComponentSettings,
   getDefaultSettings,
@@ -59,6 +60,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const userSettings = useUserSettingsStore()
 const systemTimeStore = useSystemTimeStore()
+const taskRunsStore = useTaskRunsStore()
 
 const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
 
@@ -83,6 +85,7 @@ const { displays, displayConfig } = useDisplayConfig(
   () => systemTimeStore.startTime,
   () => systemTimeStore.endTime,
   options,
+  () => taskRunsStore.selectedTaskRunIds,
 )
 
 watchEffect(() => {

--- a/src/layouts/DefaultLayout.vue
+++ b/src/layouts/DefaultLayout.vue
@@ -11,7 +11,6 @@
       <div class="h-100" id="app-bar-content-center"></div>
       <template #append>
         <div id="app-bar-content-end" />
-        <TaskRunsControl v-if="showTaskMenu" />
         <TimeControlMenu />
         <UserSettingsMenu />
         <LoginComponent v-if="configManager.authenticationIsEnabled" />
@@ -174,7 +173,6 @@ import UserSettingsMenu from '../components/user-settings/UserSettingsMenu.vue'
 import TimeControlMenu from '../components/time-control/TimeControlMenu.vue'
 import StartupDialog from '@/components/dialog/StartupDialog.vue'
 import GlobalSearchComponent from '@/components/general/GlobalSearchComponent.vue'
-import TaskRunsControl from '@/components/tasks/TaskRunsControl.vue'
 
 import { configManager } from '@/services/application-config'
 import { getResourcesStaticUrl } from '@/lib/fews-config'
@@ -286,8 +284,6 @@ const shouldRenderInfoMenu = computed(() => {
   if (currentRoute === undefined) return false
   return !currentRoute.meta?.sidebar
 })
-
-const showTaskMenu = computed(() => configStore.general.taskMenu?.enabled)
 
 function onCloseAlert(alert: Alert) {
   alertsStore.removeAlert(alert.id)

--- a/src/lib/charts/tags.ts
+++ b/src/lib/charts/tags.ts
@@ -3,4 +3,14 @@ export interface Tag {
   name: string
   disabled: boolean
   legendSvg: string
+  tooltip?: string
+}
+
+export function getMatchingIndexedString(item: string, text?: string) {
+  if (!text) return
+
+  const match = item.match(/\[(\d+)\]/)?.[0]
+  if (!match) return
+
+  return text.split('\n').find((line) => line.includes(match))
 }

--- a/src/lib/display/DisplayConfig.ts
+++ b/src/lib/display/DisplayConfig.ts
@@ -14,6 +14,7 @@ export interface DisplayConfig {
   plotId: string | undefined
   index: number | undefined
   title: string
+  forecastLegend: string | undefined
   class: string
   requests: any[]
   period: ActionPeriod | undefined

--- a/src/lib/taskruns/index.ts
+++ b/src/lib/taskruns/index.ts
@@ -1,3 +1,4 @@
 export * from './convert'
 export * from './status'
 export * from './types'
+export * from './utils'

--- a/src/lib/taskruns/status.ts
+++ b/src/lib/taskruns/status.ts
@@ -77,13 +77,13 @@ export function getCompleteTaskStatusCategories(
   return completeCategories
 }
 
-export function getTaskStatusesForCategory(
-  selectedCategory: TaskStatusCategory,
+export function getTaskStatusesForCategories(
+  selectedCategories: TaskStatusCategory[],
 ): TaskStatus[] {
-  const category = STATUS_CATEGORIES.find(
-    (current) => current.category === selectedCategory,
+  const categories = STATUS_CATEGORIES.filter((current) =>
+    selectedCategories.includes(current.category),
   )
-  return category?.statuses ?? []
+  return categories.flatMap((category) => category.statuses)
 }
 
 export function getIconForTaskStatus(status: TaskStatus): string {

--- a/src/lib/taskruns/types.ts
+++ b/src/lib/taskruns/types.ts
@@ -36,3 +36,7 @@ export interface TaskRun {
 export function isTaskStatus(value: string): value is TaskStatus {
   return Object.values(TaskStatus).includes(value as TaskStatus)
 }
+
+export function isTaskRun(value: unknown): value is TaskRun {
+  return typeof value === 'object' && value !== null && 'taskId' in value
+}

--- a/src/lib/taskruns/utils.ts
+++ b/src/lib/taskruns/utils.ts
@@ -1,0 +1,19 @@
+import { TaskRun } from './types'
+
+export function sortTasks(a: TaskRun, b: TaskRun): number {
+  const hasDispatchTimeA = a.dispatchTimestamp !== null
+  const hasDispatchTimeB = b.dispatchTimestamp !== null
+  if (!hasDispatchTimeA && !hasDispatchTimeB) {
+    // If both tasks are pending, sort by workflowId.
+    return a.workflowId.localeCompare(b.workflowId)
+  } else if (!hasDispatchTimeA) {
+    // If A is pending and B is not, return A.
+    return -1
+  } else if (!hasDispatchTimeB) {
+    // If B is pending and A is not, return B.
+    return 1
+  } else {
+    // Otherwise, sort by timestamp.
+    return b.dispatchTimestamp! - a.dispatchTimestamp!
+  }
+}

--- a/src/services/useDisplayConfig/index.ts
+++ b/src/services/useDisplayConfig/index.ts
@@ -1,4 +1,5 @@
 import {
+  ActionResult,
   PiWebserviceProvider,
   type ActionsResponse,
 } from '@deltares/fews-pi-requests'
@@ -148,6 +149,7 @@ export function useDisplayConfigFilter(
   filter: MaybeRefOrGetter<Filter | undefined>,
   startTime: MaybeRefOrGetter<Date | undefined>,
   endTime: MaybeRefOrGetter<Date | undefined>,
+  taskRunIds?: MaybeRefOrGetter<string[] | undefined>,
 ): UseDisplayConfigReturn {
   const piProvider = new PiWebserviceProvider(baseUrl, {
     transformRequestFn: createTransformRequestFn(),
@@ -160,27 +162,26 @@ export function useDisplayConfigFilter(
   watchEffect(async () => {
     const _filter = toValue(filter)
     if (_filter === undefined) return
+
     if (isFilterActionsFilter(_filter)) {
       if (!_filter.filterId) return
-      response.value = await piProvider.getFilterActions(_filter)
+
+      const _taskRunIds = toValue(taskRunIds)
+
+      const taskRunsFilter = {
+        ..._filter,
+        taskRunIds: _taskRunIds?.join(','),
+        currentForecastsAlwaysVisible: true,
+      }
+
+      const _response = await piProvider.getFilterActions(
+        _taskRunIds ? taskRunsFilter : _filter,
+      )
+      response.value = _response
     } else if (isTimeSeriesGridActionsFilter(_filter)) {
-      response.value = await piProvider.getTimeSeriesGridActions(_filter)
-      response.value.results.forEach((result) => {
-        result.requests.forEach((request) => {
-          request.key = MD5(request.request).toString()
-        })
-        if (result.config?.timeSeriesDisplay.subplots) {
-          let i = 0
-          result.config.timeSeriesDisplay.subplots.forEach((subPlot) => {
-            subPlot.items.forEach((item) => {
-              if (item.request === undefined) {
-                item.request = `${result.requests[0].key}[${i}]`
-              }
-              i++
-            })
-          })
-        }
-      })
+      const _response = await piProvider.getTimeSeriesGridActions(_filter)
+      addIndexToKeys(_response.results)
+      response.value = _response
     } else {
       displayConfig.value = null
       displays.value = null
@@ -212,4 +213,23 @@ export function useDisplayConfigFilter(
   }
 
   return shell
+}
+
+function addIndexToKeys(results: ActionResult[]) {
+  results.forEach((result) => {
+    result.requests.forEach((request) => {
+      request.key = MD5(request.request).toString()
+    })
+    if (result.config?.timeSeriesDisplay.subplots) {
+      let i = 0
+      result.config.timeSeriesDisplay.subplots.forEach((subPlot) => {
+        subPlot.items.forEach((item) => {
+          if (item.request === undefined) {
+            item.request = `${result.requests[0].key}[${i}]`
+          }
+          i++
+        })
+      })
+    }
+  })
 }

--- a/src/services/useDisplayConfig/index.ts
+++ b/src/services/useDisplayConfig/index.ts
@@ -67,6 +67,7 @@ function actionsResponseToDisplayConfig(
     const display: DisplayConfig = {
       id: title,
       title,
+      forecastLegend: result.config.timeSeriesDisplay.forecastLegend,
       plotId,
       nodeId: nodeId,
       class: 'singles',

--- a/src/services/useDisplayConfig/index.ts
+++ b/src/services/useDisplayConfig/index.ts
@@ -95,6 +95,7 @@ export function useDisplayConfig(
   startTime?: MaybeRefOrGetter<Date | undefined>,
   endTime?: MaybeRefOrGetter<Date | undefined>,
   options?: MaybeRefOrGetter<UseDisplayConfigOptions>,
+  taskRunIds?: MaybeRefOrGetter<string[]>,
 ): UseDisplayConfigReturn {
   const piProvider = new PiWebserviceProvider(baseUrl, {
     transformRequestFn: createTransformRequestFn(),
@@ -106,10 +107,22 @@ export function useDisplayConfig(
     const _nodeId = toValue(nodeId)
     if (_nodeId === undefined) return
 
-    response.value = await piProvider.getTopologyActions({
+    const filter = {
       nodeId: _nodeId,
       ...toValue(options),
-    })
+    }
+
+    const _taskRunIds = toValue(taskRunIds)
+    const taskRunsFilter = {
+      ...filter,
+      // TODO: Change this to string.join(',') when the backend is fixed
+      taskRunIds: _taskRunIds,
+      currentForecastsAlwaysVisible: true,
+    }
+
+    response.value = await piProvider.getTopologyActions(
+      _taskRunIds?.length ? taskRunsFilter : filter,
+    )
   })
 
   const displays = computed(() => {

--- a/src/services/useDisplayConfig/index.ts
+++ b/src/services/useDisplayConfig/index.ts
@@ -3,7 +3,7 @@ import {
   PiWebserviceProvider,
   type ActionsResponse,
 } from '@deltares/fews-pi-requests'
-import { computed, ref, toValue, watchEffect } from 'vue'
+import { computed, ref, toValue, watch, watchEffect } from 'vue'
 import type { MaybeRefOrGetter, Ref } from 'vue'
 import { DisplayConfig } from '../../lib/display/DisplayConfig.js'
 import { timeSeriesDisplayToChartConfig } from '../../lib/charts/timeSeriesDisplayToChartConfig.js'
@@ -150,7 +150,7 @@ export function useDisplayConfigFilter(
   filter: MaybeRefOrGetter<Filter | undefined>,
   startTime: MaybeRefOrGetter<Date | undefined>,
   endTime: MaybeRefOrGetter<Date | undefined>,
-  taskRunIds?: MaybeRefOrGetter<string[] | undefined>,
+  taskRunIds?: MaybeRefOrGetter<string[]>,
 ): UseDisplayConfigReturn {
   const piProvider = new PiWebserviceProvider(baseUrl, {
     transformRequestFn: createTransformRequestFn(),
@@ -168,7 +168,6 @@ export function useDisplayConfigFilter(
       if (!_filter.filterId) return
 
       const _taskRunIds = toValue(taskRunIds)
-
       const taskRunsFilter = {
         ..._filter,
         taskRunIds: _taskRunIds?.join(','),
@@ -176,7 +175,7 @@ export function useDisplayConfigFilter(
       }
 
       const _response = await piProvider.getFilterActions(
-        _taskRunIds ? taskRunsFilter : _filter,
+        _taskRunIds?.length ? taskRunsFilter : _filter,
       )
       response.value = _response
     } else if (isTimeSeriesGridActionsFilter(_filter)) {

--- a/src/services/useDisplayConfig/index.ts
+++ b/src/services/useDisplayConfig/index.ts
@@ -3,7 +3,7 @@ import {
   PiWebserviceProvider,
   type ActionsResponse,
 } from '@deltares/fews-pi-requests'
-import { computed, ref, toValue, watch, watchEffect } from 'vue'
+import { computed, ref, toValue, watchEffect } from 'vue'
 import type { MaybeRefOrGetter, Ref } from 'vue'
 import { DisplayConfig } from '../../lib/display/DisplayConfig.js'
 import { timeSeriesDisplayToChartConfig } from '../../lib/charts/timeSeriesDisplayToChartConfig.js'

--- a/src/services/useSsdPi/index.ts
+++ b/src/services/useSsdPi/index.ts
@@ -73,6 +73,7 @@ export function useSsdPi(
         plotId: undefined,
         index: undefined,
         title,
+        forecastLegend: undefined,
         class: 'singles',
         requests: result.requests ?? [],
         period: undefined,

--- a/src/services/useTasksRuns/index.ts
+++ b/src/services/useTasksRuns/index.ts
@@ -89,7 +89,6 @@ export function useTaskRuns(
       endDispatchTime,
       taskRunStatusIds: Object.values(TaskStatusId),
       topologyNodeId,
-      // @ts-expect-error: FIXME: Remove once the library is fixed.
       forecastCount: 99999,
       startForecastTime: convertJSDateToFewsPiParameter(
         new Date('1900-01-01T00:00:00Z'),

--- a/src/services/useTasksRuns/index.ts
+++ b/src/services/useTasksRuns/index.ts
@@ -34,6 +34,7 @@ export function useTaskRuns(
   dispatchPeriod: MaybeRefOrGetter<RelativePeriod | null>,
   workflowIds: MaybeRefOrGetter<string[]>,
   statuses: MaybeRefOrGetter<TaskStatus[]>,
+  topologyNodeId?: MaybeRefOrGetter<string | undefined>,
 ) {
   const isLoading = ref(false)
   const lastUpdatedTimestamp = ref<number | null>(null)
@@ -50,9 +51,13 @@ export function useTaskRuns(
 
   async function fetch(): Promise<void> {
     const _dispatchPeriod = toValue(dispatchPeriod)
+    const _topologyNodeId = toValue(topologyNodeId)
 
     isLoading.value = true
-    const fetchedTaskRuns = await fetchTaskRuns(_dispatchPeriod)
+    const fetchedTaskRuns = await fetchTaskRuns(
+      _dispatchPeriod,
+      _topologyNodeId,
+    )
     isLoading.value = false
 
     allTaskRuns.value = fetchedTaskRuns.map(convertFewsPiTaskRunToTaskRun)
@@ -75,39 +80,6 @@ export function useTaskRuns(
     lastUpdatedTimestamp,
     isLoading,
     fetch,
-  }
-}
-
-export function useTopologyWorkflows(
-  topologyNodeId: MaybeRefOrGetter<string | undefined>,
-) {
-  const isLoading = ref(false)
-  const workflowIds = ref<string[]>([])
-
-  watch(() => toValue(topologyNodeId), fetch)
-
-  async function fetch(): Promise<void> {
-    const _topologyNodeId = toValue(topologyNodeId)
-    if (!_topologyNodeId) return
-
-    // FIXME: Currently only gets the workflows of the last 48 hours.
-    // We should have a separate endpoint for this.
-    const period = {
-      startOffsetSeconds: -48 * 60 * 60,
-      endOffsetSeconds: 0,
-    }
-
-    isLoading.value = true
-    const fetchedTaskRuns = await fetchTaskRuns(period, _topologyNodeId)
-    isLoading.value = false
-
-    workflowIds.value = fetchedTaskRuns.map((taskRun) => taskRun.workflowId)
-  }
-
-  return {
-    isLoading,
-    fetch,
-    workflowIds,
   }
 }
 

--- a/src/stores/taskRuns.ts
+++ b/src/stores/taskRuns.ts
@@ -20,7 +20,7 @@ export const useTaskRunsStore = defineStore('taskRuns', () => {
     return selectedTaskRuns.value.some((tr) => tr.taskId === taskRun.taskId)
   }
 
-  function clearTaskRuns() {
+  function clearSelectedTaskRuns() {
     selectedTaskRuns.value = []
   }
 
@@ -36,6 +36,6 @@ export const useTaskRunsStore = defineStore('taskRuns', () => {
     selectedTaskRunIds,
     taskRunIsSelected,
     toggleTaskRun,
-    clearTaskRuns,
+    clearSelectedTaskRuns,
   }
 })

--- a/src/stores/taskRuns.ts
+++ b/src/stores/taskRuns.ts
@@ -1,0 +1,41 @@
+import { TaskRun } from '@/lib/taskruns'
+import { defineStore } from 'pinia'
+import { computed, ref } from 'vue'
+
+export const useTaskRunsStore = defineStore('taskRuns', () => {
+  const selectedTaskRuns = ref<TaskRun[]>([])
+
+  function toggleTaskRun(taskRun: TaskRun) {
+    const index = selectedTaskRuns.value.findIndex(
+      (tr) => tr.taskId === taskRun.taskId,
+    )
+    if (index === -1) {
+      selectedTaskRuns.value.push(taskRun)
+    } else {
+      selectedTaskRuns.value.splice(index, 1)
+    }
+  }
+
+  function taskRunIsSelected(taskRun: TaskRun) {
+    return selectedTaskRuns.value.some((tr) => tr.taskId === taskRun.taskId)
+  }
+
+  function clearTaskRuns() {
+    selectedTaskRuns.value = []
+  }
+
+  const selectedTaskRunIds = computed(() =>
+    selectedTaskRuns.value
+      .toSorted((a, b) => a.timeZeroTimestamp - b.timeZeroTimestamp)
+      .reverse()
+      .map((taskRun) => taskRun.taskId),
+  )
+
+  return {
+    selectedTaskRuns,
+    selectedTaskRunIds,
+    taskRunIsSelected,
+    toggleTaskRun,
+    clearTaskRuns,
+  }
+})

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -120,6 +120,7 @@ import {
 import { useTopologyNodesStore } from '@/stores/topologyNodes'
 import { useComponentSettings } from '@/services/useComponentSettings'
 import { useAvailableWorkflowsStore } from '@/stores/availableWorkflows'
+import { useTaskRunsStore } from '@/stores/taskRuns'
 import type { NavigateRoute } from '@/lib/router'
 
 interface Props {
@@ -138,6 +139,7 @@ const configStore = useConfigStore()
 const settings = useUserSettingsStore()
 const workflowsStore = useWorkflowsStore()
 const availableWorkflowsStore = useAvailableWorkflowsStore()
+const taskRunsStore = useTaskRunsStore()
 
 const menuType = computed(() => {
   const configured = settings.get('ui.hierarchical-menu-style')?.value as string
@@ -153,6 +155,8 @@ watch(active, () => {
   workflowsStore.isDrawingBoundingBox = false
   workflowsStore.coordinate = null
   workflowsStore.isSelectingCoordinate = false
+
+  taskRunsStore.clearSelectedTaskRuns()
 })
 
 const activeNode = computed(() => {

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -60,6 +60,7 @@
         />
       </v-list>
     </v-menu>
+    <TaskRunsControl v-if="showTaskMenu" :topologyNodeId="topologyNode?.id" />
   </Teleport>
   <div class="d-flex w-100 h-100">
     <router-view v-slot="{ Component }">
@@ -108,6 +109,7 @@ import {
 import { useTopologyThresholds } from '@/services/useTopologyThresholds'
 import { configManager } from '@/services/application-config'
 import InformationDisplayView from '@/views/InformationDisplayView.vue'
+import TaskRunsControl from '@/components/tasks/TaskRunsControl.vue'
 import { useDisplay } from 'vuetify'
 import { useNodesStore } from '@/stores/nodes'
 import { nodeButtonItems, recursiveUpdateNode } from '@/lib/topology/nodes'
@@ -141,6 +143,8 @@ const menuType = computed(() => {
   const configured = settings.get('ui.hierarchical-menu-style')?.value as string
   return configured ?? 'auto'
 })
+
+const showTaskMenu = computed(() => configStore.general.taskMenu?.enabled)
 
 const active = ref<string | undefined>(undefined)
 watch(active, () => {

--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -60,7 +60,7 @@
         />
       </v-list>
     </v-menu>
-    <TaskRunsControl v-if="showTaskMenu" :topologyNodeId="topologyNode?.id" />
+    <TaskRunsControl v-if="showTaskMenu" :topologyNode="topologyNode" />
   </Teleport>
   <div class="d-flex w-100 h-100">
     <router-view v-slot="{ Component }">
@@ -167,24 +167,6 @@ const activeNode = computed(() => {
   }
   return node
 })
-
-// Set preferred workflow IDs for the running tasks menu, if this node has
-// associated workflows.
-watch(
-  activeNode,
-  (node) => {
-    const primaryWorkflowId = node?.workflowId ? [node.workflowId] : []
-    const secondaryWorkflowIds =
-      node?.secondaryWorkflows?.map(
-        (workflow) => workflow.secondaryWorkflowId,
-      ) ?? []
-    // Note: this list of workflow IDs may be empty, in which case we have no
-    //       preferred workflow.
-    const workflowIds = [...primaryWorkflowId, ...secondaryWorkflowIds]
-    availableWorkflowsStore.setPreferredWorkflowIds(workflowIds)
-  },
-  { immediate: true },
-)
 // Clear the preferred workflow IDs when we unmount.
 onUnmounted(() => availableWorkflowsStore.clearPreferredWorkflowIds())
 


### PR DESCRIPTION
### Description
Adds buttons in the tasks menu to toggle the visualization of task runs in the charts.

# TODO in later issues
- On node switch select the workflows corresponding to the topologyNode and its data
- Ability to view tasks outside the ones configured for the selected node
- Clarify link between visualized task and the chart line

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
