### PR TITLE
Hide empty what-if control

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -59,6 +59,7 @@
   "workflow": {
     "expectedRuntime": "Erwartete Laufzeit",
     "noTasksAvailable": "Keine Aufgaben verfügbar",
+    "noTasksConfiguredForNode": "Keine Aufgaben konfiguriert.",
     "numberOfAvailableServers": "Anzahl verfügbarer Server",
     "showingCurrentUsersTaskOnly": "Zeigt nur Aufgaben des aktuellen Benutzers",
     "showingAllUsersTasks": "Zeigt Aufgaben aller Benutzer"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -59,6 +59,7 @@
   "workflow": {
     "expectedRuntime": "Expected runtime",
     "noTasksAvailable": "No tasks available",
+    "noTasksConfiguredForNode": "No tasks have been configured.",
     "numberOfAvailableServers": "Number of available servers",
     "showingCurrentUsersTaskOnly": "Showing current users' tasks only",
     "showingAllUsersTasks": "Showing all user's tasks"

--- a/src/views/WhatIfDisplayView.vue
+++ b/src/views/WhatIfDisplayView.vue
@@ -1,5 +1,12 @@
 <template>
-  <WhatIfDisplay :key="props.topologyNode?.id" :workflows="whatIfWorkflows" />
+  <div v-if="whatIfWorkflows.length === 0" class="ma-4">
+    {{ t('workflow.noTasksConfiguredForNode') }}
+  </div>
+  <WhatIfDisplay
+    v-else
+    :key="props.topologyNode?.id"
+    :workflows="whatIfWorkflows"
+  />
 </template>
 <script setup lang="ts">
 import { computed } from 'vue'
@@ -8,6 +15,9 @@ import { getWorkflowIdsForNode } from '@/lib/workflows/tasks'
 import { useAvailableWorkflowsStore } from '@/stores/availableWorkflows'
 import { WorkflowItem } from '@/lib/workflows'
 import WhatIfDisplay from '@/components/tasksdisplay/WhatIfDisplay.vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 interface Props {
   topologyNode?: TopologyNode


### PR DESCRIPTION
### Description
If a node has no tasks to run, only show a message saying that, and not an empty what-if scenario control.

### Screenshots
<img width="562" height="139" alt="image" src="https://github.com/user-attachments/assets/74a4525b-71e6-4686-ba98-b7ec5307760c" />

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes
