### PR TITLE
Add pointer-events-none class to prevent interaction on nested chip in thresholds

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -104,4 +104,8 @@ userSettingsStore.$onAction(({ name, args }) => {
   top: 0;
   z-index: 2;
 }
+
+.pointer-events-none {
+  pointer-events: none;
+}
 </style>

--- a/src/components/thresholds/ThresholdsPanel.vue
+++ b/src/components/thresholds/ThresholdsPanel.vue
@@ -28,7 +28,7 @@
             :text="level.count"
             density="compact"
             variant="flat"
-            class="ms-2 pa-1"
+            class="ms-2 pa-1 pointer-events-none"
             size="small"
           />
         </template>


### PR DESCRIPTION
### Description

Add `pointer-events-none` class (similar to tailwind).
Disable pointer events on nested chip in thresholds filter.
