### PR TITLE
Fix particle "ghost" remaining behind when zooming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@deltares/fews-ssd-webcomponent": "^1.1.1",
         "@deltares/fews-web-oc-charts": "^4.0.0-alpha.0",
         "@deltares/fews-wms-requests": "^2.0.0",
-        "@deltares/webgl-streamline-visualizer": "^2.2.0",
+        "@deltares/webgl-streamline-visualizer": "^3.0.1",
         "@indoorequal/vue-maplibre-gl": "^8.3.0",
         "@jsonforms/core": "^3.5.1",
         "@jsonforms/vue": "^3.5.1",
@@ -563,14 +563,14 @@
       }
     },
     "node_modules/@deltares/webgl-streamline-visualizer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@deltares/webgl-streamline-visualizer/-/webgl-streamline-visualizer-2.2.0.tgz",
-      "integrity": "sha512-x559MrTi5dzlBACdMRIK1wH5+MgRRMFrGHKULz4/deu6DL8cLRbORJM254KHo8o78ecEaCUJYyAk8u9zwsrPjg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@deltares/webgl-streamline-visualizer/-/webgl-streamline-visualizer-3.0.1.tgz",
+      "integrity": "sha512-mJl3Gcg9dtmJlhMI7hTIE/v0LXPJKz5f0krdiSRn6M2ry0cny+/U1/21DhTaYNF7rXVM8kBiAtz2mpa2JwOq6Q==",
       "license": "MIT",
       "dependencies": {
         "geotiff": "^2.1.3",
         "lodash-es": "^4.17.21",
-        "maplibre-gl": "^5.3.0"
+        "maplibre-gl": "^5.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -7679,9 +7679,9 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.3.0.tgz",
-      "integrity": "sha512-qru6B6jHlDPR4Q9/P4W1zEPbPofR4wwYbrrjiHKWI7yLtyXmpJ1/G1KaIYDr5uNdFbPZ7uiZAWdqtfdNLmIhGg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.4.0.tgz",
+      "integrity": "sha512-ZVrtdFIhFAqt53H2k5Ssqn7QIKNI19fW+He5tr4loxZxWZffp1aZYY9ImNncAJaALU/NYlV6Eul7UVB56/N7WQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@deltares/fews-ssd-webcomponent": "^1.1.1",
     "@deltares/fews-web-oc-charts": "^4.0.0-alpha.0",
     "@deltares/fews-wms-requests": "^2.0.0",
-    "@deltares/webgl-streamline-visualizer": "^2.2.0",
+    "@deltares/webgl-streamline-visualizer": "^3.0.1",
     "@indoorequal/vue-maplibre-gl": "^8.3.0",
     "@jsonforms/core": "^3.5.1",
     "@jsonforms/vue": "^3.5.1",


### PR DESCRIPTION
## Pull Request Template

### Description
This fixes problems with particles leaving behind a "ghost" of e.g. the coastline when zooming in.

### Screenshots
Before (after zooming):
![image](https://github.com/user-attachments/assets/2f5d8b1c-d7a0-4744-95ca-e0dc9720e846)

After (after zooming):
![image](https://github.com/user-attachments/assets/82d71d4f-b6c3-4880-a141-c67764eb18cf)

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes.
