### PR TITLE
Support dark theme on info iframe

### DIFF
--- a/src/components/sidepanel/MoreInfoSidePanel.vue
+++ b/src/components/sidepanel/MoreInfoSidePanel.vue
@@ -10,6 +10,7 @@
       :src="url"
       title="Information Document"
       class="w-100 h-100 ma-0 pa-0 border-none"
+      @load="postTheme"
     ></iframe>
     <div v-else class="pa-4">
       <span>No information document configured</span>
@@ -18,12 +19,13 @@
 </template>
 <script setup lang="ts">
 import type { TopologyNode } from '@deltares/fews-pi-requests'
-import { computed, useTemplateRef } from 'vue'
+import { computed, useTemplateRef, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import { getResourcesStaticUrl } from '@/lib/fews-config'
 
 import SidePanelContent from './SidePanelContent.vue'
+import { useDark } from '@vueuse/core'
 
 const { t } = useI18n()
 
@@ -38,6 +40,7 @@ interface Emits {
 const emit = defineEmits<Emits>()
 
 const frame = useTemplateRef('frame')
+const isDark = useDark()
 
 const url = computed<string | null>(() => {
   const resource = props.topologyNode?.documentFile
@@ -54,4 +57,15 @@ function goHome(): void {
   frame.value.removeAttribute('src')
   frame.value.src = url.value
 }
+
+function postTheme() {
+  const message = {
+    type: 'FEWS_WEB_OC:SET_THEME',
+    theme: isDark.value ? 'dark' : 'light',
+  }
+
+  frame.value?.contentWindow?.postMessage(message, '*')
+}
+
+watch(isDark, postTheme)
 </script>

--- a/src/views/InformationDisplayView.vue
+++ b/src/views/InformationDisplayView.vue
@@ -4,6 +4,13 @@
     :src="url"
     title="Information Document"
     class="w-100 h-100 ma-0 pa-0 border-none"
+    ref="iframeRef"
+    :style="
+      theme.current.value.dark && !themeAcknowledged
+        ? { filter: 'invert(1) hue-rotate(180deg)' }
+        : undefined
+    "
+    @load="postTheme"
   />
   <div v-else class="pa-4">
     <span>No information document configured</span>
@@ -13,13 +20,40 @@
 <script setup lang="ts">
 import { getResourcesStaticUrl } from '@/lib/fews-config'
 import { TopologyNode } from '@deltares/fews-pi-requests'
-import { computed } from 'vue'
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
+import { useTheme } from 'vuetify'
 
 interface Props {
   topologyNode?: TopologyNode
 }
 
 const props = defineProps<Props>()
+
+const theme = useTheme()
+const iframeRef = ref<HTMLIFrameElement>()
+const themeAcknowledged = ref(false)
+
+function postTheme() {
+  themeAcknowledged.value = false
+  iframeRef.value?.contentWindow?.postMessage(
+    {
+      type: 'FEWS_WEB_OC:SET_THEME',
+      theme: theme.current.value.dark ? 'dark' : 'light',
+    },
+    '*',
+  )
+}
+
+function onMessage(event: MessageEvent) {
+  if (event.data?.type === 'FEWS_WEB_OC:THEME_ACK') {
+    themeAcknowledged.value = true
+  }
+}
+
+onMounted(() => window.addEventListener('message', onMessage))
+onUnmounted(() => window.removeEventListener('message', onMessage))
+
+watch(() => theme.current.value.dark, postTheme)
 
 const url = computed(() => {
   const resource = props.topologyNode?.documentFile


### PR DESCRIPTION
To get this to work, info html need the following to be included:

```html
<script>
window.addEventListener("message", (event) => {
  if (event.data?.type === "FEWS_WEB_OC:SET_THEME") {
    document.documentElement.classList.toggle("dark", event.data.theme === "dark");
  }
});
</script>
```