### PR TITLE
Fix taskRun color fallback to use contrast color instead of primary

### DIFF
--- a/src/components/tasks/TaskRunSummary.vue
+++ b/src/components/tasks/TaskRunSummary.vue
@@ -43,7 +43,7 @@
               density="compact"
               trueIcon="mdi-chart-areaspline-variant"
               falseIcon="mdi-chart-line"
-              :color="selected ? taskRunColor : 'primary'"
+              :color="taskRunColor"
               :disabled="task.isCurrent"
               @click.stop="taskRunsStore.toggleTaskRun(task)"
             >
@@ -101,8 +101,8 @@ interface Props {
 const props = defineProps<Props>()
 
 const taskRunColor = computed(() => {
-  // Get color from store, fallback to 'primary' if not found
-  return taskRunColorsStore.getColor(props.task.taskId) || 'primary'
+  // Get color from store, fallback to contrast color if not found
+  return taskRunColorsStore.getColor(props.task.taskId) || '--contrast-color'
 })
 
 const expanded = defineModel<boolean>('expanded', {


### PR DESCRIPTION
## Pull Request Template

### Description

Fix taskRun color fallback to use contrast color instead of primary

### Checklist
- [ ] Make the title short and concise
- [ ] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [ ] Update documentation.
- [ ] Update tests.
