### PR TITLE
Option to show timeseries window full screen and timeseries charts full height

### DIFF
--- a/src/components/charts/TimeSeriesChart.vue
+++ b/src/components/charts/TimeSeriesChart.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="chart-with-chips"
-    :class="{ 'vertical-profile': verticalProfile }"
+    :class="{ 'vertical-profile': verticalProfile, maximized: maximized }"
     :style="{
       'flex-direction': settings.legend.placement.includes('under')
         ? 'column-reverse'
@@ -27,6 +27,21 @@
     />
     <div ref="chartContainer" class="chart-container"></div>
     <slot name="brush" :margin="margin" />
+    <v-btn
+      v-if="showMaximizeButton"
+      class="chart-maximize-btn"
+      size="x-small"
+      icon
+      variant="flat"
+      :title="
+        maximized ? $t('common.restoreChart') : $t('common.maximizeChart')
+      "
+      @click="$emit('toggle-maximize')"
+    >
+      <v-icon>{{
+        maximized ? 'mdi-arrow-collapse' : 'mdi-arrow-expand'
+      }}</v-icon>
+    </v-btn>
   </div>
 </template>
 
@@ -88,12 +103,17 @@ interface Props {
   verticalProfile?: boolean
   forecastLegend?: string
   settings: ChartsSettings['timeSeriesChart']
+  showMaximizeButton?: boolean
+  maximized?: boolean
 }
 
 const props = defineProps<Props>()
 const domain = defineModel<[Date, Date]>('domain')
 
 const userSettingsStore = useUserSettingsStore()
+const emit = defineEmits<{
+  'toggle-maximize': []
+}>()
 defineExpose({
   getSvgElement,
   axisAccept,
@@ -372,6 +392,24 @@ function axisAccept(visitor: Visitor) {
   flex: 1 1 80%;
   max-height: max(50%, 400px);
   width: 100%;
+}
+
+.chart-with-chips.maximized {
+  flex: 1 1 100%;
+  max-height: none;
+}
+
+.chart-maximize-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  opacity: 0;
+  transition: opacity 0.15s;
+  z-index: 1;
+}
+
+.chart-with-chips:hover .chart-maximize-btn {
+  opacity: 1;
 }
 
 .chart-with-chips.vertical-profile {

--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="container" ref="container">
-    <div class="child-container" :class="{ 'd-none': hideMap }">
+    <div class="child-container" :class="{ 'd-none': hideMap || maximized }">
       <SpatialDisplayComponent
         :layer-name="props.layerName"
         :location-ids="props.locationIds"
@@ -24,6 +24,7 @@
     <div v-if="showChartPanel" class="child-container">
       <SpatialTimeSeriesDisplay
         @close="closeTimeSeriesDisplay"
+        v-model:maximized="maximized"
         :filter="filter"
         :brushFilter="brushFilter"
         :elevation-chart-filter="elevationChartFilter"
@@ -309,6 +310,7 @@ const locationsTooltipFilter = computed<LocationsTooltipFilter | undefined>(
 
 const elevation = ref<number | undefined>()
 const currentTime = ref<Date>()
+const maximized = ref(false)
 
 const { width: containerWidth } = useElementSize(containerRef)
 
@@ -389,6 +391,7 @@ function openCoordinatesTimeSeriesDisplay(latitude: number, longitude: number) {
 }
 
 function closeTimeSeriesDisplay(): void {
+  maximized.value = false
   emit('navigate', { name: 'SpatialDisplay' })
 }
 

--- a/src/components/spatialdisplay/SpatialTimeSeriesDisplay.vue
+++ b/src/components/spatialdisplay/SpatialTimeSeriesDisplay.vue
@@ -11,6 +11,11 @@
         :informationContent="tooltip"
       >
         <template #toolbar-append>
+          <v-btn size="small" icon @click="onToggleMaximize">
+            <v-icon>{{
+              maximized ? 'mdi-fullscreen-exit' : 'mdi-fullscreen'
+            }}</v-icon>
+          </v-btn>
           <v-btn size="small" icon @click="onClose">
             <v-icon>mdi-close</v-icon>
           </v-btn>
@@ -41,12 +46,16 @@ interface Props {
   locationsTooltipFilter?: LocationsTooltipFilter
   currentTime?: Date
   settings: ComponentSettings
+  maximized?: boolean
 }
 
 const taskRunsStore = useTaskRunsStore()
 
 const props = defineProps<Props>()
-const emit = defineEmits(['close'])
+const emit = defineEmits<{
+  close: []
+  'update:maximized': [value: boolean]
+}>()
 
 const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
 
@@ -81,5 +90,9 @@ const { tooltip } = useLocationTooltip(
 
 function onClose(): void {
   emit('close')
+}
+
+function onToggleMaximize(): void {
+  emit('update:maximized', !props.maximized)
 }
 </script>

--- a/src/components/timeseries/TimeSeriesComponent.vue
+++ b/src/components/timeseries/TimeSeriesComponent.vue
@@ -8,6 +8,9 @@
       <KeepAlive>
         <template v-for="subplot in subplots" :key="subplot.id">
           <TimeSeriesChart
+            v-show="
+              maximizedSubplotId === null || maximizedSubplotId === subplot.id
+            "
             v-model:domain="visibleDomain"
             :config="subplot"
             :series="chartSeries"
@@ -16,6 +19,9 @@
             :panHandler="sharedPanHandler"
             :settings="settings.timeSeriesChart"
             :forecastLegend="config.forecastLegend"
+            :show-maximize-button="subplots.length > 1"
+            :maximized="maximizedSubplotId === subplot.id"
+            @toggle-maximize="toggleMaximizeSubplot(subplot.id)"
           >
             <template #brush="{ margin: chartMargin }">
               <TimeSeriesChartBrush
@@ -194,6 +200,12 @@ const confirmationDialog = ref(false)
 const { xs } = useDisplay()
 const { sharedZoomHandler, sharedPanHandler, sharedVerticalZoomHandler } =
   useChartHandlers()
+
+const maximizedSubplotId = ref<string | null>(null)
+
+function toggleMaximizeSubplot(id: string): void {
+  maximizedSubplotId.value = maximizedSubplotId.value === id ? null : id
+}
 
 const tab = ref<DisplayType>(props.displayType)
 

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -15,7 +15,9 @@
     "unsavedChanges": "Ungespeicherte Änderungen",
     "unsavedChangesExitWarning": "Sie haben ungespeicherte Änderungen. Ohne Speichern verlassen?",
     "finished": "abgeschlossen",
-    "failed": "fehlgeschlagen"
+    "failed": "fehlgeschlagen",
+    "maximizeChart": "Diagramm maximieren",
+    "restoreChart": "Diagramm wiederherstellen"
   },
   "layout": {
     "about": "Über",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -15,7 +15,9 @@
     "unsavedChanges": "Unsaved changes",
     "unsavedChangesExitWarning": "You have unsaved changes. Leave without saving?",
     "finished": "finished",
-    "failed": "failed"
+    "failed": "failed",
+    "maximizeChart": "Maximize chart",
+    "restoreChart": "Restore chart"
   },
   "layout": {
     "about": "About",

--- a/tests/e2e/chart/maximize.spec.ts
+++ b/tests/e2e/chart/maximize.spec.ts
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test'
+
+const base = '/topology/early_warning/node'
+const url = `${base}/viewer_rivers_level_stations/viewer_rivers_level_stations_forecast/map/waterdepth_sfincs_inland/location/Umgeni_Mouth_level`
+
+test.describe('Maximize individual chart', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(url)
+  })
+
+  test('should maximize a single chart and hide the others', async ({
+    page,
+  }) => {
+    const charts = page.locator('.chart-with-chips')
+    await expect(charts.first()).toBeVisible()
+
+    // There should be multiple charts rendered
+    const chartCount = await charts.count()
+    expect(chartCount).toBeGreaterThan(1)
+
+    // Hover over first chart to reveal the maximize button
+    await charts.first().hover()
+    const maximizeBtn = charts.first().getByTitle('Maximize chart')
+    await expect(maximizeBtn).toBeVisible()
+
+    // Click maximize
+    await maximizeBtn.click()
+
+    // First chart should still be visible and marked as maximized
+    await expect(charts.first()).toBeVisible()
+    await expect(charts.first()).toHaveClass(/maximized/)
+
+    // All other charts should be hidden
+    for (let i = 1; i < chartCount; i++) {
+      await expect(charts.nth(i)).not.toBeVisible()
+    }
+  })
+
+  test('should restore all charts after clicking restore', async ({ page }) => {
+    const charts = page.locator('.chart-with-chips')
+    await expect(charts.first()).toBeVisible()
+    const chartCount = await charts.count()
+
+    // Maximize the first chart
+    await charts.first().hover()
+    await charts.first().getByTitle('Maximize chart').click()
+
+    // Restore via the restore button
+    await charts.first().hover()
+    const restoreBtn = charts.first().getByTitle('Restore chart')
+    await expect(restoreBtn).toBeVisible()
+    await restoreBtn.click()
+
+    // All charts should be visible again and none marked as maximized
+    for (let i = 0; i < chartCount; i++) {
+      await expect(charts.nth(i)).toBeVisible()
+      await expect(charts.nth(i)).not.toHaveClass(/maximized/)
+    }
+  })
+})


### PR DESCRIPTION
Add the option to show the timeseries window (charts, vertical profile, table, info) full screen (hide the map).
Add the option to show the individual timeseries charts full height.

<img width="946" height="671" alt="Screenshot_8-5-2026_105339_localhost" src="https://github.com/user-attachments/assets/0605269d-c616-4d6c-934a-9a8cfff89337" />
<img width="946" height="671" alt="Screenshot_8-5-2026_105355_localhost" src="https://github.com/user-attachments/assets/ea7c7d3f-31dd-4f68-8841-e35dab88230b" />

