### PR TITLE
feat: add option to include current route in user log message

### DIFF
--- a/src/components/logdisplay/LogMessageItem.vue
+++ b/src/components/logdisplay/LogMessageItem.vue
@@ -108,7 +108,18 @@
         @discard="toggleEditing"
       />
       <v-card-text v-else>
-        <span class="message-text"> {{ log.text }} </span>
+        <span class="message-text">
+          <template v-for="(segment, index) in messageSegments" :key="index">
+            <RouterLink
+              v-if="segment.type === 'route'"
+              :to="segment.to"
+              class="message-route-link"
+            >
+              {{ segment.label }}
+            </RouterLink>
+            <template v-else>{{ segment.text }}</template>
+          </template>
+        </span>
         <v-spacer />
         <slot name="actions"></slot>
       </v-card-text>
@@ -136,6 +147,7 @@ import {
   logToColor,
   logToRoute,
   logToActions,
+  parseLogTextSegments,
   type LogMessage,
   type LogActionEmit,
   type ManualLogLevel,
@@ -163,6 +175,7 @@ const isEditing = ref(false)
 const editedLogLevel = ref<ManualLogLevel>('INFO')
 
 const isAcknowledged = computed(() => props.log.eventAcknowledged)
+const messageSegments = computed(() => parseLogTextSegments(props.log.text))
 
 const canEdit = computed(() => {
   // Allow editing only for manual logs created by the current user

--- a/src/components/logdisplay/NewLogMessage.vue
+++ b/src/components/logdisplay/NewLogMessage.vue
@@ -40,6 +40,18 @@
           </v-list-item>
         </v-list>
       </v-menu>
+      <v-tooltip :text="routeButtonTooltip">
+        <template #activator="{ props: tooltipProps }">
+          <v-btn
+            v-bind="tooltipProps"
+            size="x-small"
+            icon
+            :disabled="isPosting"
+            @click="toggleCurrentRoute"
+            ><v-icon size="small">{{ routeButtonIcon }}</v-icon>
+          </v-btn>
+        </template>
+      </v-tooltip>
       <v-spacer />
       <v-btn
         icon="mdi-close"
@@ -104,6 +116,7 @@
 
 <script setup lang="ts">
 import {
+  createRouteToken,
   levelToColor,
   levelToIcon,
   levelToTitle,
@@ -119,6 +132,7 @@ import {
   type ForecasterNoteGroup,
 } from '@deltares/fews-pi-requests'
 import { computed, ref } from 'vue'
+import { useRoute } from 'vue-router'
 
 type LogEditorMode = 'create' | 'edit'
 
@@ -158,6 +172,17 @@ const newLogLevel = ref<ManualLogLevel>(props.initialLogLevel)
 const postErrorMessage = ref<string>()
 const isPosting = ref(false)
 const isUiExpanded = ref(false)
+const route = useRoute()
+const currentRouteToken = computed(() => createRouteToken(route.fullPath))
+const hasCurrentRouteToken = computed(() =>
+  text.value.includes(currentRouteToken.value),
+)
+const routeButtonTooltip = computed(() =>
+  hasCurrentRouteToken.value ? 'Remove current route' : 'Insert current route',
+)
+const routeButtonIcon = computed(() =>
+  hasCurrentRouteToken.value ? 'mdi-link-off' : 'mdi-link',
+)
 
 const lineCount = computed(() => text.value.split('\n').length)
 const charCount = computed(() =>
@@ -188,6 +213,30 @@ function validateInput() {
 
 function expandUi() {
   isUiExpanded.value = true
+}
+
+function toggleCurrentRoute() {
+  const routeToken = currentRouteToken.value
+
+  if (hasCurrentRouteToken.value) {
+    text.value = text.value
+      .split(routeToken)
+      .join('')
+      .replace(/ {2,}/g, ' ')
+      .replace(/\n{3,}/g, '\n\n')
+      .trimEnd()
+    validateInput()
+    return
+  }
+
+  const separator =
+    text.value.length > 0 &&
+    !text.value.endsWith(' ') &&
+    !text.value.endsWith('\n')
+      ? ' '
+      : ''
+  text.value = `${text.value}${separator}${routeToken}`
+  validateInput()
 }
 
 async function handleClick(event: MouseEvent) {

--- a/src/lib/log/utils.ts
+++ b/src/lib/log/utils.ts
@@ -140,6 +140,57 @@ export function logToRoute(log: LogMessage) {
   }
 }
 
+const routeTokenRegex = /\[\[route:(.+?)\]\]/g
+
+export type LogTextSegment =
+  | { type: 'text'; text: string }
+  | { type: 'route'; to: string; label: string }
+
+export function createRouteToken(routePath: string) {
+  return `[[route:${routePath}]]`
+}
+
+export function parseLogTextSegments(text: string): LogTextSegment[] {
+  const segments: LogTextSegment[] = []
+  let lastIndex = 0
+
+  for (const match of text.matchAll(routeTokenRegex)) {
+    const token = match[0]
+    const routePath = match[1]?.trim()
+    const matchIndex = match.index ?? -1
+
+    if (matchIndex < 0 || !routePath) continue
+
+    if (matchIndex > lastIndex) {
+      segments.push({
+        type: 'text',
+        text: text.slice(lastIndex, matchIndex),
+      })
+    }
+
+    segments.push({
+      type: 'route',
+      to: routePath,
+      label: routePath,
+    })
+
+    lastIndex = matchIndex + token.length
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({
+      type: 'text',
+      text: text.slice(lastIndex),
+    })
+  }
+
+  if (segments.length === 0) {
+    return [{ type: 'text', text }]
+  }
+
+  return segments
+}
+
 export function logToUser(log: LogMessage, userName: string) {
   if (log.type === 'system') return log.code
   return isLogMessageByCurrentUser(log, userName) ? 'You' : log.user

--- a/tests/unit/lib/log.utils.test.ts
+++ b/tests/unit/lib/log.utils.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { createRouteToken, parseLogTextSegments } from '@/lib/log/utils'
+
+describe('log route token helpers', () => {
+  describe('createRouteToken', () => {
+    it('creates a route token with the provided path', () => {
+      expect(createRouteToken('/topology/abc/node/def?tab=log')).toBe(
+        '[[route:/topology/abc/node/def?tab=log]]',
+      )
+    })
+  })
+
+  describe('parseLogTextSegments', () => {
+    it('returns a single text segment when no route token exists', () => {
+      expect(parseLogTextSegments('Plain message')).toEqual([
+        { type: 'text', text: 'Plain message' },
+      ])
+    })
+
+    it('parses one route token between text segments', () => {
+      expect(
+        parseLogTextSegments('Check [[route:/topology/1/node/A/log]] now'),
+      ).toEqual([
+        { type: 'text', text: 'Check ' },
+        {
+          type: 'route',
+          to: '/topology/1/node/A/log',
+          label: '/topology/1/node/A/log',
+        },
+        { type: 'text', text: ' now' },
+      ])
+    })
+
+    it('parses multiple route tokens in one message', () => {
+      expect(
+        parseLogTextSegments(
+          'Before [[route:/topology/1]] middle [[route:/map/location/X]] after',
+        ),
+      ).toEqual([
+        { type: 'text', text: 'Before ' },
+        { type: 'route', to: '/topology/1', label: '/topology/1' },
+        { type: 'text', text: ' middle ' },
+        { type: 'route', to: '/map/location/X', label: '/map/location/X' },
+        { type: 'text', text: ' after' },
+      ])
+    })
+
+    it('keeps malformed empty route tokens as plain text', () => {
+      expect(parseLogTextSegments('Broken [[route:   ]] token')).toEqual([
+        { type: 'text', text: 'Broken [[route:   ]] token' },
+      ])
+    })
+  })
+})


### PR DESCRIPTION
### Description

Add option to include the current route in a user message. The link can be used to navigate to the route.

### Screenshots (if applicable)

<img width="434" height="130" alt="localhost_5173_topology_topologyDisplay_node_Salinity_map_SalinitySrmFm3D_coordinates_1 152_104 311 (1)" src="https://github.com/user-attachments/assets/23063228-0794-4891-a52b-48aa1362d5f4" />

<img width="420" height="132" alt="localhost_5173_topology_topologyDisplay_node_Salinity_map_SalinitySrmFm3D_coordinates_1 152_104 311" src="https://github.com/user-attachments/assets/edc6c977-5ba0-44ce-b684-27f01531c908" />

