### PR TITLE
Allow panning in time series charts

### DIFF
--- a/src/components/charts/TimeSeriesChart.vue
+++ b/src/components/charts/TimeSeriesChart.vue
@@ -57,6 +57,7 @@ import { difference, uniq } from 'lodash-es'
 import { getMatchingIndexedString, type Tag } from '@/lib/charts/tags'
 import { type ChartsSettings } from '@/lib/topology/componentSettings'
 import { getAxisOptions } from '@/lib/charts/axisOptions'
+import { PanHandler } from '@deltares/fews-web-oc-charts'
 
 interface Props {
   config?: ChartConfig
@@ -64,6 +65,7 @@ interface Props {
   highlightTime?: Date
   isLoading?: boolean
   zoomHandler?: ZoomHandler
+  panHandler?: PanHandler
   verticalProfile?: boolean
   forecastLegend?: string
   settings: ChartsSettings['timeSeriesChart']
@@ -129,7 +131,6 @@ onMounted(() => {
       ? new VerticalMouseOver(undefined, (value: number) => value.toString())
       : new MouseOver(undefined, (value: number) => value.toString())
     const zoom = props.zoomHandler ?? new ZoomHandler(WheelMode.NONE)
-
     const currentTime = new CurrentTime({ x: { axisIndex: 0 } })
 
     thresholdLinesVisitor = new AlertLines(thresholdLines)
@@ -142,6 +143,9 @@ onMounted(() => {
         [],
       )
       axis.accept(axisTime.value)
+    }
+    if (props.panHandler) {
+      axis.accept(props.panHandler)
     }
 
     axis.accept(thresholdLinesVisitor)


### PR DESCRIPTION
### Description
Holding the shift button and dragging with the left mouse button now pans the time axis and vertical of charts. If multiple charts are configured for the same location, the time axis of all charts will be panned synchronously, but the y-axis of only the initially clicked chart is panned. Upon finishing panning, the time series data are updated to span the new time range.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes.
