### PR TITLE
Take into account display scaling for animated particles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@deltares/fews-ssd-webcomponent": "^1.1.1",
         "@deltares/fews-web-oc-charts": "^4.0.0-alpha.7",
         "@deltares/fews-wms-requests": "^2.0.0",
-        "@deltares/webgl-streamline-visualizer": "^4.1.2",
+        "@deltares/webgl-streamline-visualizer": "^4.1.3",
         "@indoorequal/vue-maplibre-gl": "^8.3.0",
         "@jsonforms/core": "^3.5.1",
         "@jsonforms/vue": "^3.5.1",
@@ -324,9 +324,9 @@
       }
     },
     "node_modules/@deltares/webgl-streamline-visualizer": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@deltares/webgl-streamline-visualizer/-/webgl-streamline-visualizer-4.1.2.tgz",
-      "integrity": "sha512-8VvPJDBahi/Nhbs6X7Thi4hGIpexl/f4Zbphsn/mrerBLjLy19efYJMdTinivLhGvHgyZobLUanLy5ijC1KukA==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@deltares/webgl-streamline-visualizer/-/webgl-streamline-visualizer-4.1.3.tgz",
+      "integrity": "sha512-CIliDIEmGcIbmyLVGUpFXZdp7Oit3M+VREyOD87vb5oE/fEyJUJmB1HJcb9DPA7RkzygA93llIPpVXI/On9JGg==",
       "license": "MIT",
       "dependencies": {
         "geotiff": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@deltares/fews-ssd-webcomponent": "^1.1.1",
     "@deltares/fews-web-oc-charts": "^4.0.0-alpha.7",
     "@deltares/fews-wms-requests": "^2.0.0",
-    "@deltares/webgl-streamline-visualizer": "^4.1.2",
+    "@deltares/webgl-streamline-visualizer": "^4.1.3",
     "@indoorequal/vue-maplibre-gl": "^8.3.0",
     "@jsonforms/core": "^3.5.1",
     "@jsonforms/vue": "^3.5.1",


### PR DESCRIPTION
### Description
Previously, animated particles were very small on displays with high scaling factors (e.g. UHD-screens). An update in `@deltares/webgl-streamline-visualizer` fixes this.
