### PR TITLE
Product browser keep table header and footer visible and scroll table rows

### DIFF
--- a/src/components/products/ProductsBrowserTable.vue
+++ b/src/components/products/ProductsBrowserTable.vue
@@ -64,6 +64,8 @@
       "
       class="d-flex flex-1-1"
       density="compact"
+      fixed-header
+      height="400"
       @click:row="onClick"
     >
       <template v-slot:headers="{ columns, isSorted, getSortIcon, toggleSort }">


### PR DESCRIPTION
### Description

Instead of scrolling the complete table, keep table header and footer visible and scroll table rows

