### PR TITLE
Add dark mode support to iframe in InformationDisplayView

### DIFF
--- a/src/views/InformationDisplayView.vue
+++ b/src/views/InformationDisplayView.vue
@@ -32,11 +32,9 @@ const url = computed(() => {
   return getResourcesStaticUrl(resource)
 })
 
-watchEffect(
-  () => {
-    updateIframeClass(isDark.value)
-  },
-)
+watchEffect(() => {
+  updateIframeClass(isDark.value)
+})
 
 function updateIframeClass(isDark: boolean) {
   const iframe = frameRef.value

--- a/src/views/InformationDisplayView.vue
+++ b/src/views/InformationDisplayView.vue
@@ -4,6 +4,7 @@
     :src="url"
     title="Information Document"
     class="w-100 h-100 ma-0 pa-0 border-none"
+    ref="frame"
   />
   <div v-else class="pa-4">
     <span>No information document configured</span>
@@ -13,13 +14,16 @@
 <script setup lang="ts">
 import { getResourcesStaticUrl } from '@/lib/fews-config'
 import { TopologyNode } from '@deltares/fews-pi-requests'
-import { computed } from 'vue'
+import { useDark } from '@vueuse/core'
+import { computed, useTemplateRef, watchEffect } from 'vue'
+const isDark = useDark()
 
 interface Props {
   topologyNode?: TopologyNode
 }
 
 const props = defineProps<Props>()
+const frameRef = useTemplateRef('frame')
 
 const url = computed(() => {
   const resource = props.topologyNode?.documentFile
@@ -27,4 +31,34 @@ const url = computed(() => {
 
   return getResourcesStaticUrl(resource)
 })
+
+watchEffect(
+  () => {
+    updateIframeClass(isDark.value)
+  },
+)
+
+function updateIframeClass(isDark: boolean) {
+  const iframe = frameRef.value
+  if (!iframe || !isSameOrigin(iframe)) return
+
+  const doc = iframe.contentDocument || iframe.contentWindow?.document
+  if (!doc) return
+
+  if (isDark) {
+    doc.documentElement.classList.add('dark')
+  } else {
+    doc.documentElement.classList.remove('dark')
+  }
+}
+
+function isSameOrigin(iframe: HTMLIFrameElement): boolean {
+  try {
+    // Simply accessing location.href will throw a SecurityError if cross-origin
+    iframe.contentWindow?.location.href
+    return true // success → same-origin
+  } catch (e) {
+    return false // error → cross-origin
+  }
+}
 </script>


### PR DESCRIPTION
### Description

In dark mode the html document shown in the InformationDisplay will have the class dark.
```html
<html class="dark">
```
This allows editors to make dark themes for the html.
