### PR TITLE
fix: re-enable thinning option for brush chart time series

### DIFF
--- a/src/components/timeseries/TimeSeriesComponent.vue
+++ b/src/components/timeseries/TimeSeriesComponent.vue
@@ -264,6 +264,7 @@ const chartOptions = computed<UseTimeSeriesOptions>(() => {
 const brushOptions = computed<UseTimeSeriesOptions>(() => ({
   startTime: fullBrushDomain.value[0],
   endTime: fullBrushDomain.value[1],
+  thinning: true,
 }))
 
 const tableOptions = computed<UseTimeSeriesOptions>(() => ({


### PR DESCRIPTION
### Description

Re-enable thinning on brush chart timeseries requests. It was incorrectly removed in #2040 
