### PR TITLE
Improve handling of no recent reports are available for topology node

### DIFF
--- a/src/views/ReportsDisplayView.vue
+++ b/src/views/ReportsDisplayView.vue
@@ -51,9 +51,15 @@
       </template>
       <v-btn
         v-if="selectedReportItem && settings.report.downloadReport"
+        icon
         @click="downloadFile"
-        icon="mdi-download"
-      />
+        aria-label="Download Report"
+      >
+        <v-icon>mdi-download</v-icon>
+        <v-tooltip activator="parent" location="bottom"
+          >Download Report</v-tooltip
+        >
+      </v-btn>
     </v-toolbar>
     <ShadowFrame :htmlContent="reportHtml" />
   </div>

--- a/src/views/ReportsDisplayView.vue
+++ b/src/views/ReportsDisplayView.vue
@@ -50,7 +50,7 @@
         />
       </template>
       <v-btn
-        v-if="settings.report.downloadReport"
+        v-if="selectedReportItem && settings.report.downloadReport"
         @click="downloadFile"
         icon="mdi-download"
       />

--- a/src/views/ReportsDisplayView.vue
+++ b/src/views/ReportsDisplayView.vue
@@ -32,7 +32,7 @@
           </div>
         </template>
         <v-select
-          v-else
+          v-else-if="reportItems.length > 0"
           v-model="selectedReportItem"
           :items="reportItems"
           return-object

--- a/src/views/ReportsDisplayView.vue
+++ b/src/views/ReportsDisplayView.vue
@@ -114,14 +114,18 @@ watch(reports, () => {
     selectedReport.value =
       reports.value.find((r) => r.items.find((i) => i.isCurrent)) ??
       reports.value[0]
+  } else {
+    selectedReport.value = undefined
   }
 })
 
 watch(selectedReport, () => {
   const items = selectedReport.value?.items
-  if (!items) return
-
-  selectedReportItem.value = items.find((i) => i.isCurrent) ?? items[0]
+  if (items?.length) {
+    selectedReportItem.value = items.find((i) => i.isCurrent) ?? items[0]
+  } else {
+    selectedReportItem.value = undefined
+  }
 })
 
 const { reportHtml } = useReport(

--- a/tests/e2e/topology/switchingReportNodes.spec.ts
+++ b/tests/e2e/topology/switchingReportNodes.spec.ts
@@ -12,6 +12,10 @@ test.describe('Switching Nodes with ReportsDisplayView', () => {
 
     await expect(page.getByText('Rainfall return period report')).toBeVisible()
 
+    await expect(
+      page.getByRole('button', { name: 'Download Report' }),
+    ).toBeVisible()
+
     const combo = page
       .getByRole('combobox')
       .filter({ hasText: 'Analysis timeAnalysis' })

--- a/tests/e2e/topology/switchingReportNodes.spec.ts
+++ b/tests/e2e/topology/switchingReportNodes.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test'
+
+const base = '/topology/early_warning/node'
+
+test.describe('Switching Nodes with ReportsDisplayView', () => {
+  test('when selecting topology node with reports the current report should be visible', async ({
+    page,
+  }) => {
+    await page.goto(
+      `${base}/viewer_meteorology_rainfall_observed/viewer_meteorology_rainfall_observed_rain_gauges/reports`,
+    )
+
+    await expect(page.getByText('Rainfall return period report')).toBeVisible()
+
+    const combo = page
+      .getByRole('combobox')
+      .filter({ hasText: 'Analysis timeAnalysis' })
+    await expect(combo).toBeVisible()
+
+    await combo.click()
+    const list = await page.getByRole('listbox', { name: 'Analysis time-list' })
+    await expect(list.getByText('2025-03-14T10:00:00Z')).toBeVisible()
+    await expect(list.getByText('Current', { exact: true })).toBeVisible()
+  })
+
+  test('when selecting topology node with no reports the no report should be visible', async ({
+    page,
+  }) => {
+    await page.goto(
+      `${base}/viewer_meteorology_rainfall_forecast/viewer_meteorology_rainfall_forecast_saws_1x1/reports`,
+    )
+
+    await expect(page.getByText('No reports available')).toBeVisible()
+  })
+
+  test('when switching to a topology node with no reports the no report should be visible', async ({
+    page,
+  }) => {
+    await page.goto(
+      `${base}/viewer_meteorology_rainfall_observed/viewer_meteorology_rainfall_observed_rain_gauges/reports`,
+    )
+    await page.goto(
+      `${base}/viewer_meteorology_rainfall_forecast/viewer_meteorology_rainfall_forecast_saws_1x1/reports`,
+    )
+
+    await expect(page.getByText('No reports available')).toBeVisible()
+  })
+})


### PR DESCRIPTION
### Description

When selecting a topology node with no recent reports, hide the download and analysis time select.
When switching from a topology node with a recent report to a node without, do not show the report.


