### PR TITLE
feat: Always show all secondary controls in the menu

### DIFF
--- a/src/views/TopologyDisplayView.vue
+++ b/src/views/TopologyDisplayView.vue
@@ -61,9 +61,7 @@
         </template>
         <v-list>
           <v-list-item
-            v-for="control in secondaryControls.filter(
-              (c) => !c.disabled && c.type !== secondaryControl,
-            )"
+            v-for="control in secondaryControls.filter((c) => !c.disabled)"
             :prepend-icon="control.icon"
             :title="control.title"
             @click="


### PR DESCRIPTION
### Description

Always show all secondary controls in the menu.

### Screenshots
<img width="219" height="304" alt="Screenshot 2026-04-09 at 20 32 11" src="https://github.com/user-attachments/assets/8eade3a2-2aaf-45bb-bfee-782003d23d18" />
