### PR TITLE
Add warning icon with stroke so warning color is more readable

### DIFF
--- a/src/components/thresholds/ThresholdsButton.vue
+++ b/src/components/thresholds/ThresholdsButton.vue
@@ -5,7 +5,28 @@
       :model-value="badgeCount > 0"
       color="#00BBF0"
     >
-      <v-icon icon="mdi-alert" :color="maxWarningLevelColor" />
+      <v-avatar size="24" :rounded="false" v-if="maxWarningLevelColor">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+          <path
+            stroke="black"
+            stroke-width="1"
+            :fill="maxWarningLevelColor"
+            d="M8.2679491924311 3.7727586640478a2 2 0 0 1 3.4641016151378 0l6.0358983848622 10.454482671904a2 2 0 0 1 -1.7320508075689 3l-12.071796769724 0a2 2 0 0 1 -1.7320508075689 -3z"
+          />
+          <text
+            x="11"
+            y="14"
+            text-anchor="middle"
+            fill="black"
+            font-size="10"
+            font-weight="bold"
+            font-family="arial"
+          >
+            !
+          </text>
+        </svg>
+      </v-avatar>
+      <v-icon v-else icon="mdi-alert" />
     </v-badge>
   </v-btn>
 </template>


### PR DESCRIPTION
### Description
Add stroke to warning icon

### Screenshots
Before
![image](https://github.com/user-attachments/assets/7e352f11-375a-4e00-823b-355090bcbbcc)
Now
![_thumb_186899](https://github.com/user-attachments/assets/7ff7eac8-cda9-4130-bb63-dce717802d7c)
Fallback for no thresholds
![_thumb_186900](https://github.com/user-attachments/assets/ab37a505-23f9-49fd-9b2c-6e28fae8c47c)

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
