### PR TITLE
Set do follow now to false when viewing non current wms data

### DIFF
--- a/src/components/spatialdisplay/SpatialDisplayComponent.vue
+++ b/src/components/spatialdisplay/SpatialDisplayComponent.vue
@@ -147,7 +147,7 @@
       v-if="showDateTimeSlider"
       v-model:selectedDate="selectedDateOfSlider"
       :dates="times ?? []"
-      @update:doFollowNow="setLayerOptions"
+      v-model:doFollowNow="doFollowNow"
       class="spatial-display__slider"
       :hide-speed-controls="mobile"
       :isLoading="isLoading"
@@ -278,6 +278,15 @@ const minElevation = ref<number>(-Infinity)
 const maxElevation = ref<number>(Infinity)
 const elevationTicks = ref<number[]>()
 const elevationUnit = ref('')
+
+const doFollowNow = ref(taskRunId.value === undefined)
+// Set follow now to false when a task run is selected because taskRun data is typically historical data,
+// so it doesn't make sense to follow now.
+watch(taskRunId, () => {
+  if (taskRunId.value !== undefined) {
+    doFollowNow.value = false
+  }
+})
 
 const locationToChildrenMap = computed(() =>
   createLocationToChildrenMap(props.locations ?? []),


### PR DESCRIPTION
### Description
When viewing non-current data the timeslider would still try to follow now, but if now is not present in the dates it would always go to the end of the slider. This change turns off follow now when viewing non-current data.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
