### PR TITLE
Fix e2e test after vuetify update

### DIFF
--- a/tests/e2e/topology/defaultSelection.spec.ts
+++ b/tests/e2e/topology/defaultSelection.spec.ts
@@ -41,7 +41,7 @@ test.describe('Default Selection in Topology', () => {
     expect(url).toMatch(/\/topology\/early_warning\/node\/[^/]+/)
 
     // Verify that the first node in the topology tree is selected (has active class or visual indicator)
-    const firstNode = topologyTree.getByRole('link').first()
+    const firstNode = topologyTree.getByRole('listitem').first()
     await expect(firstNode).toHaveClass(/active/)
 
     // Verify that content related to the selected node is displayed
@@ -93,7 +93,9 @@ test.describe('Default Selection in Topology', () => {
     await expect(url).toContain('viewer_meteorology_rainfall_hazard_map')
 
     // Verify that the specified node is selected in the topology tree
-    const nodeLink = topologyTree.getByRole('link', { name: /Hazard map/ })
+    const nodeLink = await topologyTree
+      .getByRole('listitem')
+      .filter({ hasText: 'Hazard map' })
     await expect(nodeLink).toHaveClass(/active/)
 
     // Verify content specific to this node is displayed

--- a/tests/e2e/topology/leafNodesAsButtons.spec.ts
+++ b/tests/e2e/topology/leafNodesAsButtons.spec.ts
@@ -21,7 +21,7 @@ test.describe('Leaf nodes as buttons enabled', () => {
     await expect(layerInfo).toContainText('SAWS forecast (1x1 km)')
 
     await leafNodeButton.click()
-    await page.getByRole('link', { name: 'SAWS 4x4' }).click()
+    await page.getByRole('listitem').filter({ hasText: 'SAWS 4x4' }).click()
 
     await expect(layerInfo).toContainText('SAWS forecast (4x4 km)')
   })
@@ -41,7 +41,7 @@ test.describe('Leaf nodes as buttons enabled', () => {
     await expect(menuButton).toContainText('Early Warning')
 
     await menuButton.click()
-    await page.getByRole('link', { name: 'Admin' }).click()
+    await page.getByRole('option', { name: 'Admin' }).click()
 
     await expect(menuButton).not.toContainText('Early Warning')
     await expect(leafNodeButton).not.toBeVisible()
@@ -69,7 +69,7 @@ test.describe('Leaf nodes as buttons disabled', () => {
 
     await menuButton.click()
 
-    await page.getByRole('link', { name: 'Early Warning' }).click()
+    await page.getByRole('option', { name: 'Early Warning' }).click()
     await expect(menuButton).not.toContainText('Admin')
 
     const leafNodeButton = page.getByRole('button', { name: 'Leaf node' })

--- a/tests/e2e/topology/switchingMapNodes.spec.ts
+++ b/tests/e2e/topology/switchingMapNodes.spec.ts
@@ -13,7 +13,10 @@ test.describe('Switching Nodes with TopologySpatialTimeSeriesDisplay', () => {
     await expect(page.getByText('Water Level (m + MSL)')).toBeVisible()
 
     await page.getByText('Rivers').click()
-    await page.getByRole('link', { name: 'Badge Level stations' }).click()
+    await page
+      .getByRole('listitem')
+      .filter({ hasText: 'Level stations' })
+      .click()
 
     await expect(page.getByText('Water Level (m + MSL)')).toBeVisible()
     await expect(page.getByText('Total Water Depth (m)')).toBeVisible()
@@ -30,7 +33,7 @@ test.describe('Switching Nodes with TopologySpatialTimeSeriesDisplay', () => {
     await expect(page.getByRole('button', { name: 'Chart' })).toBeVisible()
 
     await page.getByText('Rivers').click()
-    await page.getByRole('link', { name: 'Palmiet' }).click()
+    await page.getByRole('listitem').filter({ hasText: 'Palmiet' }).click()
 
     await expect(page.getByText('Water Level (m + MSL)')).not.toBeVisible()
     await expect(page.getByRole('button', { name: 'Chart' })).not.toBeVisible()
@@ -45,7 +48,7 @@ test.describe('Switching Nodes with TopologySpatialTimeSeriesDisplayWithCoordina
     await expect(page.getByText('Precipitation Rate (mm)')).toBeVisible()
 
     await page.getByText('Coastal processes').click()
-    await page.getByRole('link', { name: 'Currents', exact: true }).click()
+    await page.getByRole('listitem').filter({ hasText: 'Currents' }).click()
 
     await expect(page.getByText('Current Speed (m/s)')).toBeVisible()
     await expect(
@@ -63,7 +66,10 @@ test.describe('Switching Nodes with TopologySpatialTimeSeriesDisplayWithCoordina
     await expect(page.getByText('Water Level (m + MSL)')).toBeVisible()
     await expect(page.getByRole('button', { name: 'Chart' })).toBeVisible()
 
-    await page.getByRole('link', { name: 'Badge Critical points' }).click()
+    await page
+      .getByRole('listitem')
+      .filter({ hasText: 'Critical points' })
+      .click()
 
     await expect(page.getByText('Water Level (m + MSL)')).not.toBeVisible()
     await expect(page.getByRole('button', { name: 'Chart' })).not.toBeVisible()


### PR DESCRIPTION
### Description

Vuetify update to 3.9 changed the role of `listitem` from "`link"` to `"listitem"`. This causes Playwright selectors to fail.