### PR TITLE
Use configured markersize

### DIFF
--- a/src/lib/charts/styles.ts
+++ b/src/lib/charts/styles.ts
@@ -214,11 +214,11 @@ export function cssStyleFromFewsMarker(item: {
  */
 export function chartMarkerFromFews(
   style: string,
-  pointSize: number = 3,
+  markerSize: number = 3,
 ): SymbolOptions {
   const marker: SymbolOptions = {
     id: SymbolType.Circle,
-    size: pointSize ** 2,
+    size: markerSize ** 2,
     skip: 1,
   }
   switch (style) {

--- a/src/lib/charts/timeSeriesDisplayToChartConfig.ts
+++ b/src/lib/charts/timeSeriesDisplayToChartConfig.ts
@@ -88,7 +88,10 @@ export function timeSeriesDisplayToChartConfig(
 
     if (item.markerStyle !== undefined && item.markerStyle !== 'none') {
       const chartSeries: ChartSeries = getChartSeries([item], 'marker', config)
-      chartSeries.marker = chartMarkerFromFews(item.markerStyle)
+      chartSeries.marker = chartMarkerFromFews(
+        item.markerStyle,
+        item.markerSize,
+      )
       chartSeries.style = cssStyleFromFewsMarker(item)
       chartSeriesArray.push(chartSeries)
     }


### PR DESCRIPTION
### Description

Use the `markerSize` from the `<timeSeriesDisplay>` configuration. Note that the drawn marker will have an area of `markerSize`^2. A square marker will be 3px by 3px (area = 9 px^2 ), while a circular marker will have a diameter of 3.39 pixels (area = 9 px^2). The default `markerSize` is 3px, this is reduced from the previous 4px.



