### PR TITLE
Fix date/time format for what-if scenario date/time picker

### DIFF
--- a/src/components/tasksdisplay/customFormRenderers/CustomDateTimeControl.vue
+++ b/src/components/tasksdisplay/customFormRenderers/CustomDateTimeControl.vue
@@ -41,6 +41,7 @@ import {
 } from '@jsonforms/vue'
 import { computed, inject, type Ref, ref, watch } from 'vue'
 
+import { toHumanReadableDateTime } from '@/lib/date'
 import {
   computeValidDateRange,
   DateValidationOptions,
@@ -169,8 +170,8 @@ function createDateRangeMessages(): string[] {
   if (validDateRange.value === null) return []
   const [startDate, endDate] = validDateRange.value
   return [
-    `Earliest valid time: ${startDate.toLocaleString()}`,
-    `Latest valid time: ${endDate.toLocaleString()}`,
+    `Earliest valid time: ${toHumanReadableDateTime(startDate)}`,
+    `Latest valid time: ${toHumanReadableDateTime(endDate)}`,
   ]
 }
 

--- a/src/lib/whatif/utils.ts
+++ b/src/lib/whatif/utils.ts
@@ -4,7 +4,10 @@ import type {
   WhatIfScenarioDescriptor,
   WhatIfTemplate,
 } from '@deltares/fews-pi-requests'
-import { convertJSDateToFewsPiParameter } from '@/lib/date'
+import {
+  convertJSDateToFewsPiParameter,
+  toHumanReadableDateTime,
+} from '@/lib/date'
 import { WhatIfProperty } from './types'
 
 export type TemplateProperty = NonNullable<WhatIfTemplate['properties']>[number]
@@ -358,8 +361,8 @@ export function getErrorsForProperties(
         if (parsed < startDate || parsed > endDate) {
           const message =
             parsed < startDate
-              ? `"${title}" must be on or after ${startDate.toLocaleString()}`
-              : `"${title}" must be on or before ${endDate.toLocaleString()}`
+              ? `"${title}" must be on or after ${toHumanReadableDateTime(startDate)}`
+              : `"${title}" must be on or before ${toHumanReadableDateTime(endDate)}`
           errors.push({
             keyword: 'date-out-of-range',
             instancePath: `/${key}`,


### PR DESCRIPTION
### Description
Currently, the date/time picker in what-if scenario parameter forms does not follow the WebOC convention for date/time formatting; this PR fixes that.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes: