### PR TITLE
fix: default font family settings

### DIFF
--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -1,9 +1,5 @@
 @forward 'vuetify/settings' with (
   $data-table-footer-padding: 0px 4px,
-  $body-font-family: (
-    var(--font-family),
-    sans-serif,
-  ),
   $timeline-item-padding: 12px,
   $color-pack: false
 );


### PR DESCRIPTION
### Description

Default font settings could use a undefined `--font-family` variable. This resulted in a fallback to default sans-serif font in the browser (Times New Roman).