### PR TITLE
Remove webserver from e2e and let runner choose dev:e2e or preview:e2e

### DIFF
--- a/developer.md
+++ b/developer.md
@@ -18,6 +18,35 @@ If the standalone TypeScript plugin doesn't feel fast enough to you, Volar has a
    2. Find `TypeScript and JavaScript Language Features`, right click and select `Disable (Workspace)`
 2. Reload the VSCode window by running `Developer: Reload Window` from the command palette.
 
+
+
+## E2E testing
+
+For end-to-end testing we use [Playwright](https://playwright.dev/).
+
+To run end-to-end tests, you have two options:
+
+**Option 1: Build and test with preview server (default)**
+
+```
+npm run build:e2e
+npm run test:e2e
+```
+
+`npm run test:e2e` will automatically start a preview server, or reuse an existing preview or dev server if one is already running.
+
+**Option 2: Use the dev server**
+
+```
+npm run dev:e2e
+npm run test:e2e
+```
+
+If the dev server is running, `npm run test:e2e` will reuse it automatically.
+
+> [!WARNING]
+> The dev server might time out for certain tests.
+
 ## Creating a release
 
 Before creating a release make sure that all changes are merged to the main branch.

--- a/package.json
+++ b/package.json
@@ -5,10 +5,13 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:e2e": "vite --port 5172 --strictPort --mode e2e",
     "build": "vue-tsc && vite build",
     "build:deltares": "vue-tsc && env-cmd -f deltares.env vite build",
     "build:weboc": "vue-tsc && vite build --base=/weboc/",
+    "build:e2e": "vite build --mode e2e",
     "preview": "vite preview",
+    "preview:e2e": "vite preview --port 5172 --strictPort --mode e2e",
     "test:unit": "vitest run",
     "test:dev": "vitest",
     "test:component": "playwright test -c playwright-ct.config.ts",

--- a/playwright-e2e.config.ts
+++ b/playwright-e2e.config.ts
@@ -28,7 +28,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    baseURL: 'http://localhost:5173',
+    baseURL: 'http://localhost:5172',
     screenshot: 'only-on-failure',
     trace: 'on-first-retry',
   },
@@ -48,8 +48,8 @@ export default defineConfig({
     // },
   ],
   webServer: {
-    command: 'npx vite --strictPort --mode e2e',
-    url: 'http://localhost:5173',
+    command: 'npm run preview:e2e',
+    url: 'http://localhost:5172',
     reuseExistingServer: !process.env.CI,
   },
 })


### PR DESCRIPTION
### Description
Remove webserver from e2e and let runner choose dev:e2e or preview:e2e

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
