### PR TITLE
Determine initials from preferred username when logging in with OIDC.

### DIFF
--- a/src/lib/auth/initials.test.ts
+++ b/src/lib/auth/initials.test.ts
@@ -1,17 +1,20 @@
 import { describe, expect, test } from 'vitest'
-import { initialsFromName, initialsFromPreferredUserName } from './initials'
+import {
+  initialsFromUpperCaseName,
+  initialsFromPreferredUserName,
+} from './initials'
 
-describe('initialsFromName', () => {
+describe('initialsFromUpperCaseName', () => {
   test('returns first two uppercase characters', () => {
-    expect(initialsFromName('John Doe')).toEqual('JD')
+    expect(initialsFromUpperCaseName('John Doe')).toEqual('JD')
   })
 
   test('returns empty string when no uppercase characters are present', () => {
-    expect(initialsFromName('john doe')).toEqual('')
+    expect(initialsFromUpperCaseName('john doe')).toEqual('')
   })
 
   test('returns one uppercase character when only one exists', () => {
-    expect(initialsFromName('john Doe')).toEqual('D')
+    expect(initialsFromUpperCaseName('john Doe')).toEqual('D')
   })
 })
 

--- a/src/lib/auth/initials.test.ts
+++ b/src/lib/auth/initials.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest'
+import { initialsFromName, initialsFromPreferredUserName } from './initials'
+
+describe('initialsFromName', () => {
+  test('returns first two uppercase characters', () => {
+    expect(initialsFromName('John Doe')).toEqual('JD')
+  })
+
+  test('returns empty string when no uppercase characters are present', () => {
+    expect(initialsFromName('john doe')).toEqual('')
+  })
+
+  test('returns one uppercase character when only one exists', () => {
+    expect(initialsFromName('john Doe')).toEqual('D')
+  })
+})
+
+describe('initialsFromPreferredUserName', () => {
+  test('returns empty string for empty input', () => {
+    expect(initialsFromPreferredUserName('')).toEqual('')
+  })
+
+  test('uses first separator match for initials', () => {
+    expect(initialsFromPreferredUserName('john.doe')).toEqual('jd')
+  })
+
+  test('supports underscore separator', () => {
+    expect(initialsFromPreferredUserName('john_doe')).toEqual('jd')
+  })
+
+  test('falls back to first two characters when no separator exists', () => {
+    expect(initialsFromPreferredUserName('johndoe')).toEqual('jo')
+  })
+
+  test('returns single character when input length is one', () => {
+    expect(initialsFromPreferredUserName('j')).toEqual('j')
+  })
+})

--- a/src/lib/auth/initials.ts
+++ b/src/lib/auth/initials.ts
@@ -1,13 +1,12 @@
-
 /**
  * Extracts initials from a name by finding uppercase characters.
  * @param givenName - The name to extract initials from
  * @returns A string containing up to 2 uppercase characters found in the name
  * @example
- * initialsFromName("JohnDoe") // Returns "JD"
- * initialsFromName("john") // Returns ""
+ * initialsFromUpperCaseName("JohnDoe") // Returns "JD"
+ * initialsFromUpperCaseName("john") // Returns ""
  */
-export function initialsFromName(givenName: string): string {
+export function initialsFromUpperCaseName(givenName: string): string {
   let initialsString = ''
   for (const character of givenName) {
     if (character !== character.toLowerCase()) {

--- a/src/lib/auth/initials.ts
+++ b/src/lib/auth/initials.ts
@@ -1,0 +1,45 @@
+
+/**
+ * Extracts initials from a name by finding uppercase characters.
+ * @param givenName - The name to extract initials from
+ * @returns A string containing up to 2 uppercase characters found in the name
+ * @example
+ * initialsFromName("JohnDoe") // Returns "JD"
+ * initialsFromName("john") // Returns ""
+ */
+export function initialsFromName(givenName: string): string {
+  let initialsString = ''
+  for (const character of givenName) {
+    if (character !== character.toLowerCase()) {
+      initialsString = initialsString + character
+    }
+    if (initialsString.length === 2) return initialsString
+  }
+  return initialsString
+}
+
+/**
+ * Extracts initials from a preferred username by taking the first character
+ * and the character after the first separator found.
+ * @param givenName - The preferred username to extract initials from
+ * @returns A string containing up to 2 characters representing the initials
+ * @example
+ * initialsFromPreferredUserName("john.doe") // Returns "jd"
+ * initialsFromPreferredUserName("john") // Returns "jo"
+ * initialsFromPreferredUserName("j") // Returns "j"
+ */
+export function initialsFromPreferredUserName(givenName: string): string {
+  if (!givenName) return ''
+
+  const firstChar = givenName.charAt(0)
+  const separators = ['.', ',', '_', '-', ' ']
+
+  for (const sep of separators) {
+    const idx = givenName.indexOf(sep)
+    if (idx !== -1 && idx + 1 < givenName.length) {
+      return firstChar + givenName.charAt(idx + 1)
+    }
+  }
+
+  return givenName.length >= 2 ? givenName.substring(0, 2) : firstChar
+}

--- a/src/views/auth/LoginComponent.vue
+++ b/src/views/auth/LoginComponent.vue
@@ -54,7 +54,6 @@ function initialsFromPreferredUserName(givenName: string): string {
   return givenName.length >= 2 ? givenName.substring(0, 2) : firstChar
 }
 
-
 const route = useRoute()
 const initials = ref('')
 const roles = ref([''])
@@ -91,15 +90,15 @@ watch(user, () => {
       roles.value = user.value.profile.roles
         ? (user.value.profile.roles as string[])
         : []
-    }
-    else if (user.value.profile?.preferred_username !== undefined) {
+    } else if (user.value.profile?.preferred_username !== undefined) {
       name.value = user.value.profile.preferred_username
-      initials.value = initialsFromPreferredUserName(user.value.profile.preferred_username)
+      initials.value = initialsFromPreferredUserName(
+        user.value.profile.preferred_username,
+      )
       roles.value = user.value.profile.roles
-          ? (user.value.profile.roles as string[])
-          : []
+        ? (user.value.profile.roles as string[])
+        : []
     }
-
   } else {
     requiresLogin.value = true
   }

--- a/src/views/auth/LoginComponent.vue
+++ b/src/views/auth/LoginComponent.vue
@@ -40,6 +40,21 @@ function initialsFromName(givenName: string): string {
   return initialsString
 }
 
+function initialsFromPreferredUserName(givenName: string): string {
+  if (!givenName) return ''
+  const firstChar = givenName.charAt(0)
+  const separators = ['.', ',', '_', '-', ' ']
+  for (const sep of separators) {
+    const idx = givenName.indexOf(sep)
+    if (idx !== -1 && idx + 1 < givenName.length) {
+      return firstChar + givenName.charAt(idx + 1)
+    }
+  }
+  // If no separator found, return first two characters if available
+  return givenName.length >= 2 ? givenName.substring(0, 2) : firstChar
+}
+
+
 const route = useRoute()
 const initials = ref('')
 const roles = ref([''])
@@ -77,6 +92,14 @@ watch(user, () => {
         ? (user.value.profile.roles as string[])
         : []
     }
+    else if (user.value.profile?.preferred_username !== undefined) {
+      name.value = user.value.profile.preferred_username
+      initials.value = initialsFromPreferredUserName(user.value.profile.preferred_username)
+      roles.value = user.value.profile.roles
+          ? (user.value.profile.roles as string[])
+          : []
+    }
+
   } else {
     requiresLogin.value = true
   }

--- a/src/views/auth/LoginComponent.vue
+++ b/src/views/auth/LoginComponent.vue
@@ -24,35 +24,11 @@ import { onMounted, ref, watch } from 'vue'
 import { authenticationManager } from '../../services/authentication/AuthenticationManager.js'
 import { useRoute } from 'vue-router'
 import type { User } from 'oidc-client-ts'
+import { initialsFromName, initialsFromPreferredUserName } from '@/lib/auth/initials.ts'
 
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
-
-function initialsFromName(givenName: string): string {
-  let initialsString = ''
-  for (const character of givenName) {
-    if (character !== character.toLowerCase()) {
-      initialsString = initialsString + character
-    }
-    if (initialsString.length === 2) return initialsString
-  }
-  return initialsString
-}
-
-function initialsFromPreferredUserName(givenName: string): string {
-  if (!givenName) return ''
-  const firstChar = givenName.charAt(0)
-  const separators = ['.', ',', '_', '-', ' ']
-  for (const sep of separators) {
-    const idx = givenName.indexOf(sep)
-    if (idx !== -1 && idx + 1 < givenName.length) {
-      return firstChar + givenName.charAt(idx + 1)
-    }
-  }
-  // If no separator found, return first two characters if available
-  return givenName.length >= 2 ? givenName.substring(0, 2) : firstChar
-}
 
 const route = useRoute()
 const initials = ref('')

--- a/src/views/auth/LoginComponent.vue
+++ b/src/views/auth/LoginComponent.vue
@@ -24,7 +24,10 @@ import { onMounted, ref, watch } from 'vue'
 import { authenticationManager } from '../../services/authentication/AuthenticationManager.js'
 import { useRoute } from 'vue-router'
 import type { User } from 'oidc-client-ts'
-import { initialsFromName, initialsFromPreferredUserName } from '@/lib/auth/initials.ts'
+import {
+  initialsFromUpperCaseName,
+  initialsFromPreferredUserName,
+} from '@/lib/auth/initials.ts'
 
 import { useI18n } from 'vue-i18n'
 
@@ -62,7 +65,7 @@ watch(user, () => {
     requiresLogin.value = false
     if (user.value.profile?.name !== undefined) {
       name.value = user.value.profile.name
-      initials.value = initialsFromName(user.value.profile.name)
+      initials.value = initialsFromUpperCaseName(user.value.profile.name)
       roles.value = user.value.profile.roles
         ? (user.value.profile.roles as string[])
         : []


### PR DESCRIPTION
### Description

After logging in with OIDC the logged in user is shown by displaying the initials from the OIDC id token name claim. This claim is not always set due to GDPR. Usually the preferred_username claim is set. This isue tries to determine the initials from the preferred_user claim if the name claim is not set. With this improvement that initials are determined from the preferred username taking separators into account like .,-_

Before the fix, it looks like this:
<img width="264" height="215" alt="image" src="https://github.com/user-attachments/assets/4077bb9f-0348-4f41-9a88-822fae616eb0" />

After the fix:
<img width="235" height="166" alt="image" src="https://github.com/user-attachments/assets/12e51c60-6f8e-4f2a-97a1-203e4c3c1f29" />
