### PR TITLE
fix: sidepanel settings

### DIFF
--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -312,10 +312,6 @@ const showActiveThresholdCrossingsForFilters = computed(() => {
   )
 })
 
-const showTaskRuns = computed(
-  () => topologyComponentConfig.value?.enableTaskRuns ?? false,
-)
-
 const topologyNodesStore = useTopologyNodesStore()
 topologyNodesStore
   .fetch()


### PR DESCRIPTION
### Description

This side panel settings had strange behavior, where the taksRuns settings interfered with the other settings.
When no side panel settings are found, the default is to not show side panel components.
Also hide the control when no side panels are enabled.

