### PR TITLE
Update @deltares/fews-web-oc-charts dependency to version 4.0.0-alpha.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@deltares/fews-pi-requests": "^1.19.1",
         "@deltares/fews-ssd-requests": "^1.1.1",
         "@deltares/fews-ssd-webcomponent": "^1.1.1",
-        "@deltares/fews-web-oc-charts": "^4.0.0-alpha.9",
+        "@deltares/fews-web-oc-charts": "^4.0.0-alpha.11",
         "@deltares/fews-wms-requests": "^2.0.0",
         "@deltares/webgl-streamline-visualizer": "^4.1.3",
         "@indoorequal/vue-maplibre-gl": "8.3.0",
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/@deltares/fews-web-oc-charts": {
-      "version": "4.0.0-alpha.10",
-      "resolved": "https://registry.npmjs.org/@deltares/fews-web-oc-charts/-/fews-web-oc-charts-4.0.0-alpha.10.tgz",
-      "integrity": "sha512-gE6xbAVL11fw6wjReQMR4pu44MdS1fRnixuJtwBy7KC60JdhFdRQ7d9qI/uRkqYss9vvOC/287WLqhKi03eaWQ==",
+      "version": "4.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/@deltares/fews-web-oc-charts/-/fews-web-oc-charts-4.0.0-alpha.11.tgz",
+      "integrity": "sha512-evdeXheLatvyBpe4WTc24EeUQFUyehmTxnqVUXmUdrmyuhtvkbei1b5nEDk8Qb6gxF8iQmd8r6RlkjdybsYbSw==",
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@deltares/fews-pi-requests": "^1.19.1",
     "@deltares/fews-ssd-requests": "^1.1.1",
     "@deltares/fews-ssd-webcomponent": "^1.1.1",
-    "@deltares/fews-web-oc-charts": "^4.0.0-alpha.9",
+    "@deltares/fews-web-oc-charts": "^4.0.0-alpha.11",
     "@deltares/fews-wms-requests": "^2.0.0",
     "@deltares/webgl-streamline-visualizer": "^4.1.3",
     "@indoorequal/vue-maplibre-gl": "8.3.0",


### PR DESCRIPTION
### Description

Update @deltares/fews-web-oc-charts dependency to version 4.0.0-alpha.11 to remove use of crypto.randomUUID.
This is not available in not secure contexts.


