### PR TITLE
Use time series thinning for charts but not for tables

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -38,8 +38,6 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
 
-
-
   # Deployment job
   deploy:
     environment:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@deltares/fews-pi-requests": "^1.13.8",
         "@deltares/fews-ssd-requests": "^1.1.1",
         "@deltares/fews-ssd-webcomponent": "^1.1.1",
-        "@deltares/fews-web-oc-charts": "^4.0.0-alpha.1",
+        "@deltares/fews-web-oc-charts": "^4.0.0-alpha.5",
         "@deltares/fews-wms-requests": "^2.0.0",
         "@deltares/webgl-streamline-visualizer": "^3.0.1",
         "@indoorequal/vue-maplibre-gl": "^8.3.0",
@@ -528,9 +528,9 @@
       }
     },
     "node_modules/@deltares/fews-web-oc-charts": {
-      "version": "4.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@deltares/fews-web-oc-charts/-/fews-web-oc-charts-4.0.0-alpha.1.tgz",
-      "integrity": "sha512-AU+/NvCYlr4A0QU2Rq/rpH9k9pR/1Yp8CJlyzxx8DgnN0R9IukikW2lKAEGwqmsMzrHZSe+YpZwY1MK/ESAx5Q==",
+      "version": "4.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@deltares/fews-web-oc-charts/-/fews-web-oc-charts-4.0.0-alpha.5.tgz",
+      "integrity": "sha512-VHSnFEwZkIjFpuGl3fcemxhNv9GRXKwoarJRAXDl0jAbd//N2bqyk4SIiksfqbDiNoW2izApDFdw3N07kiP+9Q==",
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@deltares/fews-pi-requests": "^1.13.8",
         "@deltares/fews-ssd-requests": "^1.1.1",
         "@deltares/fews-ssd-webcomponent": "^1.1.1",
-        "@deltares/fews-web-oc-charts": "^4.0.0-alpha.0",
+        "@deltares/fews-web-oc-charts": "^4.0.0-alpha.1",
         "@deltares/fews-wms-requests": "^2.0.0",
         "@deltares/webgl-streamline-visualizer": "^3.0.1",
         "@indoorequal/vue-maplibre-gl": "^8.3.0",
@@ -528,9 +528,9 @@
       }
     },
     "node_modules/@deltares/fews-web-oc-charts": {
-      "version": "4.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@deltares/fews-web-oc-charts/-/fews-web-oc-charts-4.0.0-alpha.0.tgz",
-      "integrity": "sha512-f3pY8ZxYx8YBOg51vBMsiOw5muHeZiBj48T4TGRqh7S8Mhno6tg0tBeUMICI068VqUX4KFMOnVQGdxl3d4XBtw==",
+      "version": "4.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@deltares/fews-web-oc-charts/-/fews-web-oc-charts-4.0.0-alpha.1.tgz",
+      "integrity": "sha512-AU+/NvCYlr4A0QU2Rq/rpH9k9pR/1Yp8CJlyzxx8DgnN0R9IukikW2lKAEGwqmsMzrHZSe+YpZwY1MK/ESAx5Q==",
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@deltares/fews-pi-requests": "^1.13.8",
     "@deltares/fews-ssd-requests": "^1.1.1",
     "@deltares/fews-ssd-webcomponent": "^1.1.1",
-    "@deltares/fews-web-oc-charts": "^4.0.0-alpha.1",
+    "@deltares/fews-web-oc-charts": "^4.0.0-alpha.5",
     "@deltares/fews-wms-requests": "^2.0.0",
     "@deltares/webgl-streamline-visualizer": "^3.0.1",
     "@indoorequal/vue-maplibre-gl": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@deltares/fews-pi-requests": "^1.13.8",
     "@deltares/fews-ssd-requests": "^1.1.1",
     "@deltares/fews-ssd-webcomponent": "^1.1.1",
-    "@deltares/fews-web-oc-charts": "^4.0.0-alpha.0",
+    "@deltares/fews-web-oc-charts": "^4.0.0-alpha.1",
     "@deltares/fews-wms-requests": "^2.0.0",
     "@deltares/webgl-streamline-visualizer": "^3.0.1",
     "@indoorequal/vue-maplibre-gl": "^8.3.0",

--- a/src/components/charts/TimeSeriesChart.vue
+++ b/src/components/charts/TimeSeriesChart.vue
@@ -73,6 +73,11 @@ const props = withDefaults(defineProps<Props>(), {
   },
 })
 
+interface Emits {
+  'update:x-domain': [old: [Date, Date], new: [Date, Date]]
+}
+const emit = defineEmits<Emits>()
+
 let thresholdLines!: ThresholdLine[]
 let thresholdLinesVisitor!: AlertLines
 let axis!: CartesianAxes
@@ -96,6 +101,13 @@ onMounted(() => {
       props.verticalProfile ? 1200 : null,
       axisOptions,
     )
+    axis.addEventListener('update:x-domain', (event) => {
+      emit(
+        'update:x-domain',
+        event.old as [Date, Date],
+        event.new as [Date, Date],
+      )
+    })
 
     // Keep margin in sync with axis.margin
     axis.margin = new Proxy(axis.margin, {

--- a/src/components/charts/TimeSeriesChart.vue
+++ b/src/components/charts/TimeSeriesChart.vue
@@ -14,7 +14,15 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, onMounted, onBeforeUnmount, nextTick, computed } from 'vue'
+import {
+  ref,
+  watch,
+  onMounted,
+  onBeforeUnmount,
+  nextTick,
+  computed,
+  useTemplateRef,
+} from 'vue'
 import {
   AlertLines,
   ChartArea,
@@ -84,7 +92,7 @@ let axis!: CartesianAxes
 const margin = ref<Margin>({})
 const legendTags = ref<Tag[]>([])
 const showThresholds = ref(true)
-const chartContainer = ref<HTMLElement>()
+const chartContainer = useTemplateRef('chartContainer')
 const axisTime = ref<CrossSectionSelect>()
 const hasLoadedOnce = ref(false)
 

--- a/src/components/table/TimeSeriesTable.vue
+++ b/src/components/table/TimeSeriesTable.vue
@@ -9,6 +9,7 @@
       :items="tableData"
       :expanded="editedSeriesIds"
       :items-per-page-options="itemsPerPageOptions"
+      :loading="isWaitingForTableUpdate"
       v-model:sortBy="sortBy"
       items-per-page="200"
       item-value="date"
@@ -204,6 +205,7 @@ interface Props {
   config: ChartConfig
   series: Record<string, Series>
   settings: ChartsSettings['timeSeriesTable']
+  isLoading: boolean
 }
 
 const props = defineProps<Props>()
@@ -305,6 +307,14 @@ watch(
   },
 )
 
+// We debounce the table update, so even though loading the time series may have
+// finished, updating the table items may not. Keep the loading indicator until
+// the table items have been updated.
+const isWaitingForTableUpdate = ref(true)
+watch(
+  () => props.isLoading,
+  () => (isWaitingForTableUpdate.value = true),
+)
 watchDebounced(
   // We cannot use a getter on props.series directly here, since it is not
   // reassigned, but instead its contents are modified. We also do not want to
@@ -319,6 +329,7 @@ watchDebounced(
       props.series,
       seriesIds.value,
     )
+    isWaitingForTableUpdate.value = props.isLoading
   },
   { debounce: 500, maxWait: 1000 },
 )

--- a/src/components/timeseries/TimeSeriesComponent.vue
+++ b/src/components/timeseries/TimeSeriesComponent.vue
@@ -168,13 +168,16 @@ const sharedVerticalZoomHandler = new ZoomHandler({
   sharedZoomMode: ZoomMode.Y,
 })
 
+const tab = ref<DisplayType>(props.displayType)
+
 const chartOptions = ref<UseTimeSeriesOptions>({
   startTime: store.startTime,
   endTime: store.endTime,
   thinning: true,
 })
 const tableOptions = computed<UseTimeSeriesOptions>(() => ({
-  ...chartOptions.value,
+  startTime: store.startTime,
+  endTime: store.endTime,
   thinning: false,
 }))
 
@@ -188,12 +191,14 @@ const {
   () => props.config.requests,
   lastUpdated,
   chartOptions,
+  () => tab.value === DisplayType.TimeSeriesChart,
 )
 const { series: tableSeries } = useTimeSeries(
   baseUrl,
   () => props.config.requests,
   lastUpdated,
   tableOptions,
+  () => tab.value === DisplayType.TimeSeriesTable,
 )
 const {
   series: elevationChartSeries,
@@ -203,6 +208,7 @@ const {
   () => props.elevationChartConfig.requests,
   lastUpdated,
   chartOptions,
+  () => tab.value === DisplayType.ElevationChart,
   selectedDate,
 )
 
@@ -268,8 +274,6 @@ watch(
     }
   },
 )
-
-const tab = ref<DisplayType>(props.displayType)
 
 watch(
   () => props.displayType,

--- a/src/components/timeseries/TimeSeriesComponent.vue
+++ b/src/components/timeseries/TimeSeriesComponent.vue
@@ -197,13 +197,14 @@ function isLoading(subplot: ChartConfig, loadingSeriesIds: string[]) {
 }
 
 async function onDataChange(newData: Record<string, TimeSeriesEvent[]>) {
-  const seriesHeader = series.value[props.config.requests[0].key].header
+  const seriesKey = props.config.requests[0]?.key
+  const seriesHeader = seriesKey ? series.value[seriesKey].header : undefined
   await postTimeSeriesEdit(
     baseUrl,
     props.config.requests,
     newData,
-    seriesHeader.version ?? '',
-    seriesHeader.timeZone ?? '',
+    seriesHeader?.version ?? '',
+    seriesHeader?.timeZone ?? '',
   )
   lastUpdated.value = new Date()
 }

--- a/src/components/timeseries/TimeSeriesComponent.vue
+++ b/src/components/timeseries/TimeSeriesComponent.vue
@@ -51,6 +51,7 @@
         :series="tableSeries"
         :key="tableConfig.title"
         :settings="settings.timeSeriesTable"
+        :is-loading="isLoadingTableSeries"
         class="single"
         @change="(event) => onDataChange(event)"
         @update:isEditing="isEditing = $event"
@@ -193,7 +194,7 @@ const {
   chartOptions,
   () => tab.value === DisplayType.TimeSeriesChart,
 )
-const { series: tableSeries } = useTimeSeries(
+const { series: tableSeries, isLoading: isLoadingTableSeries } = useTimeSeries(
   baseUrl,
   () => props.config.requests,
   lastUpdated,

--- a/src/components/timeseries/TimeSeriesComponent.vue
+++ b/src/components/timeseries/TimeSeriesComponent.vue
@@ -61,9 +61,6 @@
       :value="DisplayType.Information"
       class="h-100"
     >
-      <!-- <div class="px-4 h-100"> -->
-      <!--   <iframe :srcdoc="informationContent" class="h-100 w-100 border-none" /> -->
-      <!-- </div> -->
       <div v-html="informationContent" class="pa-4 h-100 w-100" />
     </v-window-item>
   </v-window>

--- a/src/components/timeseries/TimeSeriesComponent.vue
+++ b/src/components/timeseries/TimeSeriesComponent.vue
@@ -163,25 +163,32 @@ const sharedVerticalZoomHandler = new ZoomHandler({
   sharedZoomMode: ZoomMode.Y,
 })
 
-const options = computed<UseTimeSeriesOptions>(() => {
-  return {
-    startTime: store.startTime,
-    endTime: store.endTime,
-    thinning: false,
-  }
-})
+const chartOptions = computed<UseTimeSeriesOptions>(() => ({
+  startTime: store.startTime,
+  endTime: store.endTime,
+  thinning: true,
+}))
+const tableOptions = computed<UseTimeSeriesOptions>(() => ({
+  ...chartOptions.value,
+  thinning: false,
+}))
 
 const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
 const {
   series: chartSeries,
   loadingSeriesIds,
   interval: useTimeSeriesInterval,
-} = useTimeSeries(baseUrl, () => props.config.requests, lastUpdated, options)
+} = useTimeSeries(
+  baseUrl,
+  () => props.config.requests,
+  lastUpdated,
+  chartOptions,
+)
 const { series: tableSeries } = useTimeSeries(
   baseUrl,
   () => props.config.requests,
   lastUpdated,
-  options,
+  tableOptions,
 )
 const {
   series: elevationChartSeries,
@@ -190,7 +197,7 @@ const {
   baseUrl,
   () => props.elevationChartConfig.requests,
   lastUpdated,
-  options,
+  chartOptions,
   selectedDate,
 )
 

--- a/src/components/timeseries/TimeSeriesComponent.vue
+++ b/src/components/timeseries/TimeSeriesComponent.vue
@@ -9,7 +9,7 @@
         <TimeSeriesChart
           v-for="subplot in subplots"
           :config="subplot"
-          :series="series"
+          :series="chartSeries"
           :key="subplot.id"
           :highlightTime="selectedDate"
           :isLoading="isLoading(subplot, loadingSeriesIds)"
@@ -47,7 +47,7 @@
     >
       <TimeSeriesTable
         :config="tableConfig"
-        :series="series"
+        :series="tableSeries"
         :key="tableConfig.title"
         :settings="settings.timeSeriesTable"
         class="single"
@@ -170,12 +170,19 @@ const options = computed<UseTimeSeriesOptions>(() => {
     thinning: false,
   }
 })
+
 const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
 const {
-  series,
+  series: chartSeries,
   loadingSeriesIds,
   interval: useTimeSeriesInterval,
 } = useTimeSeries(baseUrl, () => props.config.requests, lastUpdated, options)
+const { series: tableSeries } = useTimeSeries(
+  baseUrl,
+  () => props.config.requests,
+  lastUpdated,
+  options,
+)
 const {
   series: elevationChartSeries,
   loadingSeriesIds: elevationLoadingSeriesIds,
@@ -198,7 +205,9 @@ function isLoading(subplot: ChartConfig, loadingSeriesIds: string[]) {
 
 async function onDataChange(newData: Record<string, TimeSeriesEvent[]>) {
   const seriesKey = props.config.requests[0]?.key
-  const seriesHeader = seriesKey ? series.value[seriesKey].header : undefined
+  const seriesHeader = seriesKey
+    ? chartSeries.value[seriesKey].header
+    : undefined
   await postTimeSeriesEdit(
     baseUrl,
     props.config.requests,

--- a/src/lib/display/DisplayConfig.ts
+++ b/src/lib/display/DisplayConfig.ts
@@ -1,5 +1,5 @@
 import { ChartConfig } from '../charts/types/ChartConfig.js'
-import { ActionPeriod } from '@deltares/fews-pi-requests'
+import { ActionPeriod, ActionRequest } from '@deltares/fews-pi-requests'
 
 export enum DisplayType {
   TimeSeriesChart = 'TimeSeriesChart',
@@ -16,7 +16,7 @@ export interface DisplayConfig {
   title: string
   forecastLegend: string | undefined
   class: string
-  requests: any[]
+  requests: ActionRequest[]
   period: ActionPeriod | undefined
   subplots: ChartConfig[]
 }

--- a/src/services/useTimeSeries/index.ts
+++ b/src/services/useTimeSeries/index.ts
@@ -86,25 +86,25 @@ export function useTimeSeries(
             1,
           )
         }
-        if (piSeries.timeSeries !== undefined) {
-          for (const index in piSeries.timeSeries) {
-            const timeSeries = piSeries.timeSeries[index]
-            const resourceId = isGridTimeSEries
-              ? `${request.key}[${index}]`
-              : (request.key ?? '')
-            updatedSeriesIds.push(resourceId)
+        if (piSeries.timeSeries === undefined) return
 
-            const _series = convertTimeSeriesResultToSeries(
-              timeSeries,
-              piSeries,
-              resourceId,
-              _selectedTime,
-            )
-            if (_series !== undefined) {
-              series.value = {
-                ...series.value,
-                [resourceId]: _series,
-              }
+        for (const index in piSeries.timeSeries) {
+          const timeSeries = piSeries.timeSeries[index]
+          const resourceId = isGridTimeSEries
+            ? `${request.key}[${index}]`
+            : (request.key ?? '')
+          updatedSeriesIds.push(resourceId)
+
+          const _series = convertTimeSeriesResultToSeries(
+            timeSeries,
+            piSeries,
+            resourceId,
+            _selectedTime,
+          )
+          if (_series !== undefined) {
+            series.value = {
+              ...series.value,
+              [resourceId]: _series,
             }
           }
         }

--- a/src/services/useTimeSeries/index.ts
+++ b/src/services/useTimeSeries/index.ts
@@ -77,7 +77,7 @@ export function useTimeSeries(
     for (const request of _requests) {
       const relativeUrl = getRelativeUrlForRequest(request)
 
-      const isGridTimeSEries = request.request.includes('/timeseries/grid?')
+      const isGridTimeSeries = request.request.includes('/timeseries/grid?')
       piProvider.getTimeSeriesWithRelativeUrl(relativeUrl).then((piSeries) => {
         if (request.key) {
           loadingSeriesIds.value.splice(
@@ -88,7 +88,7 @@ export function useTimeSeries(
         if (piSeries.timeSeries === undefined) return
 
         piSeries.timeSeries.forEach((timeSeries, index) => {
-          const resourceId = isGridTimeSEries
+          const resourceId = isGridTimeSeries
             ? `${request.key}[${index}]`
             : (request.key ?? '')
           updatedSeriesIds.push(resourceId)

--- a/src/services/useTimeSeries/index.ts
+++ b/src/services/useTimeSeries/index.ts
@@ -78,35 +78,42 @@ export function useTimeSeries(
       const relativeUrl = getRelativeUrlForRequest(request)
 
       const isGridTimeSeries = request.request.includes('/timeseries/grid?')
-      piProvider.getTimeSeriesWithRelativeUrl(relativeUrl).then((piSeries) => {
-        if (request.key) {
-          loadingSeriesIds.value.splice(
-            loadingSeriesIds.value.indexOf(request.key),
-            1,
-          )
-        }
-        if (piSeries.timeSeries === undefined) return
-
-        piSeries.timeSeries.forEach((timeSeries, index) => {
-          const resourceId = isGridTimeSeries
-            ? `${request.key}[${index}]`
-            : (request.key ?? '')
-          updatedSeriesIds.push(resourceId)
-
-          const _series = convertTimeSeriesResultToSeries(
-            timeSeries,
-            piSeries,
-            resourceId,
-            _selectedTime,
-          )
-          if (_series !== undefined) {
-            series.value = {
-              ...series.value,
-              [resourceId]: _series,
-            }
+      piProvider
+        .getTimeSeriesWithRelativeUrl(relativeUrl)
+        .then((piSeries) => {
+          if (request.key) {
+            loadingSeriesIds.value.splice(
+              loadingSeriesIds.value.indexOf(request.key),
+              1,
+            )
           }
+          if (piSeries.timeSeries === undefined) return
+
+          piSeries.timeSeries.forEach((timeSeries, index) => {
+            const resourceId = isGridTimeSeries
+              ? `${request.key}[${index}]`
+              : (request.key ?? '')
+            updatedSeriesIds.push(resourceId)
+
+            const _series = convertTimeSeriesResultToSeries(
+              timeSeries,
+              piSeries,
+              resourceId,
+              _selectedTime,
+            )
+            if (_series !== undefined) {
+              series.value = {
+                ...series.value,
+                [resourceId]: _series,
+              }
+            }
+          })
         })
-      })
+        .catch((error) => {
+          console.error(
+            `Failed to fetch time series for request URL ${request.request}: ${error}`,
+          )
+        })
     }
     const oldSeriesIds = difference(currentSeriesIds, updatedSeriesIds)
     if (oldSeriesIds.length > MAX_SERIES) {

--- a/src/services/useTimeSeries/index.ts
+++ b/src/services/useTimeSeries/index.ts
@@ -49,6 +49,7 @@ export function useTimeSeries(
   requests: MaybeRefOrGetter<ActionRequest[]>,
   lastUpdated: MaybeRefOrGetter<Date | undefined>,
   options: MaybeRefOrGetter<UseTimeSeriesOptions>,
+  fetchingEnabled: MaybeRefOrGetter<boolean>,
   selectedTime?: MaybeRefOrGetter<Date | undefined>,
 ): UseTimeSeriesReturn {
   let controller = new AbortController()
@@ -57,11 +58,14 @@ export function useTimeSeries(
   const loadingSeriesIds = ref<string[]>([])
   const isLoading = computed(() => loadingSeriesIds.value.length > 0)
 
-  watch([lastUpdated, selectedTime ?? ref(), requests, options], () => {
-    loadTimeSeries()
-  })
+  watch(
+    [lastUpdated, selectedTime ?? ref(), requests, options, fetchingEnabled],
+    loadTimeSeries,
+  )
 
   function loadTimeSeries() {
+    if (!toValue(fetchingEnabled)) return
+
     controller.abort('Timeseries request triggered again before finishing.')
     controller = new AbortController()
     const piProvider = new PiWebserviceProvider(baseUrl, {

--- a/src/services/useTimeSeries/index.ts
+++ b/src/services/useTimeSeries/index.ts
@@ -88,8 +88,7 @@ export function useTimeSeries(
         }
         if (piSeries.timeSeries === undefined) return
 
-        for (const index in piSeries.timeSeries) {
-          const timeSeries = piSeries.timeSeries[index]
+        piSeries.timeSeries.forEach((timeSeries, index) => {
           const resourceId = isGridTimeSEries
             ? `${request.key}[${index}]`
             : (request.key ?? '')
@@ -107,7 +106,7 @@ export function useTimeSeries(
               [resourceId]: _series,
             }
           }
-        }
+        })
       })
     }
     const oldSeriesIds = difference(currentSeriesIds, updatedSeriesIds)

--- a/src/services/useTimeSeries/index.ts
+++ b/src/services/useTimeSeries/index.ts
@@ -74,8 +74,7 @@ export function useTimeSeries(
     const updatedSeriesIds: string[] = []
     loadingSeriesIds.value = _requests.flatMap((r) => (r.key ? [r.key] : []))
 
-    for (const r in _requests) {
-      const request = _requests[r]
+    for (const request of _requests) {
       const relativeUrl = getRelativeUrlForRequest(request)
 
       const isGridTimeSEries = request.request.includes('/timeseries/grid?')

--- a/src/services/useTimeSeries/index.ts
+++ b/src/services/useTimeSeries/index.ts
@@ -158,12 +158,15 @@ export function useTimeSeries(
       const requestEndTime = endTime ?? parseDateTimeFromSearchParam('endTime')
 
       if (requestStartTime && requestEndTime) {
-        const timeStepPerPixel = Math.round(
-          Interval.fromDateTimes(requestStartTime, requestEndTime).length() /
-            window.outerWidth /
-            2,
+        const durationMilliseconds = Interval.fromDateTimes(
+          requestStartTime,
+          requestEndTime,
+        ).length('millisecond')
+        const estimatedChartWidth = 0.5 * window.outerWidth
+        const millisecondsPerPixel = Math.round(
+          durationMilliseconds / estimatedChartWidth,
         )
-        url.searchParams.set('thinning', timeStepPerPixel.toString())
+        url.searchParams.set('thinning', millisecondsPerPixel.toString())
       }
     }
 


### PR DESCRIPTION
### Description
The FEWS PI Webservice supports "thinning" long time series to reduce computational load when plotting them. This is useful for charts, but makes the data irregularly spaced which is unsuitable for display in a table.

Currently, data for charts and tables are shared, so we cannot use thinning. This PR separates fetching data for charts and tables, and adds thinning to chart data.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes
