### PR TITLE
Fix what-if submission errors

### DIFF
--- a/src/components/tasksdisplay/WhatIfDisplay.vue
+++ b/src/components/tasksdisplay/WhatIfDisplay.vue
@@ -131,7 +131,7 @@ import WhatIfTimeZeroSelect from './WhatIfTimeZeroSelect.vue'
 
 import { isDateTimeControl, rankWith } from '@jsonforms/core'
 import { vuetifyRenderers } from '@jsonforms/vue-vuetify'
-import { computed, provide, ref, watch, watchEffect } from 'vue'
+import { computed, provide, ref, watch } from 'vue'
 import { ErrorObject } from 'ajv'
 
 import { JsonForms } from '@jsonforms/vue'
@@ -238,8 +238,17 @@ watch(
 const { jsonSchema, uiSchema } = useWhatIfTemplateSchemas(
   selectedWhatIfTemplate,
 )
-
-watchEffect(() => {
+// NOTE: we update the default properties when the JSON schema is updated, but
+//       obtain these default values from the what-if-template and (optionally)
+//       scenario. That may seem surprising.
+//       The properties set by the JSON-forms component depend on the JSON
+//       schema. The JSON schema is an async reference, which gets updated when
+//       the selected what-if template ID updates, so it will arrive later than
+//       the what-if template update. If we update the properties before the
+//       schema updates, values from the previously selected JSON schema will be
+//       inserted by JSON-forms. Hence, we wait for the schema to be up to date,
+//       and only then update the default properties.
+watch(jsonSchema, () => {
   selectedProperties.value = getJsonDataFromProperties(
     selectedWhatIfTemplate.value?.properties,
     selectedWhatIfScenario.value?.properties,

--- a/src/components/tasksdisplay/WhatIfDisplay.vue
+++ b/src/components/tasksdisplay/WhatIfDisplay.vue
@@ -204,11 +204,14 @@ provide('whatIfReferenceTime', referenceTime)
 
 const description = ref<string>()
 
-const selectedWorkflow = computed(() =>
-  props.workflows.find(
-    (wf) => wf.whatIfTemplateId === selectedWhatIfTemplate.value?.id,
-  ),
-)
+const selectedWorkflow = computed<WorkflowItem | undefined>(() => {
+  const selectedWhatIfTemplateId = selectedWhatIfTemplate.value?.id
+  return selectedWhatIfTemplateId === undefined
+    ? undefined
+    : props.workflows.find(
+        (wf) => wf.whatIfTemplateId === selectedWhatIfTemplateId,
+      )
+})
 
 // We override all date/time controls with our own, to make sure they are
 // consistent with each other.

--- a/src/lib/whatif/fetch.ts
+++ b/src/lib/whatif/fetch.ts
@@ -38,7 +38,7 @@ export async function postWhatIfScenario(
   } catch (error) {
     console.error(error)
     return {
-      error: 'Error while posting WhatIf scenario',
+      error: 'Error while posting what-if scenario',
       status: 'error',
     }
   }


### PR DESCRIPTION
### Description
This PR fixes a problem where properties from a previously selected what-if scenario would be passed to the currently selected what-if scenario. This may lead to errors upon submitting the scenario if the properties from the previous scenario are not accepted by the current scenario.

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes