### PR TITLE
Allow scroll wheel zooming in charts while holding Shift

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@deltares/fews-pi-requests": "^1.19.3",
         "@deltares/fews-ssd-requests": "^1.1.1",
         "@deltares/fews-ssd-webcomponent": "^1.1.1",
-        "@deltares/fews-web-oc-charts": "^4.0.0-alpha.11",
+        "@deltares/fews-web-oc-charts": "^4.0.0-alpha.15",
         "@deltares/fews-wms-requests": "^2.0.0",
         "@deltares/webgl-streamline-visualizer": "^4.2.0",
         "@indoorequal/vue-maplibre-gl": "8.3.0",
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/@deltares/fews-web-oc-charts": {
-      "version": "4.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/@deltares/fews-web-oc-charts/-/fews-web-oc-charts-4.0.0-alpha.11.tgz",
-      "integrity": "sha512-evdeXheLatvyBpe4WTc24EeUQFUyehmTxnqVUXmUdrmyuhtvkbei1b5nEDk8Qb6gxF8iQmd8r6RlkjdybsYbSw==",
+      "version": "4.0.0-alpha.15",
+      "resolved": "https://registry.npmjs.org/@deltares/fews-web-oc-charts/-/fews-web-oc-charts-4.0.0-alpha.15.tgz",
+      "integrity": "sha512-avMeKtCNTLeTFZ2+wvjEz+YyVdAaMSLjKIrPlqunlGUWwF/umCnqEXBMkSTJW/39KwH0jgZJx/PBL0AzXDD+kA==",
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@deltares/fews-pi-requests": "^1.19.3",
     "@deltares/fews-ssd-requests": "^1.1.1",
     "@deltares/fews-ssd-webcomponent": "^1.1.1",
-    "@deltares/fews-web-oc-charts": "^4.0.0-alpha.11",
+    "@deltares/fews-web-oc-charts": "^4.0.0-alpha.15",
     "@deltares/fews-wms-requests": "^2.0.0",
     "@deltares/webgl-streamline-visualizer": "^4.2.0",
     "@indoorequal/vue-maplibre-gl": "8.3.0",

--- a/src/assets/DefaultUserSettings.json
+++ b/src/assets/DefaultUserSettings.json
@@ -122,5 +122,30 @@
     "label": "Show location names",
     "value": true,
     "group": "Map"
+  },
+  {
+    "id": "charts.scrollZoomMode",
+    "type": "oneOfMultiple",
+    "label": "Scroll wheel zoom mode",
+    "value": "x",
+    "items": [
+      {
+        "value": "off",
+        "title": "Off"
+      },
+      {
+        "value": "x",
+        "title": "Only X"
+      },
+      {
+        "value": "y",
+        "title": "Only Y"
+      },
+      {
+        "value": "xy",
+        "title": "Both X and Y"
+      }
+    ],
+    "group": "Charts"
   }
 ]

--- a/src/stores/userSettings.ts
+++ b/src/stores/userSettings.ts
@@ -1,3 +1,4 @@
+import { WheelMode } from '@deltares/fews-web-oc-charts'
 import { defineStore } from 'pinia'
 import DefaultUserSettings from '@/assets/DefaultUserSettings.json'
 import { LayerKind } from '@/lib/streamlines'
@@ -54,7 +55,7 @@ const parameterGroupKey = 'units.parameterGroup.'
 
 export const useUserSettingsStore = defineStore('userSettings', {
   state: (): UserSettingsState => ({
-    groups: ['Units', 'Datum', 'UI', 'Map'],
+    groups: ['Units', 'Datum', 'UI', 'Map', 'Charts'],
     items: defaultUserSettings,
     convertDatum: false,
     useDisplayUnits: true,
@@ -72,6 +73,23 @@ export const useUserSettingsStore = defineStore('userSettings', {
     },
     get: (state) => (id: string) => {
       return state.items.find((item) => item.id === id)
+    },
+    scrollZoomMode: (state): WheelMode => {
+      const item = state.items.find(
+        (item) => item.id === 'charts.scrollZoomMode',
+      )
+      switch (item?.value) {
+        case 'x':
+          return WheelMode.X
+        case 'y':
+          return WheelMode.Y
+        case 'xy':
+          return WheelMode.XY
+        case 'off':
+          return WheelMode.NONE
+        default:
+          return WheelMode.X
+      }
     },
   },
   actions: {


### PR DESCRIPTION
### Description
This PR adds the possibility to use the scroll wheel to zoom in and out while holding the Shift-key (which also enters panning mode). Which axes (if any) are zoomed with the scroll wheel can be configured from the user settings store.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes

