### PR TITLE
Change visualisation for task that take longer than expected

### DIFF
--- a/src/components/tasks/TaskRunProgress.vue
+++ b/src/components/tasks/TaskRunProgress.vue
@@ -4,8 +4,7 @@
       <v-progress-linear
         v-bind="activatorProps"
         v-model="progress"
-        :color="color"
-        :striped="isUnknownProgress"
+        :color="isOverTime ? 'warning' : color"
         height="5"
       />
     </template>
@@ -29,6 +28,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const progress = ref(0)
 const isUnknownProgress = ref(false)
+const isOverTime = ref(false)
 const details = ref('')
 
 onMounted(() => {
@@ -46,6 +46,7 @@ function updateProgress(): void {
   ) {
     // If we do not know how long to take, set progress to unknown to show
     // progress bar as indeterminate.
+    isOverTime.value = false
     setProgress(null)
     return
   }
@@ -58,12 +59,13 @@ function updateProgress(): void {
 
   // If we are over 100%, set progress to 100% and do not show the
   // progress anymore.
+  isOverTime.value = fractionDone > 1
   setProgress(fractionDone <= 1 ? fractionDone * 100 : 100)
 }
 
 function setProgress(newProgress: number | null): void {
   isUnknownProgress.value = newProgress === null
-  progress.value = newProgress ?? 100
+  progress.value = newProgress ?? 0
   details.value = getProgressDetails()
 }
 

--- a/src/components/tasks/TaskRunProgress.vue
+++ b/src/components/tasks/TaskRunProgress.vue
@@ -5,7 +5,8 @@
         v-bind="activatorProps"
         v-model="progress"
         :color="color"
-        :indeterminate="isUnknownProgress"
+        :striped="isUnknownProgress"
+        height="5"
       />
     </template>
     {{ details }}
@@ -62,7 +63,7 @@ function updateProgress(): void {
 
 function setProgress(newProgress: number | null): void {
   isUnknownProgress.value = newProgress === null
-  progress.value = newProgress ?? 0
+  progress.value = newProgress ?? 100
   details.value = getProgressDetails()
 }
 

--- a/src/components/tasks/TaskRunsPanel.vue
+++ b/src/components/tasks/TaskRunsPanel.vue
@@ -51,14 +51,17 @@
     <v-divider />
     <v-list-item :title="`Last updated: ${lastUpdatedString}`">
       <template #append>
-        <v-progress-circular v-if="isLoading" size="20" indeterminate />
         <v-btn
-          v-else
           density="compact"
           variant="plain"
           icon="mdi-refresh"
+          :loading="isLoading"
           @click="refreshTaskRuns()"
-        />
+        >
+          <template #loader>
+            <v-progress-circular size="20" indeterminate />
+          </template>
+        </v-btn>
       </template>
     </v-list-item>
   </div>

--- a/src/lib/taskruns/status.ts
+++ b/src/lib/taskruns/status.ts
@@ -90,9 +90,9 @@ export function getIconForTaskStatus(status: TaskStatus): string {
   const category = getTaskStatusCategory(status)
   switch (category) {
     case TaskStatusCategory.Pending:
-      return 'mdi-human-queue'
+      return 'mdi-timer-cog'
     case TaskStatusCategory.Running:
-      return 'mdi-run'
+      return 'mdi-spin mdi-cog'
     case TaskStatusCategory.Completed:
       return 'mdi-check'
     case TaskStatusCategory.Failed:


### PR DESCRIPTION
### Description

Running task have a spinning cog as icon. Tasks in queue have clock with cog as icon.
Change visualisation for task that take longer than expected:

Task with known progress
<img width="450" height="63" alt="task-known-progress" src="https://github.com/user-attachments/assets/85dce5b0-9567-4a6c-9e07-db8891b1c605" />

Task with overtime
<img width="450" height="63" alt="task-overtime" src="https://github.com/user-attachments/assets/83b7898b-71ad-4040-838d-89dce2e7e378" />

Task with unknown progress
<img width="434" height="63" alt="task-unkown-progress" src="https://github.com/user-attachments/assets/ee1d1f4f-2647-4cf4-9a8b-947107bd9e4e" />
