### PR TITLE
Prevent scrollbar from showing for multi line document titles

### DIFF
--- a/src/components/products/ProductView.vue
+++ b/src/components/products/ProductView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="d-flex flex-row h-100 w-100">
-    <v-navigation-drawer v-model="drawer" :width="600">
+    <v-navigation-drawer v-model="drawer" :width="650">
       <ProductsBrowserTable
         v-if="tableConfig"
         :products="filteredProducts"

--- a/src/components/products/ProductsBrowserTable.vue
+++ b/src/components/products/ProductsBrowserTable.vue
@@ -107,7 +107,7 @@
           <tr>
             <template v-for="(column, index) in columns" :key="column.key">
               <th v-if="index === 0" scope="col"></th>
-              <th v-else-if="column.key === 'actions'" scope="col" class="pa-0">
+              <th v-else-if="column.key === 'actions'" scope="col">
                 <v-btn icon size="small" variant="plain">
                   <v-icon icon="mdi-dots-vertical" />
                   <v-menu


### PR DESCRIPTION
### Description
Prevent scrollbar from showing for multi line document titles

### Checklist
- [x] Make the title short and concise
- [x] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [x] Update documentation.
- [x] Update tests.
