### PR TITLE
Fix panning while zoomed in

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@deltares/fews-pi-requests": "^1.17.0",
         "@deltares/fews-ssd-requests": "^1.1.1",
         "@deltares/fews-ssd-webcomponent": "^1.1.1",
-        "@deltares/fews-web-oc-charts": "^4.0.0-alpha.7",
+        "@deltares/fews-web-oc-charts": "^4.0.0-alpha.8",
         "@deltares/fews-wms-requests": "^2.0.0",
         "@deltares/webgl-streamline-visualizer": "^4.1.3",
         "@indoorequal/vue-maplibre-gl": "^8.3.0",
@@ -325,9 +325,9 @@
       }
     },
     "node_modules/@deltares/fews-web-oc-charts": {
-      "version": "4.0.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@deltares/fews-web-oc-charts/-/fews-web-oc-charts-4.0.0-alpha.7.tgz",
-      "integrity": "sha512-jGwIFrmVvSkDJSX2PomXh9SdQ4waDhBhos48Q789wdR9ss41ihxP+MTsrH3Wh/fJBUe5dYjnHUQgRlwzvCoueg==",
+      "version": "4.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@deltares/fews-web-oc-charts/-/fews-web-oc-charts-4.0.0-alpha.8.tgz",
+      "integrity": "sha512-n30ca2AJ708B3abhSbvfm0aaLX+Ggf/0XlGi3K8s911gGzPA3QeX7xfptr9w2jiAM1mgbRlUhXe7p3wReqet+Q==",
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@deltares/fews-pi-requests": "^1.17.0",
     "@deltares/fews-ssd-requests": "^1.1.1",
     "@deltares/fews-ssd-webcomponent": "^1.1.1",
-    "@deltares/fews-web-oc-charts": "^4.0.0-alpha.7",
+    "@deltares/fews-web-oc-charts": "^4.0.0-alpha.8",
     "@deltares/fews-wms-requests": "^2.0.0",
     "@deltares/webgl-streamline-visualizer": "^4.1.3",
     "@indoorequal/vue-maplibre-gl": "^8.3.0",


### PR DESCRIPTION
### Description
Currently, when panning while a chart is zoomed in, the zoom level is changed. This PR pulls in changes in the chart library that fixes this problem.

In addition, sometimes the chart would be stuck in panning mode, for example when the Windows Sticky Keys shortcut window pops up. This has also been fixed in the updated chart library.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes

