### PR TITLE
fix: display empty table table and upload button when product list is empty

### DIFF
--- a/src/components/products/ProductsBrowserTable.vue
+++ b/src/components/products/ProductsBrowserTable.vue
@@ -44,7 +44,6 @@
       </v-btn>
     </v-toolbar>
     <v-data-table
-      v-if="items.length > 0"
       v-model="selectedRows"
       :items="items"
       :headers="headers"


### PR DESCRIPTION
### Description

Display empty table and upload button when product list is empty.

### Screenshots (if applicable)

<img width="980" height="906" alt="localhost_5173_topology_main_node_main_document_widget_documents" src="https://github.com/user-attachments/assets/916ecb9a-237e-4f95-95cb-7244c6b5e7a5" />

