### PR TITLE
Fix area plots that fill between timeseries and 0 not working

### DIFF
--- a/src/lib/charts/timeSeriesDisplayToChartConfig.ts
+++ b/src/lib/charts/timeSeriesDisplayToChartConfig.ts
@@ -36,7 +36,7 @@ export function timeSeriesDisplayToChartConfig(
   const chartSeriesArray: ChartSeries[] = []
   const areaLegendLabels: string[] = []
 
-  for (const item of subplot.items) {
+  for (const [index, item] of subplot.items.entries()) {
     if (item.type === 'area' && item.legend) {
       if (areaLegendLabels.includes(item.legend)) {
         // Create second item as dummy for item.type 'area'
@@ -46,20 +46,16 @@ export function timeSeriesDisplayToChartConfig(
       }
       areaLegendLabels.push(item.legend)
 
-      // Area has two data resources
+      // Area can have two data resources
       const secondItemIndex = subplot.items.findLastIndex(
         (i) => i.legend === item.legend,
       )
-      if (secondItemIndex > -1) {
-        const secondItem = subplot.items[secondItemIndex]
-        const chartType = item.lineStyle === undefined ? 'area' : 'rule'
-        const chartSeries: ChartSeries = getChartSeries(
-          [item, secondItem],
-          chartType,
-          config,
-        )
-        chartSeriesArray.push(chartSeries)
-      }
+      const chartType = item.lineStyle === undefined ? 'area' : 'rule'
+      const secondItem = subplot.items[secondItemIndex]
+      const items = secondItemIndex === index ? [item] : [item, secondItem]
+
+      const chartSeries = getChartSeries(items, chartType, config)
+      chartSeriesArray.push(chartSeries)
     }
 
     if (item.type === 'horizontalColorCode') {

--- a/src/stores/taskRuns.ts
+++ b/src/stores/taskRuns.ts
@@ -34,6 +34,8 @@ export const useTaskRunsStore = defineStore('taskRuns', () => {
   }
 
   function clearSelectedTaskRuns() {
+    // Avoid unnecessary reactivity
+    if (selectedTaskRuns.value.length === 0) return
     selectedTaskRuns.value = []
   }
 


### PR DESCRIPTION
### Description
Fix area plots that fill between timeserie and 0 not working

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
