### PR TITLE
Log level filter uses colors and icons

### DIFF
--- a/src/components/logdisplay/LogDisplayComponent.vue
+++ b/src/components/logdisplay/LogDisplayComponent.vue
@@ -191,7 +191,7 @@ const props = defineProps<Props>()
 
 const search = ref<string>()
 const maxCount = ref<number>(20000)
-const selectedLevels = ref<LogLevel[]>([])
+const selectedLevels = ref<LogLevel[]>([...logLevels])
 const selectedLogTypes = ref<LogType | null>(null)
 
 const daysBack = ref<number>(2)

--- a/src/components/logdisplay/LogDisplayComponent.vue
+++ b/src/components/logdisplay/LogDisplayComponent.vue
@@ -25,13 +25,24 @@
             v-model="selectedLevels"
             :items="logLevels"
             variant="outlined"
+            chips
             clearable
             hide-details
             multiple
             density="compact"
             :item-title="levelToTitle"
             :item-value="(item) => item"
-          />
+          >
+            <template #chip="{ item }">
+              <v-chip
+                :color="levelToColor(item)"
+                label
+                :prepend-icon="levelToIcon(item)"
+              >
+                {{ levelToTitle(item) }}
+              </v-chip>
+            </template>
+          </v-select>
         </v-list-item>
         <v-list-subheader>Date</v-list-subheader>
         <v-list-item>
@@ -149,6 +160,8 @@ import {
   levelToTitle,
   LogDisseminationStatus,
   getLogDisseminationKey,
+  levelToColor,
+  levelToIcon,
 } from '@/lib/log'
 import {
   ForecasterNoteKeysRequest,


### PR DESCRIPTION
### Description

Select all log levels by default. Use chips with color and icon to show selected log levels.

### Screenshots (if applicable)

<img width="349" height="396" alt="localhost_5173_topology_admin_node_viewer_log_system_log_log (3)" src="https://github.com/user-attachments/assets/101c0ad1-4c4b-4e4e-899b-b20c88015ab0" />


