### PR TITLE
Show (abbreviated) task description without expanding task

### DIFF
--- a/src/components/compare/ForecastSummary.vue
+++ b/src/components/compare/ForecastSummary.vue
@@ -35,6 +35,12 @@
               >
                 {{ `${whatIfTemplate.name}` }}
               </v-list-item-subtitle>
+              <v-list-item-subtitle v-if="task.description">
+                <SingleLineWithOverflowTooltip
+                  :text="task.description"
+                  max-width="400"
+                />
+              </v-list-item-subtitle>
               <v-list-item-subtitle
                 :class="{ 'text-wrap': expanded, 'text-wrap-no': !expanded }"
               >
@@ -81,6 +87,7 @@ import { useAvailableWhatIfTemplatesStore } from '@/stores/availableWhatIfTempla
 import { useTaskRunsStore } from '@/stores/taskRuns'
 import { useTaskRunColorsStore } from '@/stores/taskRunColors'
 import WhatIfScenarioSummary from '@/components/tasks/WhatIfScenarioSummary.vue'
+import SingleLineWithOverflowTooltip from '../general/SingleLineWithOverflowTooltip.vue'
 
 const availableWorkflowsStore = useAvailableWorkflowsStore()
 const availableWhatIfTemplatesStore = useAvailableWhatIfTemplatesStore()

--- a/src/components/general/SingleLineWithOverflowTooltip.vue
+++ b/src/components/general/SingleLineWithOverflowTooltip.vue
@@ -1,0 +1,42 @@
+<template>
+  <div ref="container">
+    <v-tooltip
+      :text="text"
+      location="center"
+      :max-width="maxWidth"
+      :disabled="!isOverflowing"
+    >
+      <template #activator="{ props }">
+        <span v-bind="props" class="ellipsis-overflow">
+          {{ text }}
+        </span>
+      </template>
+    </v-tooltip>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, useTemplateRef } from 'vue'
+
+interface Props {
+  text: string
+  maxWidth?: string | number
+}
+defineProps<Props>()
+
+const container = useTemplateRef('container')
+const isOverflowing = computed<boolean>(() => {
+  const element = container.value?.querySelector('span')
+  if (!element) return false
+  return element.scrollWidth > element.clientWidth
+})
+</script>
+
+<style scoped>
+.ellipsis-overflow {
+  display: block;
+  text-overflow: ellipsis ' [...]';
+  white-space: nowrap;
+  overflow: hidden;
+}
+</style>

--- a/src/components/tasks/TaskRunSummary.vue
+++ b/src/components/tasks/TaskRunSummary.vue
@@ -35,6 +35,12 @@
               >
                 {{ whatIfTemplate.name }}
               </v-list-item-subtitle>
+              <v-list-item-subtitle v-if="task.description">
+                <SingleLineWithOverflowTooltip
+                  :text="task.description"
+                  max-width="400"
+                />
+              </v-list-item-subtitle>
             </div>
           </div>
         </div>
@@ -72,6 +78,7 @@ import {
 } from '@/lib/date'
 import { useAvailableWhatIfTemplatesStore } from '@/stores/availableWhatIfTemplates'
 import WhatIfScenarioSummary from './WhatIfScenarioSummary.vue'
+import SingleLineWithOverflowTooltip from '../general/SingleLineWithOverflowTooltip.vue'
 
 const availableWorkflowsStore = useAvailableWorkflowsStore()
 const availableWhatIfTemplatesStore = useAvailableWhatIfTemplatesStore()


### PR DESCRIPTION
### Description
This PR adds a line with the description of a task (if specified) to the task overview and non-current data panels. This allows users to distinguish tasks when many have been submitted for the same workflow.

### Screenshots (if applicable)
Short description:
<img width="555" height="121" alt="image" src="https://github.com/user-attachments/assets/f0356058-6f60-4d71-a4ea-3e89a4a9ecb6" />

Long description (truncated)
<img width="549" height="117" alt="image" src="https://github.com/user-attachments/assets/8dfb06df-9024-4c8a-a1bb-5d981d0c84b1" />

Long description, tooltip
<img width="550" height="152" alt="image" src="https://github.com/user-attachments/assets/6ad87fb7-bc33-4a1e-aab2-964ecbd67e31" />

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes
