### PR TITLE
Fix threshold toggling for charts without defaultDomain

### DIFF
--- a/src/components/charts/TimeSeriesChart.vue
+++ b/src/components/charts/TimeSeriesChart.vue
@@ -252,6 +252,8 @@ function setThresholdLines() {
     return { y: config }
   } else {
     thresholdLinesVisitor.options = []
+    // FIXME: fix setOptions to make it possible to delete settings like defaultDomain without having to reset the entire axis options
+    axis.options.y?.forEach((y) => delete y.defaultDomain)
     return { y: props.config.yAxis }
   }
 }


### PR DESCRIPTION
### Description

Fix an issue where autoscaling of the y-axis does not function correctly when toggling off the thresholds.
This occurs for charts with no `axisMinValue` and `axisMaxValue` specified.

