### PR TITLE
Remove thresholds from horizontalcolorcode plot and correct order of timeseries

### DIFF
--- a/src/lib/charts/timeSeriesDisplayToChartConfig.ts
+++ b/src/lib/charts/timeSeriesDisplayToChartConfig.ts
@@ -93,7 +93,7 @@ export function timeSeriesDisplayToChartConfig(
       chartSeriesArray.push(chartSeries)
     }
 
-    if (item.thresholds !== undefined) {
+    if (item.thresholds !== undefined && item.type !== 'horizontalColorCode') {
       for (const threshold of item.thresholds) {
         if (threshold.value === undefined) continue
         const thresholdId = `${threshold.label}-${threshold.value}`

--- a/src/lib/charts/timeSeriesDisplayToChartConfig.ts
+++ b/src/lib/charts/timeSeriesDisplayToChartConfig.ts
@@ -68,7 +68,7 @@ export function timeSeriesDisplayToChartConfig(
         'horizontalColorCode',
         config,
       )
-      chartSeriesArray.push(chartSeries)
+      chartSeriesArray.unshift(chartSeries)
     }
 
     if (


### PR DESCRIPTION
### Description
Remove thresholds from horizontalcolorcode plot and correct order of timeseries

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
