### PR TITLE
Update icon for dynamic reports tab to mdi-table-clock

### DIFF
--- a/src/lib/topology/component.ts
+++ b/src/lib/topology/component.ts
@@ -31,7 +31,7 @@ export const componentTypeToIconMap = {
   'data-download-display': 'mdi-download',
   report: 'mdi-file-document',
   'schematic-status-display': 'mdi-application',
-  'dynamic-report-display': 'mdi-file-document-edit',
+  'dynamic-report-display': 'mdi-table-clock',
   'system-monitor': 'mdi-monitor',
   'html-display': 'mdi-web',
   'runtask-display': 'mdi-cog',


### PR DESCRIPTION
### Description

Update icon for dynamic reports tab to mdi-table-clock

### Screenshots

<img width="192" height="48" alt="localhost_5173_topology_early_warning_node_viewer_coastal_waves_viewer_coastal_waves_swan_dynamicreport" src="https://github.com/user-attachments/assets/4b3896cb-511d-4db6-beee-e66a2e48b3f7" />
