### PR TITLE
Fix dashboard double click when changing wms layer resulting in first wms layer click

### DIFF
--- a/src/components/dashboard/DashboardItem.vue
+++ b/src/components/dashboard/DashboardItem.vue
@@ -153,7 +153,10 @@ function onNavigate(to: NavigateRoute) {
 }
 
 function navigateTo(to: NavigateRoute) {
+  const layerName = to.params?.layerName ?? routeParams.value.layerName
+
   routeParams.value = {
+    layerName,
     ...to.params,
   }
 }


### PR DESCRIPTION
### Description
Remember layerName in dashboard navigates just like in topologyDisplayview

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.