### PR TITLE
Fix: System log should function without a manual log configuration

### DIFF
--- a/src/components/logdisplay/LogDisplayComponent.vue
+++ b/src/components/logdisplay/LogDisplayComponent.vue
@@ -98,7 +98,7 @@
       <template #default="{ item }">
         <DateSeparator v-if="item.type === 'dateSeparator'" :date="item.date" />
         <LogItem
-          v-else-if="item.type === 'logItem' && noteGroup"
+          v-else-if="item.type === 'logItem'"
           :logs="item.logs"
           :taskRuns="taskRuns"
           :disseminations="disseminations"

--- a/src/components/logdisplay/LogItem.vue
+++ b/src/components/logdisplay/LogItem.vue
@@ -23,7 +23,7 @@
     />
   </template>
   <LogMessageItem
-    v-if="log.type === 'manual'"
+    v-if="log.type === 'manual' && noteGroup"
     class="mt-2"
     :noteGroup="noteGroup"
     :log="log"
@@ -58,7 +58,7 @@ import { computed } from 'vue'
 
 interface Props {
   userName: string
-  noteGroup: ForecasterNoteGroup
+  noteGroup?: ForecasterNoteGroup
   logs: LogMessage[]
   taskRuns: TaskRun[]
   disseminations: LogDisplayDisseminationAction[]


### PR DESCRIPTION
### Description

When the manual log forecaster notes configuration was missing the system log did not function correctly.