### PR TITLE
fix: adjust chart controls style to prevent margin issues

### DIFF
--- a/src/components/charts/ChartLegend.vue
+++ b/src/components/charts/ChartLegend.vue
@@ -133,11 +133,11 @@ function toggleLine(tag: Tag) {
 
 const chipMargin = 8
 const chartControlsStyle = computed(() => {
-  const { left = 0, right = 0, top = 0, bottom = 0 } = props.margin
+  const { left = 0, right = 0 } = props.margin
 
   const maxHeight =
     expanded.value || !requiresExpand.value
-      ? `min(${legendHeight.value + 2}px, calc(100% - ${top + bottom}px))`
+      ? `${legendHeight.value + 2}px`
       : `${height.value + 2}px`
 
   const marginRight = right ? `${right - chipMargin}px` : undefined


### PR DESCRIPTION
### Description

Fix: Chart legend above the chart was no longer expanding on toggle, but a scrollbar was shown.