### PR TITLE
Show select in user settings menu when setting has 4 options or more

### DIFF
--- a/src/assets/DefaultUserSettings.json
+++ b/src/assets/DefaultUserSettings.json
@@ -131,19 +131,23 @@
     "items": [
       {
         "value": "off",
-        "title": "Off"
+        "title": "Off",
+        "icon": "mdi-cancel"
       },
       {
         "value": "x",
-        "title": "Only X"
+        "title": "Only X",
+        "icon": "mdi-arrow-expand-horizontal"
       },
       {
         "value": "y",
-        "title": "Only Y"
+        "title": "Only Y",
+        "icon": "mdi-arrow-expand-vertical"
       },
       {
         "value": "xy",
-        "title": "Both X and Y"
+        "title": "Both X and Y",
+        "icon": "mdi-arrow-expand-all"
       }
     ],
     "group": "Charts"

--- a/src/components/user-settings/UserSettings.vue
+++ b/src/components/user-settings/UserSettings.vue
@@ -26,7 +26,6 @@
         <template #item="{ props }">
           <v-list-item
             v-bind="props"
-            :disabled="props?.disabled === true"
             :aria-label="`${group} ${setting.label} ${props.title}`"
           >
             <template #prepend>

--- a/src/components/user-settings/UserSettingsMenu.vue
+++ b/src/components/user-settings/UserSettingsMenu.vue
@@ -10,8 +10,11 @@
         :disabled="setting?.disabled"
       >
         <v-list-item-subtitle>{{ setting.label }} </v-list-item-subtitle>
-        <v-list-item-action v-if="setting.type === 'oneOfMultiple'">
+        <v-list-item-action
+          v-if="setting.type === 'oneOfMultiple' && setting.items"
+        >
           <v-btn-toggle
+            v-if="setting.items.length < 4"
             density="compact"
             class="my-2 multi-line-toggle"
             v-model="setting.value"
@@ -33,6 +36,37 @@
               }}</v-tooltip>
             </v-btn>
           </v-btn-toggle>
+          <v-select
+            v-else
+            v-model="setting.value"
+            :items="setting.items"
+            :disabled="setting.disabled"
+            variant="solo-filled"
+            density="compact"
+            item-title="title"
+            item-value="value"
+            :item-props="true"
+            flat
+            hide-details
+            :aria-label="`${setting.label}`"
+            class="my-2"
+            @click.preventDefault
+            @update:modelValue="onValueChange(setting)"
+          >
+            <template #item="{ props }">
+              <v-list-item
+                v-bind="props"
+                :disabled="props?.disabled === true"
+                :aria-label="`${setting.label} ${props.title}`"
+              >
+                <template #prepend>
+                  <v-icon>
+                    {{ props.icon }}
+                  </v-icon>
+                </template>
+              </v-list-item>
+            </template>
+          </v-select>
         </v-list-item-action>
         <v-list-item-action v-else-if="setting.type === 'boolean'">
           <v-switch


### PR DESCRIPTION
### Description

Show select in user settings menu when setting has 4 options or more.
Add icons for scroll wheel zoom mode options.

<img width="246" height="587" alt="Screenshot 2025-09-16 155628" src="https://github.com/user-attachments/assets/e1504342-5f49-4118-98f0-9ba654ec2b6d" />

