### PR TITLE
Improve vertical and horizontal zoom mode in charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@deltares/fews-pi-requests": "^2.0.0-beta.1",
         "@deltares/fews-ssd-requests": "^2.0.0-rc.3",
         "@deltares/fews-ssd-webcomponent": "^2.0.0-rc.4",
-        "@deltares/fews-web-oc-charts": "^4.2.0",
+        "@deltares/fews-web-oc-charts": "^4.3.1",
         "@deltares/fews-wms-requests": "^4.0.1",
         "@deltares/webgl-streamline-visualizer": "^4.5.0",
         "@indoorequal/vue-maplibre-gl": "8.4.1",
@@ -367,9 +367,9 @@
       }
     },
     "node_modules/@deltares/fews-web-oc-charts": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@deltares/fews-web-oc-charts/-/fews-web-oc-charts-4.2.0.tgz",
-      "integrity": "sha512-bsGtnO4RiTY3jcCeUOPRRQhnqyl97Xn8LfIdMdMLH3FZ7xJ3RCSWqtGPd9lc6hUwpm4Wh4yzRkt3Ut1NlbvNAA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@deltares/fews-web-oc-charts/-/fews-web-oc-charts-4.3.1.tgz",
+      "integrity": "sha512-ZJKvMlCSi3ptEnMEV0Gcfttd0PLBnhRwDjaFeE6vLxuGCJS5ohBu/dSvJgVOhLZRxHQHc4vpwkoVbPjkzd8/iQ==",
       "license": "MIT",
       "dependencies": {
         "d3": "^7.9.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@deltares/fews-pi-requests": "^2.0.0-beta.1",
     "@deltares/fews-ssd-requests": "^2.0.0-rc.3",
     "@deltares/fews-ssd-webcomponent": "^2.0.0-rc.4",
-    "@deltares/fews-web-oc-charts": "^4.2.0",
+    "@deltares/fews-web-oc-charts": "^4.3.1",
     "@deltares/fews-wms-requests": "^4.0.1",
     "@deltares/webgl-streamline-visualizer": "^4.5.0",
     "@indoorequal/vue-maplibre-gl": "8.4.1",


### PR DESCRIPTION
### Description

Increase the distance the mouse has to move to enter free zoom mode. This makes it easier for the user to stay in horizontal or vertical zoom mode by keeping inside the white zoom indicators.

### Screenshots (if applicable)

Horizontal zoom:
<img width="594" height="485" alt="image" src="https://github.com/user-attachments/assets/e396f8de-f760-4a59-9ecf-9c7351db451c" />
Vertical zoom:
<img width="594" height="485" alt="image" src="https://github.com/user-attachments/assets/8f9e8fec-1071-426c-8ea9-3d3e2180ad75" />
Free zoom:
<img width="595" height="486" alt="image" src="https://github.com/user-attachments/assets/0e4237c5-8264-4411-a306-fc50948cd325" />

