### PR TITLE
Fix timeZeroString assignment to be valid FEWS PI date parameter

### DIFF
--- a/src/components/tasksdisplay/WhatIfTimeZeroSelect.vue
+++ b/src/components/tasksdisplay/WhatIfTimeZeroSelect.vue
@@ -61,6 +61,10 @@ function setTimeZero(date: string | undefined): void {
 }
 
 watch(selectedTimeZero, (newTimeZero) => {
-  timeZeroString.value = newTimeZero
+  if (!newTimeZero) {
+    timeZeroString.value = ''
+    return
+  }
+  timeZeroString.value = convertJSDateToFewsPiParameter(new Date(newTimeZero))
 })
 </script>


### PR DESCRIPTION
### Description

WhatIf timeZero parameter should always use Zulu time for time zone, i.e. string should end with `Z`.

