### PR TITLE
feat: update measure tools to support dark theme

### DIFF
--- a/src/assets/DefaultUserSettings.json
+++ b/src/assets/DefaultUserSettings.json
@@ -145,9 +145,9 @@
     "group": "Map"
   },
   {
-    "id": "ui.map.tools",
+    "id": "ui.map.measuringTools",
     "type": "boolean",
-    "label": "Show map tools",
+    "label": "Show measuring tools",
     "value": false,
     "group": "Map"
   },

--- a/src/components/map/MapToolsControl.vue
+++ b/src/components/map/MapToolsControl.vue
@@ -49,27 +49,31 @@ const removeControl = () => {
 }
 
 onMounted(() => {
-  watch(
-    () => settings.get('ui.map.measuringTools')?.value ?? false,
-    (enabled) => {
-      if (!map) {
-        console.warn('Map is not available')
-        return
-      }
-
-      if (enabled) {
-        if (!measureControl) {
-          addControl()
-        }
-      } else {
-        if (measureControl) {
-          removeControl()
-        }
-      }
-    },
-    { immediate: true },
-  )
+  const enabled = settings.get('ui.map.measuringTools')?.value ?? false
+  if (enabled) {
+    addControl()
+  }
 })
+
+watch(
+  () => settings.get('ui.map.measuringTools')?.value ?? false,
+  (enabled) => {
+    if (!map) {
+      console.warn('Map is not available')
+      return
+    }
+
+    if (enabled) {
+      if (!measureControl) {
+        addControl()
+      }
+    } else {
+      if (measureControl) {
+        removeControl()
+      }
+    }
+  },
+)
 
 onBeforeUnmount(() => {
   if (measureControl) {

--- a/src/components/map/MapToolsControl.vue
+++ b/src/components/map/MapToolsControl.vue
@@ -5,9 +5,17 @@ import { onBeforeUnmount, watch, onMounted } from 'vue'
 import { useMap } from '@/services/useMap'
 import { useUserSettingsStore } from '@/stores/userSettings'
 import { MaplibreMeasureControl } from '@watergis/maplibre-gl-terradraw'
+import {
+  getLineLayerLabelSpec,
+  getModeOtions,
+  getPointLayerLabelSpec,
+  getPolygonLayerSpec,
+} from '@/lib/map/terraDraw'
+import { useDark } from '@vueuse/core'
 
 const { map } = useMap()
 const settings = useUserSettingsStore()
+const isDark = useDark()
 
 let measureControl: MaplibreMeasureControl | null = null
 
@@ -26,6 +34,10 @@ const addControl = () => {
       'download',
     ],
     open: true,
+    modeOptions: getModeOtions(isDark.value),
+    pointLayerLabelSpec: getPointLayerLabelSpec(isDark.value),
+    lineLayerLabelSpec: getLineLayerLabelSpec(isDark.value),
+    polygonLayerSpec: getPolygonLayerSpec(isDark.value),
   })
   map.addControl(measureControl, 'top-right')
 }

--- a/src/components/map/MapToolsControl.vue
+++ b/src/components/map/MapToolsControl.vue
@@ -50,7 +50,7 @@ const removeControl = () => {
 
 onMounted(() => {
   watch(
-    () => settings.get('ui.map.tools')?.value ?? false,
+    () => settings.get('ui.map.measuringTools')?.value ?? false,
     (enabled) => {
       if (!map) {
         console.warn('Map is not available')

--- a/src/components/map/MapToolsControl.vue
+++ b/src/components/map/MapToolsControl.vue
@@ -52,6 +52,9 @@ const addControl = () => {
   terraDrawInstance.on('finish', (e) => {
     features.value = terraDrawInstance.getSnapshot()
   })
+  measureControl.on('feature-deleted', () => {
+    features.value = terraDrawInstance.getSnapshot()
+  })
 
   if (features.value.length > 0) {
     map.once('idle', () => {

--- a/src/lib/map/terraDraw.ts
+++ b/src/lib/map/terraDraw.ts
@@ -1,0 +1,240 @@
+import {
+  TerraDrawCircleMode,
+  TerraDrawFreehandMode,
+  TerraDrawLineStringMode,
+  TerraDrawPointMode,
+  TerraDrawPolygonMode,
+  TerraDrawRectangleMode,
+} from 'terra-draw'
+import { SymbolLayerSpecification } from 'maplibre-gl'
+
+export function getModeOtions(isDark: boolean = false) {
+  return {
+    point: new TerraDrawPointMode({
+      editable: true,
+      styles: {
+        pointColor: isDark ? '#000000' : '#FFFFFF',
+        pointWidth: 5,
+        pointOutlineColor: isDark ? '#999999' : '#666666',
+        pointOutlineWidth: 1,
+      },
+    }),
+    linestring: new TerraDrawLineStringMode({
+      editable: true,
+      styles: {
+        lineStringColor: isDark ? '#999999' : '#666666',
+        lineStringWidth: 2,
+        closingPointColor: isDark ? '#000000' : '#FFFFFF',
+        closingPointWidth: 3,
+        closingPointOutlineColor: isDark ? '#999999' : '#666666',
+        closingPointOutlineWidth: 1,
+      },
+    }),
+    polygon: new TerraDrawPolygonMode({
+      editable: true,
+      styles: {
+        fillColor: isDark ? '#000000' : '#EDEFF0',
+        fillOpacity: 0.7,
+        outlineColor: isDark ? '#999999' : '#666666',
+        outlineWidth: 2,
+        closingPointColor: isDark ? '#000000' : '#FAFAFA',
+        closingPointWidth: 3,
+        closingPointOutlineColor: isDark ? '#999999' : '#666666',
+        closingPointOutlineWidth: 1,
+      },
+    }),
+
+    rectangle: new TerraDrawRectangleMode({
+      styles: {
+        fillColor: isDark ? '#000000' : '#EDEFF0',
+        fillOpacity: 0.7,
+        outlineColor: isDark ? '#999999' : '#666666',
+        outlineWidth: 2,
+      },
+    }),
+    circle: new TerraDrawCircleMode({
+      styles: {
+        fillColor: isDark ? '#000000' : '#EDEFF0',
+        fillOpacity: 0.7,
+        outlineColor: isDark ? '#999999' : '#666666',
+        outlineWidth: 2,
+      },
+    }),
+    freehand: new TerraDrawFreehandMode({
+      styles: {
+        fillColor: isDark ? '#000000' : '#EDEFF0',
+        fillOpacity: 0.7,
+        outlineColor: isDark ? '#999999' : '#666666',
+        outlineWidth: 2,
+        closingPointColor: isDark ? '#000000' : '#FAFAFA',
+        closingPointWidth: 3,
+        closingPointOutlineColor: isDark ? '#999999' : '#666666',
+        closingPointOutlineWidth: 1,
+      },
+    }),
+  }
+}
+
+export function getPointLayerLabelSpec(isDark: boolean = false) {
+  const specification: SymbolLayerSpecification = {
+    id: '{prefix}-point-label',
+    type: 'symbol',
+    source: '{prefix}-point',
+    filter: [
+      'all',
+      ['==', '$type', 'Point'],
+      ['any', ['==', 'mode', 'point'], ['==', 'mode', 'marker']],
+    ],
+    layout: {
+      'text-field': [
+        'case',
+        ['all', ['has', 'elevation'], ['>', ['get', 'elevation'], 0]],
+        [
+          'concat',
+          'Alt. ',
+          ['to-string', ['floor', ['get', 'elevation']]],
+          ' ',
+          ['get', 'elevationUnit'],
+        ],
+        '',
+      ],
+      'symbol-placement': 'point',
+      'text-size': [
+        'interpolate',
+        ['linear'],
+        ['zoom'],
+        5,
+        10,
+        10,
+        12.0,
+        13,
+        14.0,
+        14,
+        16.0,
+        18,
+        18.0,
+      ],
+      'text-overlap': 'always',
+      'text-variable-anchor': ['left', 'right', 'top', 'bottom'],
+      'text-radial-offset': 0.5,
+      'text-justify': 'center',
+      'text-letter-spacing': 0.05,
+    },
+    paint: {
+      'text-halo-color': isDark ? '#232E3D' : '#F7F7F7',
+      'text-halo-width': 1,
+      'text-color': isDark ? '#F7F7F7' : '#232E3D',
+    },
+  }
+  return specification
+}
+
+export function getLineLayerLabelSpec(isDark: boolean = false) {
+  const specification: SymbolLayerSpecification = {
+    id: '{prefix}-line-label',
+    type: 'symbol',
+    source: '{prefix}-line-source',
+    filter: ['==', '$type', 'Point'],
+    layout: {
+      'text-field': [
+        'concat',
+        ['to-string', ['get', 'distance']],
+        ' ',
+        ['get', 'unit'],
+        [
+          'case',
+          ['==', ['get', 'total'], 0],
+          '',
+          [
+            'concat',
+            '\n(',
+            ['to-string', ['get', 'total']],
+            ' ',
+            ['get', 'totalUnit'],
+            ')',
+          ],
+        ],
+        [
+          'case',
+          ['all', ['has', 'elevation'], ['>', ['get', 'elevation'], 0]],
+          [
+            'concat',
+            '\nAlt. ',
+            ['to-string', ['floor', ['get', 'elevation']]],
+            ' ',
+            ['get', 'elevationUnit'],
+          ],
+          '',
+        ],
+      ],
+      'symbol-placement': 'point',
+      'text-size': [
+        'interpolate',
+        ['linear'],
+        ['zoom'],
+        5,
+        10,
+        10,
+        12.0,
+        13,
+        14.0,
+        14,
+        16.0,
+        18,
+        18.0,
+      ],
+      'text-overlap': 'always',
+      'text-variable-anchor': ['left', 'right', 'top', 'bottom'],
+      'text-radial-offset': 0.5,
+      'text-justify': 'center',
+      'text-letter-spacing': 0.05,
+    },
+    paint: {
+      'text-halo-color': isDark ? '#232E3D' : '#F7F7F7',
+      'text-halo-width': 1,
+      'text-color': isDark ? '#F7F7F7' : '#232E3D',
+    },
+  }
+  return specification
+}
+
+export function getPolygonLayerSpec(isDark: boolean = false) {
+  const specification: SymbolLayerSpecification = {
+    id: '{prefix}-polygon-label',
+    type: 'symbol',
+    source: '{prefix}-polygon-source',
+    filter: ['==', '$type', 'Point'],
+    layout: {
+      'text-field': [
+        'concat',
+        ['to-string', ['get', 'area']],
+        ' ',
+        ['get', 'unit'],
+      ],
+      'symbol-placement': 'point',
+      'text-size': [
+        'interpolate',
+        ['linear'],
+        ['zoom'],
+        5,
+        10,
+        10,
+        12.0,
+        13,
+        14.0,
+        14,
+        16.0,
+        18,
+        18.0,
+      ],
+      'text-overlap': 'always',
+      'text-letter-spacing': 0.05,
+    },
+    paint: {
+      'text-halo-color': isDark ? '#232E3D' : '#F7F7F7',
+      'text-halo-width': 1,
+      'text-color': isDark ? '#F7F7F7' : '#232E3D',
+    },
+  }
+  return specification
+}

--- a/src/lib/map/utils.ts
+++ b/src/lib/map/utils.ts
@@ -2,6 +2,7 @@ import type { Map } from 'maplibre-gl'
 
 const LAYER_PREFIX = 'weboc-layer-'
 const SOURCE_PREFIX = 'weboc-source-'
+const TERRADRAW_PREFIX = 'td-measure-'
 
 export function getLayerId(id: string) {
   return `${LAYER_PREFIX}${id}`
@@ -12,11 +13,11 @@ export function getSourceId(id: string) {
 }
 
 export function isCustomLayer(id: string) {
-  return id.startsWith(LAYER_PREFIX)
+  return id.startsWith(LAYER_PREFIX) || id.startsWith(TERRADRAW_PREFIX)
 }
 
 export function isCustomSource(id: string) {
-  return id.startsWith(SOURCE_PREFIX)
+  return id.startsWith(SOURCE_PREFIX) || id.startsWith(TERRADRAW_PREFIX)
 }
 
 export const mapIds = {


### PR DESCRIPTION
### Description

The map measuring tools style is update to better contrast in dark mode. Also reduces text halo width to be more inline with Carto style labels. Renames "Map tools" to "Measuring tools". 

### Screenshots (if applicable)

If there are any visual changes, please attach screenshots here.

