### PR TITLE
Improve what-if property tables in Task overview and Non-current data panels

### DIFF
--- a/src/components/compare/ForecastSummary.vue
+++ b/src/components/compare/ForecastSummary.vue
@@ -67,7 +67,10 @@
       <DataTable v-if="expanded" class="mt-4" :tableData="tableData" />
       <div v-if="expanded && task.whatIfScenario">
         <v-divider class="my-2" />
-        <WhatIfScenarioSummary :what-if-scenario="task.whatIfScenario" />
+        <WhatIfScenarioSummary
+          :what-if-scenario="task.whatIfScenario"
+          :num-columns="2"
+        />
       </div>
     </v-card-text>
     <ForecastRange

--- a/src/components/general/DataTable.vue
+++ b/src/components/general/DataTable.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="table-container">
-    <table v-for="table in filteredTableData" class="data-table">
+    <table v-for="table in filteredTableData" class="data-table w-100">
       <thead>
         <tr>
           <th
@@ -19,6 +19,7 @@
           <td
             v-for="column in table.filteredColumns"
             class="text-medium-emphasis"
+            :style="{ width: column.width }"
           >
             {{ column.value }}
           </td>
@@ -35,6 +36,7 @@ interface Column {
   header: string
   subHeader?: string
   value: string | undefined | null
+  width?: string
 }
 
 interface Table {

--- a/src/components/general/DataTable.vue
+++ b/src/components/general/DataTable.vue
@@ -5,10 +5,13 @@
         <tr>
           <th
             v-for="column in table.filteredColumns"
-            class="font-weight-medium"
+            class="font-weight-medium text-medium-emphasis"
           >
             {{ column.header }}
-            <span v-if="column.subHeader" class="text-medium-emphasis">
+            <span
+              v-if="column.subHeader"
+              class="text-medium-emphasis ml-2 subtitle"
+            >
               {{ column.subHeader }}
             </span>
           </th>
@@ -18,7 +21,6 @@
         <tr>
           <td
             v-for="column in table.filteredColumns"
-            class="text-medium-emphasis"
             :style="{ width: column.width }"
           >
             {{ column.value }}
@@ -78,5 +80,9 @@ const filteredTableData = computed(() =>
 
 .data-table td {
   padding-bottom: 5px;
+}
+
+.subtitle {
+  font-size: 0.9em;
 }
 </style>

--- a/src/components/tasks/TaskRunSummary.vue
+++ b/src/components/tasks/TaskRunSummary.vue
@@ -17,7 +17,7 @@
                 :text="t('workflow.startedByMe')"
               >
                 <template #activator="{ props }">
-                  <v-icon v-bind="props" icon="mdi-account" size="small" />
+                  <v-icon v-bind="props" icon="mdi-account" />
                 </template>
               </v-tooltip>
               <v-tooltip
@@ -30,7 +30,6 @@
                   <v-icon
                     v-bind="props"
                     :icon="isFollowed ? 'mdi-bell' : 'mdi-bell-off'"
-                    size="small"
                     @click.stop="toggleFollow"
                   />
                 </template>

--- a/src/components/tasks/TaskRunSummary.vue
+++ b/src/components/tasks/TaskRunSummary.vue
@@ -72,7 +72,10 @@
       <DataTable v-if="expanded" class="mt-4" :tableData="tableData" />
       <div v-if="expanded && task.whatIfScenario">
         <v-divider class="my-2" />
-        <WhatIfScenarioSummary :what-if-scenario="task.whatIfScenario" />
+        <WhatIfScenarioSummary
+          :what-if-scenario="task.whatIfScenario"
+          :num-columns="2"
+        />
       </div>
     </v-card-text>
     <TaskRunProgress

--- a/src/components/tasks/WhatIfScenarioSummary.vue
+++ b/src/components/tasks/WhatIfScenarioSummary.vue
@@ -20,13 +20,15 @@ import {
 import { useAvailableWhatIfTemplatesStore } from '@/stores/availableWhatIfTemplates'
 
 import DataTable from '@/components/general/DataTable.vue'
+import { chunk } from 'lodash-es'
 
 const whatIfTemplatesStore = useAvailableWhatIfTemplatesStore()
 
 interface Props {
   whatIfScenario: WhatIfScenarioDescriptor
+  numColumns?: number
 }
-const props = defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), { numColumns: 1 })
 
 const whatIfTemplate = computed<WhatIfTemplate | null>(
   () =>
@@ -41,22 +43,30 @@ const visibleProperties = computed<ScenarioProperty[]>(() => {
   )
 })
 
-const tableData = computed(() =>
-  visibleProperties.value.map(convertPropertyToColumn),
-)
+const tableData = computed(() => {
+  // Group properties in rows of numColumns, then convert those to a format
+  // accepted by DataTable.
+  const chunkedProperties = chunk(visibleProperties.value, props.numColumns)
+  const columnWidth = `${100 / props.numColumns}%`
+  return chunkedProperties.map((rowProperties) => ({
+    columns: rowProperties.map((property) =>
+      convertPropertyToColumn(property, columnWidth),
+    ),
+  }))
+})
 
-function convertPropertyToColumn(property: ScenarioProperty) {
+function convertPropertyToColumn(
+  property: ScenarioProperty,
+  columnWidth: string,
+) {
   const whatIfTemplateProperty = whatIfTemplate.value?.properties?.find(
     (templateProperty) => templateProperty.id === property.id,
   )
   const header = whatIfTemplateProperty?.name ?? property.id
   return {
-    columns: [
-      {
-        header,
-        value: formatWhatIfScenarioProperty(property, whatIfTemplateProperty),
-      },
-    ],
+    header,
+    value: formatWhatIfScenarioProperty(property, whatIfTemplateProperty),
+    width: columnWidth,
   }
 }
 </script>

--- a/src/components/tasks/WhatIfScenarioSummary.vue
+++ b/src/components/tasks/WhatIfScenarioSummary.vue
@@ -54,7 +54,7 @@ function convertPropertyToColumn(property: ScenarioProperty) {
     columns: [
       {
         header,
-        value: formatWhatIfScenarioProperty(property),
+        value: formatWhatIfScenarioProperty(property, whatIfTemplateProperty),
       },
     ],
   }

--- a/src/lib/whatif/format.ts
+++ b/src/lib/whatif/format.ts
@@ -1,8 +1,11 @@
+import { WhatIfMultiProperty } from '@deltares/fews-pi-requests'
 import { toHumanReadableDateTime } from '../date'
-import { ScenarioProperty } from './utils'
+import type { WhatIfTemplateProperty } from './types'
+import type { ScenarioProperty } from './utils'
 
 export function formatWhatIfScenarioProperty(
   property: ScenarioProperty,
+  whatIfTemplateProperty?: WhatIfTemplateProperty,
 ): string {
   switch (property.type) {
     case 'boolean':
@@ -15,8 +18,29 @@ export function formatWhatIfScenarioProperty(
     case 'number':
       // Show values with 3 significant digits.
       return property.value.toPrecision(3)
+    case 'multiPropertyEnumeration':
+      return formatMultiPropertyEnumeration(property, whatIfTemplateProperty)
     default:
       // Handle the rest by just returning its (string) value.
       return property.value
   }
+}
+
+function formatMultiPropertyEnumeration(
+  property: WhatIfMultiProperty,
+  whatIfTemplateProperty?: WhatIfTemplateProperty,
+): string {
+  // Fall back to just the index if we get no (valid) what-if template
+  // property.
+  const fallback = property.value
+  if (
+    whatIfTemplateProperty === undefined ||
+    whatIfTemplateProperty.type !== 'multiProperty'
+  ) {
+    return fallback
+  }
+  const selectedOption = whatIfTemplateProperty.selectionOptions.find(
+    (option) => option.code === property.value,
+  )
+  return selectedOption?.label ?? fallback
 }

--- a/src/lib/whatif/types.ts
+++ b/src/lib/whatif/types.ts
@@ -1,6 +1,10 @@
 import { WhatIfTemplate } from '@deltares/fews-pi-requests'
 
-export type WhatIfTemplateProperty = Pick<
-  NonNullable<WhatIfTemplate['properties']>[number],
+export type WhatIfTemplateProperty = NonNullable<
+  WhatIfTemplate['properties']
+>[number]
+
+export type PartialWhatIfTemplateProperty = Pick<
+  WhatIfTemplateProperty,
   'id' | 'type'
 >

--- a/src/lib/whatif/utils.test.ts
+++ b/src/lib/whatif/utils.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { convertPropertiesToFewsPi } from './utils'
-import { WhatIfTemplateProperty } from './types'
+import type { PartialWhatIfTemplateProperty } from './types'
 
 describe('convertPropertiesToFewsPi', () => {
   it('should convert dateTime properties to FEWS PI format', () => {
-    const templateProperties: WhatIfTemplateProperty[] = [
+    const templateProperties: PartialWhatIfTemplateProperty[] = [
       {
         id: 'startDate',
         type: 'dateTime',
@@ -35,7 +35,7 @@ describe('convertPropertiesToFewsPi', () => {
   })
 
   it('should return properties unchanged if template does not define types', () => {
-    const templateProperties: WhatIfTemplateProperty[] = [
+    const templateProperties: PartialWhatIfTemplateProperty[] = [
       { id: 'someKey', type: 'string' },
       { id: 'anotherKey', type: 'number' },
       { id: 'multiValueKey', type: 'multiProperty' },

--- a/src/lib/whatif/utils.ts
+++ b/src/lib/whatif/utils.ts
@@ -8,7 +8,7 @@ import {
   convertJSDateToFewsPiParameter,
   toHumanReadableDateTime,
 } from '@/lib/date'
-import { WhatIfTemplateProperty } from './types'
+import type { PartialWhatIfTemplateProperty } from './types'
 
 export type TemplateProperty = NonNullable<WhatIfTemplate['properties']>[number]
 export type ScenarioProperty = NonNullable<
@@ -424,7 +424,7 @@ export function computeValidDateRange(
  */
 export function convertPropertiesToFewsPi(
   properties: Record<string, any>,
-  templateProperties: WhatIfTemplateProperty[] | undefined,
+  templateProperties: PartialWhatIfTemplateProperty[] | undefined,
 ): Record<string, string | number> {
   if (!templateProperties) return properties as Record<string, string | number>
   const converted: Record<string, string | number> = {}


### PR DESCRIPTION
### Description
This PR improves the UI of the what-if property tables in the Task overview and Non-current data panels in several ways:

- Show labels of multi-property enumerations, instead of just the code
- Make icon size consistent between Task overview and Non-current data
- Show what-if properties in a two-column table to reduce the space occupied
- Switch emphasis colours between header and value in the table; the value now has more emphasis

### Screenshots
Multi-property enumeration label:
<img width="139" height="55" alt="image" src="https://github.com/user-attachments/assets/e616320c-8fb0-42f3-b054-05f743bed638" />

Consistent icon sizes:
<img width="547" height="102" alt="image" src="https://github.com/user-attachments/assets/2e2423c4-9446-48d1-8394-da725d994e37" />

<img width="555" height="102" alt="image" src="https://github.com/user-attachments/assets/30f373cb-0498-41b7-b083-436b0666cd07" />

Two-column what-if property table and switched emphasis colours:
<img width="521" height="217" alt="image" src="https://github.com/user-attachments/assets/075377fb-0bd5-416e-b67e-4fd71d02c72a" />

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes
