### PR TITLE
Make x-axis nice in vertical profiles

### DIFF
--- a/src/lib/charts/axisOptions.ts
+++ b/src/lib/charts/axisOptions.ts
@@ -55,6 +55,7 @@ function getVerticalProfileOptions(): Partial<CartesianAxesOptions> {
     x: [
       {
         type: AxisType.value, // x-axis is never time for vertical profile
+        nice: true,
       },
     ],
   }


### PR DESCRIPTION
Vertical profiles in sigma layers were sometimes not visible. Was an issue with x-axis limits I fixed it but I do not know if it is the cleanest approach