### PR TITLE
Invert draw order of shown layers in the overlay panel

### DIFF
--- a/src/components/wms/panel/OverlayPanel.vue
+++ b/src/components/wms/panel/OverlayPanel.vue
@@ -81,7 +81,12 @@ interface Props {
 }
 
 const props = defineProps<Props>()
-const overlays = defineModel<Overlay[]>('overlays')
+// UI displays topmost overlay first, but style.json stores it last
+// This mismatch requires bidirectional reversal in both get/set accessors
+const overlays = defineModel<Overlay[]>('overlays', {
+  get: (overlays) => [...overlays].reverse(),
+  set: (overlays) => [...overlays].reverse(),
+})
 
 function getTitle(overlay: Overlay): string {
   if (overlay.type === 'gridLayer') {


### PR DESCRIPTION
### Description
Invert draw order of shown layers in the overlay panel

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.