### PR TITLE
Show "no thresholds"  in warning levels list

### DIFF
--- a/src/stores/warningLevels.ts
+++ b/src/stores/warningLevels.ts
@@ -36,11 +36,6 @@ export const useWarningLevelsStore = defineStore('warningLevels', () => {
         }
       })
       .sort((a, b) => b.severity - a.severity)
-    // The warning level with the lowest severity is always the default "no thresholds" level.
-    // That level should not be shown in list of warning levels
-    if (levels.length > 0) {
-      levels.pop()
-    }
     return levels
   })
 


### PR DESCRIPTION
### Description

Add filter for 'no active thresholds' in thresholds component

### Screenshots

![localhost_5174_topology_main_node_control_conductivity_map_meteo_nea_singv_precipitation_location_ws17_con001](https://github.com/user-attachments/assets/f5cd43b0-1d2f-4724-ba8c-638bfb9d8d41)


