### PR TITLE
Add thresholds count by option

### DIFF
--- a/src/components/sidepanel/SidePanelContent.vue
+++ b/src/components/sidepanel/SidePanelContent.vue
@@ -1,7 +1,7 @@
 <template>
   <Teleport to="#main-side-panel" defer>
     <div
-      class="d-flex flex-column h-100 side-panel"
+      class="d-flex flex-column h-100"
       :style="mobile ? 'width: 100vw;' : 'width: 450px;'"
       aria-label="Side panel"
     >
@@ -13,6 +13,7 @@
           {{ title }}
         </span>
         <template #append>
+          <slot name="append"></slot>
           <v-btn @click="emit('close')" icon size="small">
             <v-icon size="small">mdi-close</v-icon>
           </v-btn>
@@ -44,9 +45,5 @@ const { mobile } = useDisplay()
 <style scoped>
 :deep(.v-window__container) {
   height: 100%;
-}
-
-.side-panel {
-  width: 450px;
 }
 </style>

--- a/src/components/sidepanel/SidePanelContent.vue
+++ b/src/components/sidepanel/SidePanelContent.vue
@@ -13,7 +13,6 @@
           {{ title }}
         </span>
         <template #append>
-          <slot name="append"></slot>
           <v-btn @click="emit('close')" icon size="small">
             <v-icon size="small">mdi-close</v-icon>
           </v-btn>

--- a/src/components/sidepanel/ThresholdsSidePanel.vue
+++ b/src/components/sidepanel/ThresholdsSidePanel.vue
@@ -1,7 +1,7 @@
 <template>
   <SidePanelContent :title="t('sidePanel.thresholds')" @close="emit('close')">
     <div>
-      <v-menu>
+      <v-menu v-if="!onlyOneParameter">
         <template #activator="{ props, isActive }">
           <v-chip
             variant="tonal"
@@ -139,6 +139,12 @@ const groupedCrossings = computed(() => {
   })
   return Object.values(grouped)
 })
+
+const onlyOneParameter = computed(() =>
+  warningLevelsStore.warningLevels.every(
+    (level) => level.parameterWarningLevelCount?.length === 1,
+  ),
+)
 
 // Scroll to the selected item
 async function scrollToSelectedItem() {

--- a/src/components/sidepanel/ThresholdsSidePanel.vue
+++ b/src/components/sidepanel/ThresholdsSidePanel.vue
@@ -1,18 +1,33 @@
 <template>
   <SidePanelContent :title="t('sidePanel.thresholds')" @close="emit('close')">
-    <template #append>
-      <v-select
-        v-model="countType"
-        :items="countTypes"
-        variant="outlined"
-        density="compact"
-        hide-details
-        prepend-inner-icon="mdi-filter-variant"
-        min-width="170px"
-        label="Count by"
-      />
-    </template>
     <div>
+      <v-menu>
+        <template #activator="{ props, isActive }">
+          <v-chip
+            variant="tonal"
+            pilled
+            label
+            v-bind="props"
+            class="mt-2 ms-2"
+            prepend-icon="mdi-sigma"
+          >
+            <template #default>
+              <span>{{ countType }}</span>
+              <v-spacer />
+              <SelectIcon :active="isActive" />
+            </template>
+          </v-chip>
+        </template>
+        <v-list density="compact">
+          <v-list-subheader>Count by</v-list-subheader>
+          <v-list-item
+            v-for="type in countTypes"
+            :title="type"
+            :active="countType === type"
+            @click="countType = type"
+          />
+        </v-list>
+      </v-menu>
       <v-chip-group
         class="px-2 py-2 d-flex flex-wrap flex-0-0"
         v-model="warningLevelsStore.selectedWarningLevelIds"
@@ -84,6 +99,7 @@ import { nodeHasMap } from '@/lib/topology/nodes'
 
 import { useWarningLevelsStore } from '@/stores/warningLevels'
 
+import SelectIcon from '@/components/general/SelectIcon.vue'
 import ThresholdSummary from '@/components/thresholds/ThresholdSummary.vue'
 import SidePanelContent from './SidePanelContent.vue'
 
@@ -147,30 +163,3 @@ onMounted(() => {
   scrollToSelectedItem()
 })
 </script>
-
-<style scoped>
-.threshold-summary-container {
-  width: 450px;
-}
-
-.warning-count {
-  text-align: center;
-}
-
-.v-list-item-subtitle {
-  font-size: 0.8em;
-  color: var(--v-theme-on-surface);
-  opacity: 1;
-  width: 100%;
-  text-align: center;
-}
-
-:deep(.v-list-item__content) {
-  overflow: visible !important;
-  width: 65px;
-}
-
-:deep(.v-chip__content) {
-  width: 100%;
-}
-</style>

--- a/src/components/sidepanel/ThresholdsSidePanel.vue
+++ b/src/components/sidepanel/ThresholdsSidePanel.vue
@@ -1,33 +1,35 @@
 <template>
   <SidePanelContent :title="t('sidePanel.thresholds')" @close="emit('close')">
     <div>
-      <v-menu v-if="!onlyOneParameter">
-        <template #activator="{ props, isActive }">
-          <v-chip
-            variant="tonal"
-            pilled
-            label
-            v-bind="props"
-            class="mt-2 ms-2"
-            prepend-icon="mdi-sigma"
-          >
-            <template #default>
-              <span>{{ countType }}</span>
-              <v-spacer />
-              <SelectIcon :active="isActive" />
+      <v-list-item>
+        <v-list-item-title>
+          {{ t('thresholds.warningLevels') }}
+        </v-list-item-title>
+        <template #append>
+          <v-menu>
+            <template #activator="{ props, isActive }">
+              <v-chip variant="tonal" pilled v-bind="props" class="mt-2 ms-2">
+                <template #default>
+                  <span
+                    >{{ t('thresholds.count') }}:
+                    {{ t(`thresholds.countBy.${countType}`) }}</span
+                  >
+                  <v-spacer />
+                  <SelectIcon :active="isActive" />
+                </template>
+              </v-chip>
             </template>
-          </v-chip>
+            <v-list density="compact">
+              <v-list-item
+                v-for="type in countTypes"
+                :title="t(`thresholds.countBy.${type}`)"
+                :active="countType === type"
+                @click="countType = type"
+              />
+            </v-list>
+          </v-menu>
         </template>
-        <v-list density="compact">
-          <v-list-subheader>{{ t('thresholds.countBy') }}</v-list-subheader>
-          <v-list-item
-            v-for="type in countTypes"
-            :title="type"
-            :active="countType === type"
-            @click="countType = type"
-          />
-        </v-list>
-      </v-menu>
+      </v-list-item>
       <v-chip-group
         class="px-2 py-2 d-flex flex-wrap flex-0-0"
         v-model="warningLevelsStore.selectedWarningLevelIds"
@@ -58,7 +60,7 @@
             <template #append>
               <v-chip
                 :text="
-                  countType === 'Location' ? level.locationCount : level.count
+                  countType === 'Locations' ? level.locationCount : level.count
                 "
                 density="compact"
                 variant="flat"
@@ -69,6 +71,11 @@
           </v-chip>
         </template>
       </v-chip-group>
+      <v-list-item>
+        <v-list-item-title>
+          {{ t('thresholds.activeThresholdCrossings') }}
+        </v-list-item-title>
+      </v-list-item>
       <div v-if="warningLevelsStore.warningLevels.length === 0" class="pa-2">
         {{ t('thresholds.noThresholdCrossing') }}
       </div>
@@ -133,8 +140,8 @@ const selectable = computed<boolean>(() => {
 
 const virtualScroll = useTemplateRef('virtualScroll')
 
-const countTypes = ['Location', 'Parameter'] as const
-const countType = ref<(typeof countTypes)[number]>('Location')
+const countTypes = ['Locations', 'Crossings'] as const
+const countType = ref<(typeof countTypes)[number]>('Locations')
 
 const groupedCrossings = computed(() => {
   const grouped: Record<string, LevelThresholdCrossings[]> = {}
@@ -147,12 +154,6 @@ const groupedCrossings = computed(() => {
   })
   return Object.values(grouped)
 })
-
-const onlyOneParameter = computed(() =>
-  warningLevelsStore.warningLevels.every(
-    (level) => level.parameterWarningLevelCount?.length === 1,
-  ),
-)
 
 // Scroll to the selected item
 async function scrollToSelectedItem() {

--- a/src/components/sidepanel/ThresholdsSidePanel.vue
+++ b/src/components/sidepanel/ThresholdsSidePanel.vue
@@ -35,31 +35,39 @@
         column
         selected-class="v-chip--variant-tonal"
       >
-        <v-chip
-          v-for="level in warningLevelsStore.warningLevels"
+        <template
+          v-for="(level, index) in warningLevelsStore.warningLevels"
           :key="level.id"
-          :value="level.id"
-          :text="level.name"
-          label
-          variant="text"
-          class="pe-0 ps-2"
-          border
         >
-          <template #prepend>
-            <v-img width="20" height="20" :src="level.icon" class="me-1" />
-          </template>
-          <template #append>
-            <v-chip
-              :text="
-                countType === 'Location' ? level.locationCount : level.count
-              "
-              density="compact"
-              variant="flat"
-              class="ms-2 pa-1 pointer-events-none"
-              size="small"
-            />
-          </template>
-        </v-chip>
+          <div
+            v-if="showSeverityZeroSeparator(index)"
+            class="w-100 my-1 severity-zero-separator"
+            aria-hidden="true"
+          ></div>
+          <v-chip
+            :value="level.id"
+            :text="level.name"
+            label
+            variant="text"
+            class="pe-0 ps-2"
+            border
+          >
+            <template #prepend>
+              <v-img width="20" height="20" :src="level.icon" class="me-1" />
+            </template>
+            <template #append>
+              <v-chip
+                :text="
+                  countType === 'Location' ? level.locationCount : level.count
+                "
+                density="compact"
+                variant="flat"
+                class="ms-2 pa-1 pointer-events-none"
+                size="small"
+              />
+            </template>
+          </v-chip>
+        </template>
       </v-chip-group>
       <div v-if="warningLevelsStore.warningLevels.length === 0" class="pa-2">
         {{ t('thresholds.noThresholdCrossing') }}
@@ -168,4 +176,18 @@ watch([() => props.locationIds, groupedCrossings], () => {
 onMounted(() => {
   scrollToSelectedItem()
 })
+
+function showSeverityZeroSeparator(index: number): boolean {
+  if (index <= 0) return false
+  const levels = warningLevelsStore.warningLevels
+  const currentSeverity = levels[index]?.severity
+  const previousSeverity = levels[index - 1]?.severity
+  return currentSeverity === 0 && previousSeverity !== 0
+}
 </script>
+
+<style scoped>
+.severity-zero-separator {
+  border-top: 1px solid rgba(var(--v-theme-on-surface), 0.2);
+}
+</style>

--- a/src/components/sidepanel/ThresholdsSidePanel.vue
+++ b/src/components/sidepanel/ThresholdsSidePanel.vue
@@ -97,7 +97,7 @@ const virtualScroll = useTemplateRef('virtualScroll')
 
 const groupedCrossings = computed(() => {
   const grouped: Record<string, LevelThresholdCrossings[]> = {}
-  warningLevelsStore.selectedThresholdCrossings.forEach((crossing) => {
+  warningLevelsStore.selectedCrossings.forEach((crossing) => {
     const key = crossing.locationId
     if (!grouped[key]) {
       grouped[key] = []

--- a/src/components/sidepanel/ThresholdsSidePanel.vue
+++ b/src/components/sidepanel/ThresholdsSidePanel.vue
@@ -1,7 +1,7 @@
 <template>
   <SidePanelContent :title="t('sidePanel.thresholds')" @close="emit('close')">
     <div>
-      <v-list-item>
+      <v-list-item v-if="warningLevelsStore.warningLevels.length > 0">
         <v-list-item-title>
           {{ t('thresholds.warningLevels') }}
         </v-list-item-title>

--- a/src/components/sidepanel/ThresholdsSidePanel.vue
+++ b/src/components/sidepanel/ThresholdsSidePanel.vue
@@ -1,5 +1,17 @@
 <template>
   <SidePanelContent :title="t('sidePanel.thresholds')" @close="emit('close')">
+    <template #append>
+      <v-select
+        v-model="countType"
+        :items="countTypes"
+        variant="outlined"
+        density="compact"
+        hide-details
+        prepend-inner-icon="mdi-filter-variant"
+        min-width="170px"
+        label="Count by"
+      />
+    </template>
     <div>
       <v-chip-group
         class="px-2 py-2 d-flex flex-wrap flex-0-0"
@@ -23,7 +35,9 @@
           </template>
           <template #append>
             <v-chip
-              :text="level.count"
+              :text="
+                countType === 'Location' ? level.locationCount : level.count
+              "
               density="compact"
               variant="flat"
               class="ms-2 pa-1 pointer-events-none"
@@ -62,7 +76,7 @@ import type {
   LevelThresholdCrossings,
   TopologyNode,
 } from '@deltares/fews-pi-requests'
-import { computed, watch, nextTick, onMounted, useTemplateRef } from 'vue'
+import { computed, watch, nextTick, onMounted, useTemplateRef, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 import type { NavigateRoute } from '@/lib/router/types'
@@ -94,6 +108,9 @@ const selectable = computed<boolean>(() => {
 })
 
 const virtualScroll = useTemplateRef('virtualScroll')
+
+const countTypes = ['Location', 'Parameter'] as const
+const countType = ref<(typeof countTypes)[number]>('Location')
 
 const groupedCrossings = computed(() => {
   const grouped: Record<string, LevelThresholdCrossings[]> = {}

--- a/src/components/sidepanel/ThresholdsSidePanel.vue
+++ b/src/components/sidepanel/ThresholdsSidePanel.vue
@@ -19,7 +19,7 @@
           </v-chip>
         </template>
         <v-list density="compact">
-          <v-list-subheader>Count by</v-list-subheader>
+          <v-list-subheader>{{ t('thresholds.countBy') }}</v-list-subheader>
           <v-list-item
             v-for="type in countTypes"
             :title="type"

--- a/src/components/sidepanel/ThresholdsSidePanel.vue
+++ b/src/components/sidepanel/ThresholdsSidePanel.vue
@@ -73,12 +73,13 @@
       </v-chip-group>
       <v-list-item>
         <v-list-item-title>
-          {{ t('thresholds.activeThresholdCrossings') }}
+          {{
+            warningLevelsStore.warningLevels.length === 0
+              ? t('thresholds.noThresholdCrossing')
+              : t('thresholds.activeThresholdCrossings')
+          }}
         </v-list-item-title>
       </v-list-item>
-      <div v-if="warningLevelsStore.warningLevels.length === 0" class="pa-2">
-        {{ t('thresholds.noThresholdCrossing') }}
-      </div>
       <!-- Important to have item-height as it greatly improves performance -->
       <v-virtual-scroll
         ref="virtualScroll"

--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -146,13 +146,10 @@ watch(locations, (newLocations) =>
 )
 
 const selectedCrossings = computed(() => {
-  if (warningLevelsStore.selectedWarningLevelIds.length === 0) return []
-  return warningLevelsStore.selectedThresholdCrossings
-    .sort((a, b) => b.severity - a.severity)
-    .filter(
-      (crossing, index, self) =>
-        index === self.findIndex((c) => c.locationId === crossing.locationId),
-    )
+  return warningLevelsStore.selectedCrossings.filter(
+    (crossing, index, self) =>
+      index === self.findIndex((c) => c.locationId === crossing.locationId),
+  )
 })
 const selectedSeverities = computed(() =>
   warningLevelsStore.selectedWarningLevels.map((level) => level.severity),

--- a/src/components/thresholds/ThresholdSummary.vue
+++ b/src/components/thresholds/ThresholdSummary.vue
@@ -62,12 +62,22 @@ function onMouseLeave() {
 }
 
 function onPanelClick() {
-  // Route to open the crossing in the map
+  if (isSelected) {
+    closeTimeSeriesDisplay()
+  } else {
+    // Route to open the crossing in the map
+    navigateToLocation(crossings[0].locationId)
+  }
+}
+
+function closeTimeSeriesDisplay() {
+  emit('navigate', { name: 'SpatialDisplay' })
+}
+
+function navigateToLocation(locationIds: string) {
   const to = {
     name: 'SpatialDisplayWithLocation',
-    params: {
-      locationIds: crossings[0].locationId,
-    },
+    params: { locationIds },
   }
   emit('navigate', to)
 }

--- a/src/components/thresholds/ThresholdsButton.vue
+++ b/src/components/thresholds/ThresholdsButton.vue
@@ -39,13 +39,13 @@ const warningLevelsStore = useWarningLevelsStore()
 interface Props {
   active: boolean
 }
-const props = defineProps<Props>()
+defineProps<Props>()
 
 const maxWarningLevelColor = computed(() => {
   const maxWarningLevel = warningLevelsStore.warningLevels.find(
     (warningLevel) => warningLevel.count > 0,
   )
-  const foundCrossing = warningLevelsStore.thresholdCrossings.find(
+  const foundCrossing = warningLevelsStore.crossings.find(
     (crossing) => crossing.warningLevelId === maxWarningLevel?.id,
   )
   return foundCrossing?.color

--- a/src/lib/thresholds/types.ts
+++ b/src/lib/thresholds/types.ts
@@ -4,4 +4,5 @@ export interface WarningLevel {
   severity: number
   icon?: string
   count: number
+  locationCount: number
 }

--- a/src/lib/thresholds/types.ts
+++ b/src/lib/thresholds/types.ts
@@ -1,8 +1,6 @@
-export interface WarningLevel {
-  id: string
-  name: string
-  severity: number
-  icon?: string
+import { ParameterLevelThresholdWarningLevels } from '@deltares/fews-pi-requests'
+
+export interface WarningLevel extends ParameterLevelThresholdWarningLevels {
   count: number
   locationCount: number
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -34,7 +34,8 @@
   },
   "thresholds": {
     "thresholds": "Schwellenwerte",
-    "noThresholdCrossing": "Zurzeit keine Schwellenwertüberschreitungen"
+    "noThresholdCrossing": "Zurzeit keine Schwellenwertüberschreitungen",
+    "countBy": "Zählen nach"
   },
   "download": {
     "downloadTimeSeries": "Zeitreihe herunterladen",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -33,9 +33,16 @@
     "endDateAfterStartDate": "Enddatum muss nach Startdtaum liegen"
   },
   "thresholds": {
-    "thresholds": "Schwellenwerte",
+    "activeThresholdCrossings": "Aktive Schwellenwertüberschreitungen",
+    "count": "Anzahl",
+    "countBy": {
+      "Locations": "Messstellen",
+      "Crossings": "Überschreitungen"
+    },
+    "countCrossings": "Überschreitungen",
     "noThresholdCrossing": "Zurzeit keine Schwellenwertüberschreitungen",
-    "countBy": "Zählen nach"
+    "thresholds": "Schwellenwerte",
+    "warningLevels": "Warnstufen"
   },
   "download": {
     "downloadTimeSeries": "Zeitreihe herunterladen",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -34,7 +34,8 @@
   },
   "thresholds": {
     "thresholds": "Thresholds",
-    "noThresholdCrossing": "No active threshold crossings"
+    "noThresholdCrossing": "No active threshold crossings",
+    "countBy": "Count by"
   },
   "download": {
     "downloadTimeSeries": "Download time series",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -33,9 +33,15 @@
     "endDateAfterStartDate": "End date must be after start date"
   },
   "thresholds": {
-    "thresholds": "Thresholds",
+    "count": "Count",
+    "countBy": {
+      "Locations": "Locations",
+      "Crossings": "Crossings"
+    },
+    "activeThresholdCrossings": "Active threshold crossings",
     "noThresholdCrossing": "No active threshold crossings",
-    "countBy": "Count by"
+    "thresholds": "Thresholds",
+    "warningLevels": "Levels"
   },
   "download": {
     "downloadTimeSeries": "Download time series",

--- a/src/services/useTopologyThresholds/index.ts
+++ b/src/services/useTopologyThresholds/index.ts
@@ -29,10 +29,18 @@ export function useTopologyThresholds(
   const error = shallowRef<string>()
 
   async function loadTopologyThresholds() {
+    const _nodeId = toValue(nodeId)
+    const hasNodeId = nodeId !== undefined
+
+    if (hasNodeId && _nodeId === undefined) {
+      thresholds.value = undefined
+      error.value = undefined
+      return
+    }
+
     isLoading.value = true
     isReady.value = false
     try {
-      const _nodeId = toValue(nodeId)
       const provider = new PiWebserviceProvider(baseUrl, {
         transformRequestFn: createTransformRequestFn(),
       })

--- a/src/stores/warningLevels.ts
+++ b/src/stores/warningLevels.ts
@@ -20,12 +20,25 @@ export const useWarningLevelsStore = defineStore('warningLevels', () => {
   const _crossings = computed(
     () => thresholds.value?.levelThresholdCrossings ?? [],
   )
-  const aggregatedWarningLevels = computed(
+  const _aggregatedWarningLevels = computed(
     () => thresholds.value?.aggregatedLevelThresholdWarningLevels ?? [],
   )
   const _warningLevels = computed(
     () => thresholds.value?.levelThresholdWarningLevels ?? [],
   )
+
+  function getCrossingsCountForLevel(levelId: string): number {
+    return _crossings.value.filter(
+      (crossing) => crossing.warningLevelId === levelId,
+    ).length
+  }
+
+  function getAggregatedCountForLevel(levelId: string): number {
+    const aggregatedLevel = _aggregatedWarningLevels.value.find(
+      (aggLevel) => aggLevel.id === levelId,
+    )
+    return aggregatedLevel?.count ?? 0
+  }
 
   const warningLevels = computed<WarningLevel[]>(() =>
     _warningLevels.value
@@ -34,10 +47,11 @@ export const useWarningLevelsStore = defineStore('warningLevels', () => {
         const count = parameters.reduce((a, b) => a + b.count, 0) ?? 0
         const icon = level.icon ? getResourcesIconsUrl(level.icon) : undefined
 
-        const aggregatedLevel = aggregatedWarningLevels.value.find(
-          (aggLevel) => aggLevel.id === level.id,
-        )
-        const locationCount = aggregatedLevel?.count ?? 0
+        // For warning levels with severity 0 we have no crossings
+        const locationCount =
+          level.severity === 0
+            ? getAggregatedCountForLevel(level.id)
+            : getCrossingsCountForLevel(level.id)
 
         return {
           ...level,

--- a/src/stores/warningLevels.ts
+++ b/src/stores/warningLevels.ts
@@ -13,7 +13,7 @@ export const useWarningLevelsStore = defineStore('warningLevels', () => {
   const selectedWarningLevels = ref<LevelThresholdWarningLevels[]>([])
   const showCrossingDetails = ref(false)
 
-  const { thresholds } = useTopologyThresholds(baseUrl, () => nodeId.value)
+  const { thresholds } = useTopologyThresholds(baseUrl, nodeId)
 
   const aggregatedWarningLevels = computed(() => {
     if (thresholds.value === undefined || thresholds.value.length === 0) {

--- a/src/stores/warningLevels.ts
+++ b/src/stores/warningLevels.ts
@@ -20,6 +20,9 @@ export const useWarningLevelsStore = defineStore('warningLevels', () => {
   const _crossings = computed(
     () => thresholds.value?.levelThresholdCrossings ?? [],
   )
+  const aggregatedWarningLevels = computed(
+    () => thresholds.value?.aggregatedLevelThresholdWarningLevels ?? [],
+  )
   const _warningLevels = computed(
     () => thresholds.value?.levelThresholdWarningLevels ?? [],
   )
@@ -31,9 +34,15 @@ export const useWarningLevelsStore = defineStore('warningLevels', () => {
         const count = parameters.reduce((a, b) => a + b.count, 0) ?? 0
         const icon = level.icon ? getResourcesIconsUrl(level.icon) : undefined
 
+        const aggregatedLevel = aggregatedWarningLevels.value.find(
+          (aggLevel) => aggLevel.id === level.id,
+        )
+        const locationCount = aggregatedLevel?.count ?? 0
+
         return {
           ...level,
           count,
+          locationCount,
           icon,
         }
       })

--- a/src/stores/warningLevels.ts
+++ b/src/stores/warningLevels.ts
@@ -1,6 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref, computed, watch } from 'vue'
-import { LevelThresholdWarningLevels } from '@deltares/fews-pi-requests'
+import { ref, computed } from 'vue'
 import { useTopologyThresholds } from '@/services/useTopologyThresholds'
 import { configManager } from '@/services/application-config'
 import { getResourcesIconsUrl } from '@/lib/fews-config'
@@ -8,112 +7,63 @@ import type { WarningLevel } from '@/lib/thresholds'
 
 export const useWarningLevelsStore = defineStore('warningLevels', () => {
   const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
-  const nodeId = ref<string | undefined>(undefined)
+  const nodeId = ref<string>()
   const selectedWarningLevelIds = ref<string[]>([])
-  const selectedWarningLevels = ref<LevelThresholdWarningLevels[]>([])
-  const showCrossingDetails = ref(false)
 
-  const { thresholds } = useTopologyThresholds(baseUrl, nodeId)
+  const { thresholds: topologyThresholds } = useTopologyThresholds(
+    baseUrl,
+    nodeId,
+  )
 
-  const aggregatedWarningLevels = computed(() => {
-    if (thresholds.value === undefined || thresholds.value.length === 0) {
-      return []
-    }
+  const thresholds = computed(() => topologyThresholds.value?.[0])
 
-    const aggregatedLevels = thresholds.value[0]?.levelThresholdWarningLevels
-    return (
-      aggregatedLevels?.map((level) => {
+  const _crossings = computed(
+    () => thresholds.value?.levelThresholdCrossings ?? [],
+  )
+  const _warningLevels = computed(
+    () => thresholds.value?.levelThresholdWarningLevels ?? [],
+  )
+
+  const warningLevels = computed<WarningLevel[]>(() =>
+    _warningLevels.value
+      .map((level) => {
+        const parameters = level.parameterWarningLevelCount ?? []
+        const count = parameters.reduce((a, b) => a + b.count, 0) ?? 0
+        const icon = level.icon ? getResourcesIconsUrl(level.icon) : undefined
+
         return {
           ...level,
-          count:
-            level.parameterWarningLevelCount?.reduce(
-              (a, b) => a + b.count,
-              0,
-            ) ?? 0,
-        }
-      }) ?? []
-    )
-  })
-
-  const warningLevels = computed<WarningLevel[]>(() => {
-    const levels = aggregatedWarningLevels.value
-      .map((warningLevel) => {
-        return {
-          ...warningLevel,
-          ...{
-            icon: warningLevel.icon
-              ? getResourcesIconsUrl(warningLevel.icon)
-              : undefined,
-          },
+          count,
+          icon,
         }
       })
-      .sort((a, b) => b.severity - a.severity)
-    return levels
-  })
+      .sort((a, b) => b.severity - a.severity),
+  )
 
-  const thresholdCrossings = computed(() => {
-    if (thresholds.value === undefined || thresholds.value.length === 0)
-      return []
-    return (thresholds.value[0].levelThresholdCrossings ?? []).map(
-      (crossing) => {
-        return {
-          ...crossing,
-          ...{
-            icon: crossing.icon ? getResourcesIconsUrl(crossing.icon) : '',
-          },
-        }
-      },
+  const crossings = computed(() =>
+    _crossings.value
+      .map((crossing) => ({
+        ...crossing,
+        icon: crossing.icon ? getResourcesIconsUrl(crossing.icon) : '',
+      }))
+      .sort((a, b) => b.severity - a.severity),
+  )
+
+  const selectedCrossings = computed(() => {
+    if (selectedWarningLevelIds.value.length === 0) return crossings.value
+
+    return crossings.value.filter((crossing) =>
+      selectedWarningLevelIds.value.includes(crossing.warningLevelId ?? ''),
     )
   })
 
-  const selectedThresholdCrossings = computed(() => {
-    const crossings =
-      selectedWarningLevelIds.value.length === 0
-        ? thresholdCrossings.value
-        : thresholdCrossings.value?.filter((crossing) =>
-            selectedWarningLevelIds.value.includes(
-              crossing.warningLevelId ?? '',
-            ),
-          )
-    return crossings.sort((a, b) => b.severity - a.severity)
-  })
+  const selectedWarningLevels = computed(() => {
+    if (selectedWarningLevelIds.value.length === 0) return warningLevels.value
 
-  const aggregatedThresholdCrossings = computed(() => {
-    if (thresholds.value === undefined || thresholds.value.length === 0)
-      return []
-    return thresholds.value[0].aggregatedLevelThresholdCrossings ?? []
+    return warningLevels.value.filter((level) =>
+      selectedWarningLevelIds.value.includes(level.id),
+    )
   })
-
-  const selectedAggregatedThresholdCrossings = computed(() => {
-    const crossings =
-      selectedWarningLevelIds.value.length === 0
-        ? aggregatedThresholdCrossings.value
-        : aggregatedThresholdCrossings.value?.filter((crossing) =>
-            selectedWarningLevelIds.value.includes(
-              crossing.warningLevelId ?? '',
-            ),
-          )
-    return crossings.sort((a, b) => b.severity - a.severity)
-  })
-
-  watch([selectedWarningLevelIds, aggregatedWarningLevels], () => {
-    updateSelectedLevels()
-  })
-
-  watch(aggregatedWarningLevels, () => {
-    updateSelectedLevels()
-  })
-
-  // Update the selected levels based on selected IDs
-  function updateSelectedLevels() {
-    if (selectedWarningLevelIds.value.length === 0) {
-      selectedWarningLevels.value = aggregatedWarningLevels.value
-    } else {
-      selectedWarningLevels.value = aggregatedWarningLevels.value.filter(
-        (level) => selectedWarningLevelIds.value.includes(level.id),
-      )
-    }
-  }
 
   function setTopologyNodeId(id: string | undefined) {
     nodeId.value = id
@@ -124,13 +74,9 @@ export const useWarningLevelsStore = defineStore('warningLevels', () => {
     selectedWarningLevelIds,
     selectedWarningLevels,
     warningLevels,
-    aggregatedWarningLevels,
     thresholds,
-    thresholdCrossings,
-    selectedThresholdCrossings,
-    aggregatedThresholdCrossings,
-    selectedAggregatedThresholdCrossings,
-    showCrossingDetails,
+    crossings,
+    selectedCrossings,
     setTopologyNodeId,
   }
 })


### PR DESCRIPTION
### Description

Add thresholds count by locations or crossings option.
Add labels for levels and crossings.
Add separator for non severe levels.

# Screenshots

<img width="555" height="559" alt="localhost_5173_topology_early_warning_node_viewer_rivers_level_stations_viewer_rivers_level_stations_forecast_map_waterdepth_sfincs_inland_location_Illovo_River_level" src="https://github.com/user-attachments/assets/4d50e11b-325f-4fdd-b689-7ab515b925d6" />



