### PR TITLE
Show notification upon task run completion or failure

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -20,6 +20,7 @@ import { getResourcesStaticUrl } from '@/lib/fews-config'
 import { useUserSettingsStore } from './stores/userSettings'
 import { useTheme } from 'vuetify'
 import { useDark, usePreferredDark, useToggle } from '@vueuse/core'
+import { useTaskRunMonitorStore } from './stores/taskRunMonitor'
 
 import '@/assets/fews-flags.css'
 
@@ -30,6 +31,9 @@ const { change } = useTheme()
 const prefersDark = usePreferredDark()
 const isDark = useDark()
 const toggleDark = useToggle(isDark)
+
+// Initialise task run monitoring.
+useTaskRunMonitorStore()
 
 onMounted(() => {
   updateTheme()

--- a/src/components/analysis/AnalysisAsyncChart.vue
+++ b/src/components/analysis/AnalysisAsyncChart.vue
@@ -98,7 +98,7 @@ watch(
   category,
   async () => {
     if (category.value === 'completed') {
-      const taskRunId = task.value?.taskId
+      const taskRunId = task.value?.taskRunId
       if (!taskRunId) {
         throw new Error('Task run ID is not available')
       }

--- a/src/components/compare/ForecastSummary.vue
+++ b/src/components/compare/ForecastSummary.vue
@@ -111,7 +111,7 @@ const {
 
 const taskRunColor = computed(() => {
   // Get color from store, fallback to contrast color if not found
-  return taskRunColorsStore.getColor(task.taskId) || '--contrast-color'
+  return taskRunColorsStore.getColor(task.taskRunId) || '--contrast-color'
 })
 
 const expanded = defineModel<boolean>('expanded', {
@@ -142,7 +142,7 @@ const tableData = computed(() => [
   {
     columns: [
       { header: 'User', value: task.userId ?? 'No user' },
-      { header: 'Task run ID', value: task.taskId },
+      { header: 'Task run ID', value: task.taskRunId },
     ],
   },
   {
@@ -234,8 +234,8 @@ function toggleTaskSelection() {
   taskRunsStore.toggleTaskRun(task)
 
   // Assign a color to the task if it doesn't have one already
-  if (!taskRunColorsStore.getColor(task.taskId)) {
-    taskRunColorsStore.assignColor(task.taskId)
+  if (!taskRunColorsStore.getColor(task.taskRunId)) {
+    taskRunColorsStore.assignColor(task.taskRunId)
   }
 }
 </script>

--- a/src/components/compare/ForecastSummary.vue
+++ b/src/components/compare/ForecastSummary.vue
@@ -47,7 +47,14 @@
                 {{ timeZeroString }}
               </v-list-item-subtitle>
             </div>
-            <v-icon v-if="isCurrentUsersTask" icon="mdi-account" />
+            <v-tooltip
+              v-if="isCurrentUsersTask"
+              :text="t('workflow.startedByMe')"
+            >
+              <template #activator="{ props }">
+                <v-icon v-bind="props" icon="mdi-account" size="small" />
+              </template>
+            </v-tooltip>
             <v-btn
               density="compact"
               :icon="expanded ? 'mdi-chevron-up' : 'mdi-chevron-down'"
@@ -77,6 +84,7 @@
 import { TaskRun, TaskStatus } from '@/lib/taskruns'
 import { useAvailableWorkflowsStore } from '@/stores/availableWorkflows'
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import ForecastRange from './ForecastRange.vue'
 import DataTable from '@/components/general/DataTable.vue'
 import {
@@ -89,6 +97,8 @@ import { useTaskRunsStore } from '@/stores/taskRuns'
 import { useTaskRunColorsStore } from '@/stores/taskRunColors'
 import WhatIfScenarioSummary from '@/components/tasks/WhatIfScenarioSummary.vue'
 import SingleLineWithOverflowTooltip from '../general/SingleLineWithOverflowTooltip.vue'
+
+const { t } = useI18n()
 
 const availableWorkflowsStore = useAvailableWorkflowsStore()
 const availableWhatIfTemplatesStore = useAvailableWhatIfTemplatesStore()

--- a/src/components/compare/NonCurrentDataPanel.vue
+++ b/src/components/compare/NonCurrentDataPanel.vue
@@ -32,8 +32,8 @@
               :startTime="outputStartTime"
               :endTime="outputEndTime"
               :is-current-users-task="user.isCurrentUser(task.userId)"
-              :key="task.taskId"
-              v-model:expanded="expandedItems[task.taskId]"
+              :key="task.taskRunId"
+              v-model:expanded="expandedItems[task.taskRunId]"
             />
           </div>
         </template>

--- a/src/components/logdisplay/LogItem.vue
+++ b/src/components/logdisplay/LogItem.vue
@@ -74,7 +74,9 @@ const expanded = defineModel<boolean>('expanded', {
 })
 
 const taskRun = computed(() =>
-  props.taskRuns.find((taskRun) => taskRun.taskId === props.logs[0].taskRunId),
+  props.taskRuns.find(
+    (taskRun) => taskRun.taskRunId === props.logs[0].taskRunId,
+  ),
 )
 
 const log = computed(() => props.logs[0])
@@ -83,7 +85,7 @@ const emit = defineEmits<LogActionEmit>()
 
 function getTitleForLog(log: LogMessage, userName: string) {
   const workflowId = props.taskRuns.find(
-    (taskRun) => taskRun.taskId === log.taskRunId,
+    (taskRun) => taskRun.taskRunId === log.taskRunId,
   )?.workflowId
 
   const workflow = workflowId ? availableWorkflows.byId(workflowId) : undefined

--- a/src/components/logdisplay/TaskRunItem.vue
+++ b/src/components/logdisplay/TaskRunItem.vue
@@ -107,7 +107,7 @@ const tableData = computed(() => {
         },
         {
           header: 'Task run ID',
-          value: props.taskRun?.taskId,
+          value: props.taskRun?.taskRunId,
         },
         {
           header: 'FSS ID',

--- a/src/components/tasks/TaskRunSummary.vue
+++ b/src/components/tasks/TaskRunSummary.vue
@@ -12,17 +12,29 @@
           <v-list-item-subtitle class="mb-1 d-flex justify-space-between">
             <span>{{ timeZeroString }}</span>
             <div class="d-flex gc-1">
-              <v-icon
+              <v-tooltip
                 v-if="isCurrentUsersTask"
-                icon="mdi-account"
-                size="small"
-              />
-              <v-icon
+                :text="t('workflow.startedByMe')"
+              >
+                <template #activator="{ props }">
+                  <v-icon v-bind="props" icon="mdi-account" size="small" />
+                </template>
+              </v-tooltip>
+              <v-tooltip
                 v-if="canBeFollowed"
-                :icon="isFollowed ? 'mdi-bell' : 'mdi-bell-off'"
-                size="small"
-                @click.stop="toggleFollow"
-              />
+                :text="
+                  t(isFollowed ? 'workflow.following' : 'workflow.notFollowing')
+                "
+              >
+                <template #activator="{ props }">
+                  <v-icon
+                    v-bind="props"
+                    :icon="isFollowed ? 'mdi-bell' : 'mdi-bell-off'"
+                    size="small"
+                    @click.stop="toggleFollow"
+                  />
+                </template>
+              </v-tooltip>
             </div>
           </v-list-item-subtitle>
           <div class="d-flex align-center ga-1 w-100">
@@ -94,6 +106,9 @@ import {
 import { useAvailableWhatIfTemplatesStore } from '@/stores/availableWhatIfTemplates'
 import WhatIfScenarioSummary from './WhatIfScenarioSummary.vue'
 import SingleLineWithOverflowTooltip from '../general/SingleLineWithOverflowTooltip.vue'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
 
 const availableWorkflowsStore = useAvailableWorkflowsStore()
 const availableWhatIfTemplatesStore = useAvailableWhatIfTemplatesStore()

--- a/src/components/tasks/TaskRunSummary.vue
+++ b/src/components/tasks/TaskRunSummary.vue
@@ -11,7 +11,19 @@
         <div class="w-100">
           <v-list-item-subtitle class="mb-1 d-flex justify-space-between">
             <span>{{ timeZeroString }}</span>
-            <v-icon v-if="isCurrentUsersTask" icon="mdi-account" size="small" />
+            <div class="d-flex gc-1">
+              <v-icon
+                v-if="isCurrentUsersTask"
+                icon="mdi-account"
+                size="small"
+              />
+              <v-icon
+                v-if="canBeFollowed"
+                :icon="isFollowed ? 'mdi-bell' : 'mdi-bell-off'"
+                size="small"
+                @click.stop="toggleFollow"
+              />
+            </div>
           </v-list-item-subtitle>
           <div class="d-flex align-center ga-1 w-100">
             <v-tooltip>
@@ -65,8 +77,10 @@ import {
   convertTaskStatusToString,
   getColorForTaskStatus,
   getIconForTaskStatus,
+  getTaskStatusCategory,
   TaskRun,
   TaskStatus,
+  TaskStatusCategory,
 } from '@/lib/taskruns'
 import { useAvailableWorkflowsStore } from '@/stores/availableWorkflows'
 import { computed } from 'vue'
@@ -87,8 +101,18 @@ const availableWhatIfTemplatesStore = useAvailableWhatIfTemplatesStore()
 interface Props {
   task: TaskRun
   isCurrentUsersTask?: boolean
+  isFollowed?: boolean
 }
-const props = withDefaults(defineProps<Props>(), { isCurrentUsersTask: false })
+const props = withDefaults(defineProps<Props>(), {
+  isCurrentUsersTask: false,
+  isFollowed: false,
+})
+
+interface Emits {
+  follow: [taskRunId: string]
+  unfollow: [taskRunId: string]
+}
+const emit = defineEmits<Emits>()
 
 const expanded = defineModel<boolean>('expanded', {
   required: false,
@@ -217,6 +241,22 @@ function onExpansionPanelToggle() {
   // Only expand when no text is selected
   if (window.getSelection()?.toString() === '') {
     expanded.value = !expanded.value
+  }
+}
+
+const canBeFollowed = computed<boolean>(() => {
+  const category = getTaskStatusCategory(props.task.status)
+  return (
+    category !== TaskStatusCategory.Completed &&
+    category !== TaskStatusCategory.Failed
+  )
+})
+
+function toggleFollow(): void {
+  if (props.isFollowed) {
+    emit('unfollow', props.task.taskRunId)
+  } else {
+    emit('follow', props.task.taskRunId)
   }
 }
 </script>

--- a/src/components/tasks/TaskRunSummary.vue
+++ b/src/components/tasks/TaskRunSummary.vue
@@ -107,7 +107,7 @@ const tableData = computed(() => [
   {
     columns: [
       { header: 'User', value: props.task.userId ?? 'No user' },
-      { header: 'Task run ID', value: props.task.taskId },
+      { header: 'Task run ID', value: props.task.taskRunId },
     ],
   },
   {

--- a/src/components/tasks/TaskRunsPanel.vue
+++ b/src/components/tasks/TaskRunsPanel.vue
@@ -32,9 +32,9 @@
           <div v-else class="my-1 mx-2">
             <TaskRunSummary
               :task="task"
-              :key="task.taskId"
+              :key="task.taskRunId"
               :is-current-users-task="user.isCurrentUser(task.userId)"
-              v-model:expanded="expandedItems[task.taskId]"
+              v-model:expanded="expandedItems[task.taskRunId]"
             />
           </div>
         </template>

--- a/src/components/tasks/TaskRunsPanel.vue
+++ b/src/components/tasks/TaskRunsPanel.vue
@@ -34,7 +34,10 @@
               :task="task"
               :key="task.taskRunId"
               :is-current-users-task="user.isCurrentUser(task.userId)"
+              :is-followed="taskRunMonitor.isFollowed(task.taskRunId)"
               v-model:expanded="expandedItems[task.taskRunId]"
+              @follow="taskRunMonitor.follow"
+              @unfollow="taskRunMonitor.unfollow"
             />
           </div>
         </template>
@@ -71,6 +74,7 @@ import { useCurrentUser } from '@/services/useCurrentUser'
 import { useTaskRuns } from '@/services/useTasksRuns'
 
 import { useAvailableWorkflowsStore } from '@/stores/availableWorkflows'
+import { useTaskRunMonitorStore } from '@/stores/taskRunMonitor'
 
 import TaskStatusFilterControl from './TaskStatusFilterControl.vue'
 import TaskRunSummary from './TaskRunSummary.vue'
@@ -86,6 +90,8 @@ interface Props {
 const props = defineProps<Props>()
 
 const availableWorkflowsStore = useAvailableWorkflowsStore()
+const taskRunMonitor = useTaskRunMonitorStore()
+
 const user = useCurrentUser()
 const { t } = useI18n()
 

--- a/src/components/tasksdisplay/WhatIfDisplay.vue
+++ b/src/components/tasksdisplay/WhatIfDisplay.vue
@@ -158,6 +158,7 @@ import { useAlertsStore } from '@/stores/alerts'
 import { useWorkflowsStore, WorkflowType } from '@/stores/workflows'
 import { useWorkflowBoundingBox } from '@/services/useWorkflowBoundingBox'
 import { useWhatIfTemplateSchemas } from '@/services/useWhatIfTemplateSchemas'
+import { useTaskRunMonitorStore } from '@/stores/taskRunMonitor'
 
 interface Props {
   workflows: WorkflowItem[]
@@ -178,6 +179,7 @@ const emit = defineEmits<Emits>()
 const availableWhatIfTemplatesStore = useAvailableWhatIfTemplatesStore()
 const alertStore = useAlertsStore()
 const workflowsStore = useWorkflowsStore()
+const taskRunMonitor = useTaskRunMonitorStore()
 
 const selectedWhatIfTemplate = ref<WhatIfTemplate>()
 const selectedWhatIfScenario = ref<WhatIfScenarioDescriptor>()
@@ -366,6 +368,18 @@ async function submit() {
     if (workflowType === WorkflowType.ProcessData) {
       showSuccessMessage('File download completed')
     } else {
+      // The result is a taskId (note: not a taskRunId!); monitor this task's
+      // progress to notify the user when it completes or fails.
+      if (result) {
+        taskRunMonitor
+          .followByTaskId(result)
+          .catch((error) =>
+            console.error(
+              `Failed to monitor task with taskId ${result}: ${error}`,
+            ),
+          )
+      }
+
       showStartMessage(
         'Workflow submitted successfully. You can monitor the task progress using the Task Overview.',
       )

--- a/src/components/wms/TaskRunControl.vue
+++ b/src/components/wms/TaskRunControl.vue
@@ -27,18 +27,18 @@
         <v-list-subheader>Current</v-list-subheader>
         <TaskRunControlItem
           v-for="item in currentTaskRuns"
-          :key="item.taskId"
-          @click="taskRunId = item?.taskId"
-          :active="item?.taskId === taskRunId"
+          :key="item.taskRunId"
+          @click="taskRunId = item?.taskRunId"
+          :active="item?.taskRunId === taskRunId"
           :item="item"
         />
         <v-list-subheader>Non Current</v-list-subheader>
         <TaskRunControlItem
           v-for="item in taskRuns"
-          :key="item.taskId"
+          :key="item.taskRunId"
           :item="item"
-          @click="taskRunId = item?.taskId"
-          :active="item?.taskId === taskRunId"
+          @click="taskRunId = item?.taskRunId"
+          :active="item?.taskRunId === taskRunId"
         />
       </v-list>
     </v-menu>
@@ -67,7 +67,7 @@ const numberOfTaskRuns = computed(() => taskRuns.value.length)
 
 watch(numberOfTaskRuns, (newNumberOfTaskRuns, oldNumberOfTaskRuns) => {
   if (newNumberOfTaskRuns > 0 && oldNumberOfTaskRuns == 0) {
-    taskRunId.value = taskRuns.value[0].taskId
+    taskRunId.value = taskRuns.value[0].taskRunId
   }
 })
 
@@ -76,9 +76,9 @@ watch(
   (newRuns) => {
     if (
       taskRunId.value &&
-      !newRuns.find((taskRun) => taskRun.taskId === taskRunId.value)
+      !newRuns.find((taskRun) => taskRun.taskRunId === taskRunId.value)
     ) {
-      taskRunId.value = newRuns[0]?.taskId
+      taskRunId.value = newRuns[0]?.taskRunId
     }
   },
   { deep: true },
@@ -90,11 +90,11 @@ function toggleTaskRunId() {
   if (taskRunId.value === undefined) {
     if (
       lastSelectedTaskRunId &&
-      taskRuns.value.find((t) => t.taskId === lastSelectedTaskRunId)
+      taskRuns.value.find((t) => t.taskRunId === lastSelectedTaskRunId)
     ) {
       taskRunId.value = lastSelectedTaskRunId
     } else {
-      taskRunId.value = taskRuns.value[0]?.taskId
+      taskRunId.value = taskRuns.value[0]?.taskRunId
     }
   } else {
     lastSelectedTaskRunId = taskRunId.value

--- a/src/components/wms/TaskRunControlItem.vue
+++ b/src/components/wms/TaskRunControlItem.vue
@@ -45,7 +45,7 @@ const timeZeroString = computed(() => {
 
 const color = computed(() => {
   if (!item) return
-  return taskRunColorsStore.getColor(item.taskId)
+  return taskRunColorsStore.getColor(item.taskRunId)
 })
 </script>
 

--- a/src/lib/log/utils.ts
+++ b/src/lib/log/utils.ts
@@ -14,7 +14,7 @@ export function getTitleForLog(
   workflows: WorkflowItem[],
 ) {
   const workflowId = taskRuns.find(
-    (taskRun) => taskRun.taskId === log.taskRunId,
+    (taskRun) => taskRun.taskRunId === log.taskRunId,
   )?.workflowId
 
   const workflow = workflowId
@@ -49,7 +49,7 @@ export function filterLog(
   const text = log.text.toLowerCase()
   const searchText = search?.toLowerCase()
   const taskRunId = log.taskRunId?.toLowerCase()
-  const taskRun = taskRuns.find((tr) => tr.taskId === log.taskRunId)
+  const taskRun = taskRuns.find((tr) => tr.taskRunId === log.taskRunId)
   const taskRunUser = taskRun?.userId?.toLowerCase()
   const title = getTitleForLog(log, '', taskRuns, workflows)?.toLowerCase()
   return (

--- a/src/lib/taskruns/convert.ts
+++ b/src/lib/taskruns/convert.ts
@@ -25,7 +25,7 @@ export function convertFewsPiTaskRunToTaskRun(
   // Set null for undefined and empty descriptions.
   const description = taskRun.description ? taskRun.description : null
   return {
-    taskId: taskRun.id,
+    taskRunId: taskRun.id,
     workflowId: taskRun.workflowId,
     userId: taskRun.user,
     fssId: taskRun.fssId ?? null,

--- a/src/lib/taskruns/types.ts
+++ b/src/lib/taskruns/types.ts
@@ -22,7 +22,7 @@ export enum TaskStatusCategory {
 }
 
 export interface TaskRun {
-  taskId: string
+  taskRunId: string
   workflowId: string
   fssId: string | null
   status: TaskStatus
@@ -42,5 +42,5 @@ export function isTaskStatus(value: string): value is TaskStatus {
 }
 
 export function isTaskRun(value: unknown): value is TaskRun {
-  return typeof value === 'object' && value !== null && 'taskId' in value
+  return typeof value === 'object' && value !== null && 'taskRunId' in value
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -13,7 +13,9 @@
     "selectAll": "Alle auswählen",
     "start": "Start",
     "unsavedChanges": "Ungespeicherte Änderungen",
-    "unsavedChangesExitWarning": "Sie haben ungespeicherte Änderungen. Ohne Speichern verlassen?"
+    "unsavedChangesExitWarning": "Sie haben ungespeicherte Änderungen. Ohne Speichern verlassen?",
+    "finished": "abgeschlossen",
+    "failed": "fehlgeschlagen"
   },
   "layout": {
     "about": "Über",
@@ -66,7 +68,9 @@
     "noTasksConfiguredForNode": "Keine Aufgaben konfiguriert.",
     "numberOfAvailableServers": "Anzahl verfügbarer Server",
     "showingCurrentUsersTaskOnly": "Zeigt nur Aufgaben des aktuellen Benutzers",
-    "showingAllUsersTasks": "Zeigt Aufgaben aller Benutzer"
+    "showingAllUsersTasks": "Zeigt Aufgaben aller Benutzer",
+    "unknownWorkflow": "Unbekannter Workflow",
+    "taskRunFinishedMessage": "Die Aufgabenausführung für Workflow {name}, gestartet am {datetime}, ist {statusVerb}."
   },
   "taskDuration": {
     "noExpectedRuntime": "Keine erwartete Laufzeit",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -69,8 +69,11 @@
     "numberOfAvailableServers": "Anzahl verfügbarer Server",
     "showingCurrentUsersTaskOnly": "Zeigt nur Aufgaben des aktuellen Benutzers",
     "showingAllUsersTasks": "Zeigt Aufgaben aller Benutzer",
+    "startedByMe": "Von mir gestartet",
     "unknownWorkflow": "Unbekannter Workflow",
-    "taskRunFinishedMessage": "Die Aufgabenausführung für Workflow {name}, gestartet am {datetime}, ist {statusVerb}."
+    "taskRunFinishedMessage": "Die Aufgabenausführung für Workflow {name}, gestartet am {datetime}, ist {statusVerb}.",
+    "following": "Benachrichtigung bei Aufgabenabschluss oder -fehler wird angezeigt",
+    "notFollowing": "Benachrichtigung bei Aufgabenabschluss oder -fehler wird nicht angezeigt"
   },
   "taskDuration": {
     "noExpectedRuntime": "Keine erwartete Laufzeit",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -69,8 +69,11 @@
     "numberOfAvailableServers": "Number of available servers",
     "showingCurrentUsersTaskOnly": "Showing current users' tasks only",
     "showingAllUsersTasks": "Showing all user's tasks",
+    "startedByMe": "Started by me",
     "unknownWorkflow": "Unknown workflow",
-    "taskRunFinishedMessage": "Task run for workflow {name} started at {datetime} has {statusVerb}."
+    "taskRunFinishedMessage": "Task run for workflow {name} started at {datetime} has {statusVerb}.",
+    "following": "Showing notification upon task completion or failure",
+    "notFollowing": "Not showing notification upon task completion or failure"
   },
   "taskDuration": {
     "noExpectedRuntime": "No expected runtime",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -13,7 +13,9 @@
     "selectAll": "Select all",
     "start": "Start",
     "unsavedChanges": "Unsaved changes",
-    "unsavedChangesExitWarning": "You have unsaved changes. Leave without saving?"
+    "unsavedChangesExitWarning": "You have unsaved changes. Leave without saving?",
+    "finished": "finished",
+    "failed": "failed"
   },
   "layout": {
     "about": "About",
@@ -66,7 +68,9 @@
     "noTasksConfiguredForNode": "No tasks have been configured.",
     "numberOfAvailableServers": "Number of available servers",
     "showingCurrentUsersTaskOnly": "Showing current users' tasks only",
-    "showingAllUsersTasks": "Showing all user's tasks"
+    "showingAllUsersTasks": "Showing all user's tasks",
+    "unknownWorkflow": "Unknown workflow",
+    "taskRunFinishedMessage": "Task run for workflow {name} started at {datetime} has {statusVerb}."
   },
   "taskDuration": {
     "noExpectedRuntime": "No expected runtime",

--- a/src/stores/availableWorkflows.ts
+++ b/src/stores/availableWorkflows.ts
@@ -5,12 +5,15 @@ import {
   fetchWorkflowsWithExpectedRunTime,
   WorkflowItem,
 } from '@/lib/workflows'
+import { until } from '@vueuse/core'
 
 export const useAvailableWorkflowsStore = defineStore(
   'availableWorkflows',
   () => {
     const workflows = ref<WorkflowItem[]>([])
     const preferredWorkflowIds = ref<string[]>([])
+
+    const hasFetched = ref(false)
 
     const workflowIds = computed(() => {
       return workflows.value.map((workflow) => workflow.id)
@@ -47,7 +50,15 @@ export const useAvailableWorkflowsStore = defineStore(
     }
 
     async function fetch() {
-      workflows.value = await fetchWorkflowsWithExpectedRunTime()
+      try {
+        workflows.value = await fetchWorkflowsWithExpectedRunTime()
+      } finally {
+        hasFetched.value = true
+      }
+    }
+
+    async function waitForFetch(): Promise<void> {
+      await until(hasFetched).toBeTruthy()
     }
 
     function setPreferredWorkflowIds(workflowIds: string[]): void {
@@ -76,6 +87,7 @@ export const useAvailableWorkflowsStore = defineStore(
       byWhatIfTemplateId,
       hasWhatIfTemplate,
       fetch,
+      waitForFetch,
       setPreferredWorkflowIds,
       clearPreferredWorkflowIds,
     }

--- a/src/stores/taskRunMonitor.ts
+++ b/src/stores/taskRunMonitor.ts
@@ -151,11 +151,16 @@ export const useTaskRunMonitorStore = defineStore(
       )
     }
 
+    function isFollowed(taskRunId: string): boolean {
+      return monitoredTaskRunIds.value.includes(taskRunId)
+    }
+
     return {
       monitoredTaskRunIds,
       followByTaskId,
       follow,
       unfollow,
+      isFollowed,
     }
   },
   {

--- a/src/stores/taskRunMonitor.ts
+++ b/src/stores/taskRunMonitor.ts
@@ -1,0 +1,164 @@
+import {
+  DocumentFormat,
+  PiWebserviceProvider,
+} from '@deltares/fews-pi-requests'
+import { defineStore } from 'pinia'
+import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+import { toHumanReadableDateTime } from '@/lib/date'
+import { createTransformRequestFn } from '@/lib/requests/transformRequest'
+import {
+  getTaskStatusCategory,
+  type TaskRun,
+  TaskStatusCategory,
+} from '@/lib/taskruns'
+import { uid } from '@/lib/utils/uid'
+
+import { configManager } from '@/services/application-config'
+import { useTaskRuns } from '@/services/useTaskRuns'
+
+import { type Alert, useAlertsStore } from './alerts'
+import { useAvailableWorkflowsStore } from './availableWorkflows'
+
+export const useTaskRunMonitorStore = defineStore(
+  'taskRunMonitor',
+  () => {
+    const POLL_INTERVAL_SECONDS = 10
+    const TASK_RUN_ID_FROM_TASK_ID_DELAY_SECONDS = 1
+
+    const { t } = useI18n()
+
+    const alertsStore = useAlertsStore()
+    const availableWorkflowsStore = useAvailableWorkflowsStore()
+
+    const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
+    const provider = new PiWebserviceProvider(baseUrl, {
+      transformRequestFn: createTransformRequestFn(),
+    })
+
+    const monitoredTaskRunIds = ref<string[]>([])
+
+    // We use the "taskruns" endpoint rather than the seemingly more obvious
+    // "taskrunstatus" endpoint, as the former
+    //    1. Allows us to specify multiple taskRunIds for a single request.
+    //    2. Uses taskRunIds instead of taskIds, which are easier to work with
+    //       in the existing code base.
+    const { taskRuns } = useTaskRuns(
+      baseUrl,
+      () => ({ taskRunIds: monitoredTaskRunIds.value }),
+      POLL_INTERVAL_SECONDS * 1000,
+    )
+    availableWorkflowsStore
+      .waitForFetch()
+      .then(() => {
+        // We use the available workflows to obtain the name of the workflow to
+        // show in the alert, these available workflows are fetched upon opening
+        // the WebOC. This task run monitor is also started immediately, and we
+        // may immediately fetch task run status updates for monitored
+        // taskRunIds persisted in session storage. This status update may (and
+        // often will) finish quicker than fetching the available workflows, in
+        // which case we cannot generate a valid name in the notification.
+        // Hence, we only setup the watcher for fetched task runs after the
+        // available workflows have been fetched.
+        // Note: this watcher cannot be cleaned up automatically, but we'll
+        //       never need to clean it up as this store lives as long as the app.
+        watch(
+          taskRuns,
+          (monitoredTaskRuns) =>
+            monitoredTaskRuns.forEach((taskRun) => {
+              try {
+                handleTaskRun(taskRun)
+              } catch (error) {
+                console.error(
+                  `Failed to monitor task run with taskRunId "${taskRun.taskRunId}": ${error}`,
+                )
+              }
+            }),
+          // Run immediately such that we can check task runs for taskRunIds
+          // persisted in session storage.
+          { immediate: true },
+        )
+      })
+      .catch((error) =>
+        console.error(`Failed to initialise task run monitor: ${error}`),
+      )
+
+    function handleTaskRun(taskRun: TaskRun): void {
+      const statusCategory = getTaskStatusCategory(taskRun.status)
+      const isCompleted = statusCategory === TaskStatusCategory.Completed
+      const isFailed = statusCategory === TaskStatusCategory.Failed
+
+      // Do nothing here, just keep monitoring tasks that haven't completed or
+      // failed.
+      if (!isCompleted && !isFailed) return
+
+      // Add alert to show a notification to the user, then unfollow this task
+      // run, as it will no longer change status.
+      const alert = createAlert(taskRun, isCompleted)
+      alertsStore.addAlert(alert)
+      unfollow(taskRun.taskRunId)
+    }
+
+    function createAlert(taskRun: TaskRun, isCompleted: boolean): Alert {
+      const type = isCompleted ? 'success' : 'error'
+
+      const workflow = availableWorkflowsStore.byId(taskRun.workflowId)
+      const name = workflow?.name ?? t('workflow.unknownWorkflow')
+      const datetime = toHumanReadableDateTime(taskRun.dispatchTimestamp)
+      const statusVerb = isCompleted ? t('common.finished') : t('common.failed')
+      const message = t('workflow.taskRunFinishedMessage', {
+        name,
+        datetime,
+        statusVerb,
+      })
+
+      return { id: uid(), type, message }
+    }
+
+    async function followByTaskId(taskId: string): Promise<void> {
+      // We get a taskId, which is (obviously) different from a taskRunId. For
+      // scheduled tasks, multiple taskRunIds can be created from a single
+      // taskId. However, single-shot tasks (such as the what-if scenario runs
+      // we are expecting here) will always have a unique taskId, which has a
+      // unique associated taskRunId.
+      // When a task is submitted, a taskId is created instantaneously, but a
+      // taskRunId is only created when a task is assigned to a machine that
+      // will run it. So we wait a bit for the creation of the taskRunId in FEWS
+      // and then use the  taskrunstatus endpoint to get a taskRunId.
+      await new Promise((resolve) =>
+        setTimeout(resolve, TASK_RUN_ID_FROM_TASK_ID_DELAY_SECONDS * 1000),
+      )
+      const response = await provider.getTaskRunStatus({
+        documentFormat: DocumentFormat.PI_JSON,
+        taskId,
+      })
+      const taskRunId = response.taskRunId
+      if (!taskRunId) {
+        throw new Error(`Failed to get taskRunId for taskId "${taskId}"`)
+      }
+      follow(taskRunId)
+    }
+
+    function follow(taskRunId: string): void {
+      if (monitoredTaskRunIds.value.includes(taskRunId)) return
+      monitoredTaskRunIds.value = [...monitoredTaskRunIds.value, taskRunId]
+    }
+
+    function unfollow(taskRunId: string): void {
+      monitoredTaskRunIds.value = monitoredTaskRunIds.value.filter(
+        (id) => id !== taskRunId,
+      )
+    }
+
+    return {
+      monitoredTaskRunIds,
+      followByTaskId,
+      follow,
+      unfollow,
+    }
+  },
+  {
+    persist: { storage: sessionStorage },
+  },
+)

--- a/src/stores/taskRuns.ts
+++ b/src/stores/taskRuns.ts
@@ -6,17 +6,17 @@ export const useTaskRunsStore = defineStore('taskRuns', () => {
   const currentTaskRuns = ref<TaskRun[]>([])
   const selectedTaskRuns = ref<TaskRun[]>([])
 
-  function getTaskRunById(taskId: string | undefined) {
-    if (!taskId) return
+  function getTaskRunById(taskRunId: string | undefined) {
+    if (!taskRunId) return
     return (
-      currentTaskRuns.value.find((tr) => tr.taskId === taskId) ??
-      selectedTaskRuns.value.find((tr) => tr.taskId === taskId)
+      currentTaskRuns.value.find((tr) => tr.taskRunId === taskRunId) ??
+      selectedTaskRuns.value.find((tr) => tr.taskRunId === taskRunId)
     )
   }
 
   function toggleTaskRun(taskRun: TaskRun) {
     const index = selectedTaskRuns.value.findIndex(
-      (tr) => tr.taskId === taskRun.taskId,
+      (tr) => tr.taskRunId === taskRun.taskRunId,
     )
     if (index === -1) {
       selectedTaskRuns.value.push(taskRun)
@@ -30,7 +30,9 @@ export const useTaskRunsStore = defineStore('taskRuns', () => {
   }
 
   function taskRunIsSelected(taskRun: TaskRun) {
-    return selectedTaskRuns.value.some((tr) => tr.taskId === taskRun.taskId)
+    return selectedTaskRuns.value.some(
+      (tr) => tr.taskRunId === taskRun.taskRunId,
+    )
   }
 
   function clearSelectedTaskRuns() {
@@ -48,7 +50,7 @@ export const useTaskRunsStore = defineStore('taskRuns', () => {
   )
 
   const selectedTaskRunIds = computed(() =>
-    sortedSelectedTaskRuns.value.map((taskRun) => taskRun.taskId),
+    sortedSelectedTaskRuns.value.map((taskRun) => taskRun.taskRunId),
   )
 
   return {


### PR DESCRIPTION
### Description
This PR introduces a task run monitor store, that allows polling individual task runs' statuses and notify the user when one completes or fails.

Tasks created from the "Run tasks" panel will automatically be followed. Other running or pending tasks can be followed from the "Task overview".

Also renames the confusing `taskId` in the `TaskRun` interface; it is actually a `taskRunId` and not a `taskId`, which is (obviously) a separate concept.

Auch auf Deutsch verfügbar!

### Screenshots
Notification when a task has finished:
<img width="607" height="90" alt="image" src="https://github.com/user-attachments/assets/8a26003a-7942-4dd3-ba31-2089e7c9d588" />

Icon to follow and unfollow a task:
<img width="543" height="92" alt="image" src="https://github.com/user-attachments/assets/93c27319-74ac-409f-b1c7-226d1ea02aa8" />

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes.