### PR TITLE
Maximize time series window for schematic status display

### DIFF
--- a/src/components/ssd/SchematicStatusDisplay.vue
+++ b/src/components/ssd/SchematicStatusDisplay.vue
@@ -1,10 +1,6 @@
 <template>
   <div class="container" ref="container">
-    <div
-      class="child-container"
-      :class="{ 'd-none': hideSSD }"
-      ref="ssdContainer"
-    >
+    <div class="child-container" v-show="!hideSSD" ref="ssdContainer">
       <SsdComponent
         :src="src"
         :key="panelId"
@@ -26,7 +22,21 @@
         :panelId="panelId"
         :objectId="objectId"
         @close="closeTimeSeriesDisplay"
-      />
+      >
+        <template #toolbar-append>
+          <v-btn
+            v-if="!mobile"
+            size="small"
+            :icon="maximized ? 'mdi-fullscreen-exit' : 'mdi-fullscreen'"
+            @click="maximized = !maximized"
+          />
+          <v-btn
+            size="small"
+            icon="mdi-close"
+            @click="closeTimeSeriesDisplay"
+          />
+        </template>
+      </SSDTimeSeriesDisplay>
     </div>
   </div>
 </template>
@@ -127,8 +137,15 @@ const { src } = useSsd(
   () => debouncedDateString.value,
 )
 
+const maximized = ref(false)
+
+const { width: containerWidth } = useElementSize(container)
+const mobile = computed(() => {
+  return containerWidth.value < thresholds.value.md
+})
+
 const hideSSD = computed(() => {
-  return mobile.value && props.objectId !== ''
+  return maximized.value || (mobile.value && props.objectId !== '')
 })
 
 const { width: ssdContainerWidth } = useElementSize(ssdContainer)
@@ -137,11 +154,6 @@ const ssdMobile = computed(() => {
 })
 watch(ssdContainerWidth, () => {
   ssdComponent.value?.resize()
-})
-
-const { width: containerWidth } = useElementSize(container)
-const mobile = computed(() => {
-  return containerWidth.value < thresholds.value.md
 })
 
 function onAction(event: CustomEvent<SsdActionEventPayload>): void {
@@ -227,6 +239,7 @@ function openTimeSeriesDisplay(panelId: string, objectId: string) {
 }
 
 function closeTimeSeriesDisplay(): void {
+  maximized.value = false
   const to = {
     name: 'SchematicStatusDisplay',
     params: { groupId: props.groupId, panelId: props.panelId },

--- a/src/components/ssd/SsdTimeSeriesDisplay.vue
+++ b/src/components/ssd/SsdTimeSeriesDisplay.vue
@@ -19,9 +19,7 @@
       <v-spacer />
     </template>
     <template v-slot:toolbar-append>
-      <v-btn size="small" variant="text" @click="onClose">
-        <v-icon size="small">mdi-close</v-icon>
-      </v-btn>
+      <slot name="toolbar-append" />
     </template>
     <TimeSeriesComponent :config="displayConfig" :displayType="displayType">
     </TimeSeriesComponent>


### PR DESCRIPTION
### Description

The time series window for the schematic status display can be maximized in the same way as in the map display.

### Screenshots (if applicable)

<img width="1100" height="787" alt="Screenshot_30-7-2026_11226_localhost" src="https://github.com/user-attachments/assets/fa575353-f6ee-4bea-a899-c0e1237e8307" />

