### PR TITLE
Combine import and export status views into unified overview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "fews-weboc",
       "version": "1.5.0-rc.0",
       "dependencies": {
-        "@deltares/fews-pi-requests": "3.0.1",
+        "@deltares/fews-pi-requests": "^3.1.0",
         "@deltares/fews-ssd-requests": "^2.0.0",
         "@deltares/fews-ssd-webcomponent": "^2.0.0",
         "@deltares/fews-web-oc-charts": "^4.7.2",
@@ -409,9 +409,9 @@
       }
     },
     "node_modules/@deltares/fews-pi-requests": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@deltares/fews-pi-requests/-/fews-pi-requests-3.0.1.tgz",
-      "integrity": "sha512-CYDPEVHkOOpfwZuz42j1JEeO/O/Kg5isJ+sfu5qhlnjmR3i37W26+pHx7RSWTFgIQQmsEtFsqrXOi4kLNM2lUA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@deltares/fews-pi-requests/-/fews-pi-requests-3.1.0.tgz",
+      "integrity": "sha512-PVDzRwtnrMxz79VzExhPQH6q5oeCYTcdwEhSIb1y0ZyJjAYo95gWz/1o2r9vlojf4W51BPF6YMY3Crmd7VgRcw==",
       "license": "MIT",
       "dependencies": {
         "@deltares/fews-web-oc-utils": "^2.1.1"
@@ -442,18 +442,6 @@
         "@deltares/fews-pi-requests": "^3.0.1",
         "@deltares/fews-ssd-requests": "^2.0.0-rc.3",
         "@stencil/core": "^4.43.5"
-      }
-    },
-    "node_modules/@deltares/fews-ssd-webcomponent/node_modules/@deltares/fews-pi-requests": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@deltares/fews-pi-requests/-/fews-pi-requests-3.0.1.tgz",
-      "integrity": "sha512-CYDPEVHkOOpfwZuz42j1JEeO/O/Kg5isJ+sfu5qhlnjmR3i37W26+pHx7RSWTFgIQQmsEtFsqrXOi4kLNM2lUA==",
-      "license": "MIT",
-      "dependencies": {
-        "@deltares/fews-web-oc-utils": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=22.0.0"
       }
     },
     "node_modules/@deltares/fews-web-oc-charts": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "sonar": "sonar-scanner -Dsonar.host.url=$SONAR_URL -Dsonar.login=$SONAR_TOKEN -Dsonar.projectKey=$SONAR_KEY -Dsonar.projectName='Delft-FEWS Web OC'"
   },
   "dependencies": {
-    "@deltares/fews-pi-requests": "3.0.1",
+    "@deltares/fews-pi-requests": "^3.1.0",
     "@deltares/fews-ssd-requests": "^2.0.0",
     "@deltares/fews-ssd-webcomponent": "^2.0.0",
     "@deltares/fews-web-oc-charts": "^4.7.2",

--- a/src/components/sidepanel/ImportStatusSidePanel.vue
+++ b/src/components/sidepanel/ImportStatusSidePanel.vue
@@ -1,6 +1,9 @@
 <template>
   <SidePanelContent :title="t('sidePanel.importStatus')" @close="emit('close')">
-    <ImportStatusControl :topology-node="topologyNode" />
+    <ImportStatusControl
+      :topology-node="topologyNode"
+      @open-log-task-run="emit('openLogTaskRun', $event)"
+    />
   </SidePanelContent>
 </template>
 
@@ -20,6 +23,7 @@ defineProps<Props>()
 
 interface Emits {
   close: []
+  openLogTaskRun: [taskRunId: string]
 }
 const emit = defineEmits<Emits>()
 </script>

--- a/src/components/sidepanel/ImportStatusSidePanel.vue
+++ b/src/components/sidepanel/ImportStatusSidePanel.vue
@@ -1,25 +1,16 @@
 <template>
   <SidePanelContent :title="t('sidePanel.importStatus')" @close="emit('close')">
-    <ImportStatusControl
-      :topology-node="topologyNode"
-      @open-log-task-run="emit('openLogTaskRun', $event)"
-    />
+    <ImportStatusControl @open-log-task-run="emit('openLogTaskRun', $event)" />
   </SidePanelContent>
 </template>
 
 <script setup lang="ts">
-import type { TopologyNode } from '@deltares/fews-pi-requests'
 import { useI18n } from 'vue-i18n'
 
 import SidePanelContent from './SidePanelContent.vue'
 import ImportStatusControl from '@/components/systemmonitor/ImportStatusControl.vue'
 
 const { t } = useI18n()
-
-interface Props {
-  topologyNode?: TopologyNode
-}
-defineProps<Props>()
 
 interface Emits {
   close: []

--- a/src/components/sidepanel/ImportStatusSidePanel.vue
+++ b/src/components/sidepanel/ImportStatusSidePanel.vue
@@ -5,12 +5,18 @@
 </template>
 
 <script setup lang="ts">
+import type { TopologyNode } from '@deltares/fews-pi-requests'
 import { useI18n } from 'vue-i18n'
 
 import SidePanelContent from './SidePanelContent.vue'
 import ImportStatusControl from '@/components/systemmonitor/ImportStatusControl.vue'
 
 const { t } = useI18n()
+
+interface Props {
+  topologyNode?: TopologyNode
+}
+defineProps<Props>()
 
 interface Emits {
   close: []

--- a/src/components/sidepanel/LogSidePanel.vue
+++ b/src/components/sidepanel/LogSidePanel.vue
@@ -144,6 +144,7 @@ interface Props {
   topologyNode?: TopologyNode
   settings: {
     logDisplayId: string
+    taskRunId?: string
   }
 }
 
@@ -242,9 +243,11 @@ const filters = computed(() => {
 })
 
 const debouncedFilters = refDebounced(filters, requestDebounce)
+const selectedTaskRunId = computed(() => props.settings.taskRunId?.trim() ?? '')
 
 const customFilter = (log: LogMessage) =>
   Boolean(
+    (!selectedTaskRunId.value || log.taskRunId === selectedTaskRunId.value) &&
     filterLog(
       log,
       debouncedSelectedLevels.value,

--- a/src/components/systemmonitor/ImportStatusComponent.vue
+++ b/src/components/systemmonitor/ImportStatusComponent.vue
@@ -2,21 +2,25 @@
   <v-data-table
     :headers="headers"
     :items-per-page="100"
-    :items="importStatus"
+    :items="statusItems"
     fixed-header
   >
-    <template v-slot:[`item.lastImportTime`]="{ item }">
+    <template v-slot:[`item.lastSuccessfulTime`]="{ item }">
       <v-chip
         size="small"
-        :color="item.lastImportTimeBackgroundColor"
+        :color="item.lastSuccessfulTimeBackgroundColor"
         variant="flat"
       >
-        {{ item.lastImportTime }}
+        {{ item.lastSuccessfulTime }}
       </v-chip>
     </template>
-    <template v-slot:[`item.fileFailed`]="{ item }">
-      <v-chip size="small" :color="getColor(item.fileFailed)" variant="flat">
-        {{ item.fileFailed }}
+    <template v-slot:[`item.filesFailedCount`]="{ item }">
+      <v-chip
+        size="small"
+        :color="getColor(item.filesFailedCount)"
+        variant="flat"
+      >
+        {{ item.filesFailedCount }}
       </v-chip>
     </template>
     <template #bottom>
@@ -26,11 +30,16 @@
 </template>
 
 <script setup lang="ts">
-import { ImportStatus, PiWebserviceProvider } from '@deltares/fews-pi-requests'
+import {
+  PiWebserviceProvider,
+  type ExportStatus,
+  type ImportStatus,
+} from '@deltares/fews-pi-requests'
 import { onMounted, onUnmounted, ref } from 'vue'
 import { configManager } from '@/services/application-config'
 import { createTransformRequestFn } from '@/lib/requests/transformRequest'
 import type { ReadonlyDataTableHeader } from '@/lib/table/types/TableHeaders'
+import type { ImportExportStatusItem } from './statusTypes'
 
 interface Props {
   timeOut: number
@@ -38,14 +47,15 @@ interface Props {
 const props = defineProps<Props>()
 
 const headers: ReadonlyDataTableHeader[] = [
+  { title: 'Type', key: 'statusType' },
   { title: 'Source', key: 'dataFeed' },
   { title: 'Directory', key: 'directory' },
-  { title: 'Last import time', key: 'lastImportTime' },
-  { title: 'Last file imported', key: 'lastFileImported' },
-  { title: 'Files imported', key: 'fileRead' },
-  { title: 'Failed imports', key: 'fileFailed' },
+  { title: 'Last successful time', key: 'lastSuccessfulTime' },
+  { title: 'Last file', key: 'lastSuccessfulFile' },
+  { title: 'Files successful', key: 'filesSuccessfulCount' },
+  { title: 'Failed files', key: 'filesFailedCount' },
 ]
-const importStatus = ref<ImportStatus[]>([])
+const statusItems = ref<ImportExportStatusItem[]>([])
 let active: boolean = false
 
 const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
@@ -59,7 +69,7 @@ onUnmounted(() => {
 
 onMounted(async () => {
   active = true
-  await loadImportStatus()
+  await loadStatuses()
 })
 
 function getColor(failure: number): string {
@@ -67,15 +77,39 @@ function getColor(failure: number): string {
   return 'red'
 }
 
-async function loadImportStatus() {
+function normalizeStatuses(
+  items: (ImportStatus | ExportStatus)[],
+  statusType: 'import' | 'export',
+): ImportExportStatusItem[] {
+  return items.map((item) => ({
+    ...item,
+    statusType,
+  }))
+}
+
+async function loadStatuses() {
   try {
     if (!active) return
-    const res = await webServiceProvider.getImportStatus()
-    importStatus.value = res.importStatus
+
+    const [importResult, exportResult] = await Promise.allSettled([
+      webServiceProvider.getImportStatus(),
+      webServiceProvider.getExportStatus(),
+    ])
+
+    const importItems =
+      importResult.status === 'fulfilled'
+        ? normalizeStatuses(importResult.value.importStatus, 'import')
+        : []
+    const exportItems =
+      exportResult.status === 'fulfilled'
+        ? normalizeStatuses(exportResult.value.exportStatus, 'export')
+        : []
+
+    statusItems.value = [...importItems, ...exportItems]
   } catch (error) {
     console.warn(error)
   } finally {
-    setTimeout(loadImportStatus, props.timeOut)
+    setTimeout(loadStatuses, props.timeOut)
   }
 }
 </script>

--- a/src/components/systemmonitor/ImportStatusComponent.vue
+++ b/src/components/systemmonitor/ImportStatusComponent.vue
@@ -30,16 +30,9 @@
 </template>
 
 <script setup lang="ts">
-import {
-  PiWebserviceProvider,
-  type ExportStatus,
-  type ImportStatus,
-} from '@deltares/fews-pi-requests'
-import { onMounted, onUnmounted, ref } from 'vue'
-import { configManager } from '@/services/application-config'
-import { createTransformRequestFn } from '@/lib/requests/transformRequest'
+import { onMounted, onUnmounted } from 'vue'
 import type { ReadonlyDataTableHeader } from '@/lib/table/types/TableHeaders'
-import type { ImportExportStatusItem } from './statusTypes'
+import { useImportExportStatus } from './useImportExportStatus'
 
 interface Props {
   timeOut: number
@@ -55,61 +48,20 @@ const headers: ReadonlyDataTableHeader[] = [
   { title: 'Files successful', key: 'filesSuccessfulCount' },
   { title: 'Failed files', key: 'filesFailedCount' },
 ]
-const statusItems = ref<ImportExportStatusItem[]>([])
-let active: boolean = false
-
-const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
-const webServiceProvider = new PiWebserviceProvider(baseUrl, {
-  transformRequestFn: createTransformRequestFn(),
+const { statusItems, startPolling, stopPolling } = useImportExportStatus({
+  pollIntervalMs: props.timeOut,
 })
 
 onUnmounted(() => {
-  active = false
+  stopPolling()
 })
 
 onMounted(async () => {
-  active = true
-  await loadStatuses()
+  await startPolling()
 })
 
 function getColor(failure: number): string {
   if (failure == 0) return 'grey'
   return 'red'
-}
-
-function normalizeStatuses(
-  items: (ImportStatus | ExportStatus)[],
-  statusType: 'import' | 'export',
-): ImportExportStatusItem[] {
-  return items.map((item) => ({
-    ...item,
-    statusType,
-  }))
-}
-
-async function loadStatuses() {
-  try {
-    if (!active) return
-
-    const [importResult, exportResult] = await Promise.allSettled([
-      webServiceProvider.getImportStatus(),
-      webServiceProvider.getExportStatus(),
-    ])
-
-    const importItems =
-      importResult.status === 'fulfilled'
-        ? normalizeStatuses(importResult.value.importStatus, 'import')
-        : []
-    const exportItems =
-      exportResult.status === 'fulfilled'
-        ? normalizeStatuses(exportResult.value.exportStatus, 'export')
-        : []
-
-    statusItems.value = [...importItems, ...exportItems]
-  } catch (error) {
-    console.warn(error)
-  } finally {
-    setTimeout(loadStatuses, props.timeOut)
-  }
 }
 </script>

--- a/src/components/systemmonitor/ImportStatusControl.vue
+++ b/src/components/systemmonitor/ImportStatusControl.vue
@@ -1,8 +1,8 @@
 <template>
   <v-virtual-scroll
-    v-if="importStatusItems.length"
+    v-if="statusItems.length"
     class="overflow-y-auto h-100"
-    :items="importStatusItems"
+    :items="statusItems"
     :item-height="62"
   >
     <template #default="{ item }">
@@ -17,14 +17,17 @@
 </template>
 
 <script setup lang="ts">
-import { PiWebserviceProvider } from '@deltares/fews-pi-requests'
+import {
+  PiWebserviceProvider,
+  type ExportStatus,
+  type ImportStatus,
+} from '@deltares/fews-pi-requests'
 import { onMounted, onUnmounted, ref } from 'vue'
 import { configManager } from '@/services/application-config'
 import { createTransformRequestFn } from '@/lib/requests/transformRequest'
 import type { TopologyNode } from '@deltares/fews-pi-requests'
-import ImportStatusSummary, {
-  type ImportStatusDirectory,
-} from './ImportStatusSummary.vue'
+import type { ImportExportStatusItem } from './statusTypes'
+import ImportStatusSummary from './ImportStatusSummary.vue'
 
 interface Props {
   topologyNode?: TopologyNode
@@ -32,7 +35,7 @@ interface Props {
 
 defineProps<Props>()
 
-const importStatusItems = ref<ImportStatusDirectory[]>([])
+const statusItems = ref<ImportExportStatusItem[]>([])
 const expandedItems = ref<Record<string, boolean>>({})
 let active: boolean = false
 
@@ -47,18 +50,42 @@ onUnmounted(() => {
 
 onMounted(async () => {
   active = true
-  await loadImportStatus()
+  await loadStatuses()
 })
 
-async function loadImportStatus() {
+function normalizeStatuses(
+  items: (ImportStatus | ExportStatus)[],
+  statusType: 'import' | 'export',
+): ImportExportStatusItem[] {
+  return items.map((item) => ({
+    ...item,
+    statusType,
+  }))
+}
+
+async function loadStatuses() {
   try {
     if (!active) return
-    const res = await webServiceProvider.getImportStatus()
-    importStatusItems.value = res.importStatus as ImportStatusDirectory[]
+
+    const [importResult, exportResult] = await Promise.allSettled([
+      webServiceProvider.getImportStatus(),
+      webServiceProvider.getExportStatus(),
+    ])
+
+    const importItems =
+      importResult.status === 'fulfilled'
+        ? normalizeStatuses(importResult.value.importStatus, 'import')
+        : []
+    const exportItems =
+      exportResult.status === 'fulfilled'
+        ? normalizeStatuses(exportResult.value.exportStatus, 'export')
+        : []
+
+    statusItems.value = [...importItems, ...exportItems]
   } catch (error) {
     console.warn(error)
   } finally {
-    setTimeout(loadImportStatus, 10000)
+    setTimeout(loadStatuses, 10000)
   }
 }
 </script>

--- a/src/components/systemmonitor/ImportStatusControl.vue
+++ b/src/components/systemmonitor/ImportStatusControl.vue
@@ -24,6 +24,7 @@
           <ImportStatusSummary
             :item="item"
             v-model:expanded="expandedItems[item.dataFeed]"
+            @open-log-task-run="emit('openLogTaskRun', $event)"
           />
         </div>
       </template>
@@ -36,11 +37,11 @@ import {
   PiWebserviceProvider,
   type ExportStatus,
   type ImportStatus,
+  type TopologyNode,
 } from '@deltares/fews-pi-requests'
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { configManager } from '@/services/application-config'
 import { createTransformRequestFn } from '@/lib/requests/transformRequest'
-import type { TopologyNode } from '@deltares/fews-pi-requests'
 import BaseTaskFilterControl from '@/components/tasks/BaseTaskFilterControl.vue'
 import type {
   ImportExportStatusItem,
@@ -54,6 +55,11 @@ interface Props {
 }
 
 defineProps<Props>()
+
+interface Emits {
+  openLogTaskRun: [taskRunId: string]
+}
+const emit = defineEmits<Emits>()
 
 const statusItems = ref<ImportExportStatusItem[]>([])
 const expandedItems = ref<Record<string, boolean>>({})

--- a/src/components/systemmonitor/ImportStatusControl.vue
+++ b/src/components/systemmonitor/ImportStatusControl.vue
@@ -1,19 +1,34 @@
 <template>
-  <v-virtual-scroll
-    v-if="statusItems.length"
-    class="overflow-y-auto h-100"
-    :items="statusItems"
-    :item-height="62"
-  >
-    <template #default="{ item }">
-      <div class="my-1 mx-2">
-        <ImportStatusSummary
-          :item="item"
-          v-model:expanded="expandedItems[item.dataFeed]"
-        />
-      </div>
-    </template>
-  </v-virtual-scroll>
+  <div class="status-panel h-100 d-flex flex-column">
+    <div class="d-flex pt-3 pb-2 align-center flex-shrink-0">
+      <BaseTaskFilterControl
+        v-model="selectedSources"
+        :items="sourceFilterOptions"
+        label="Source"
+      />
+      <BaseTaskFilterControl
+        v-model="selectedResults"
+        :items="resultFilterOptions"
+        label="Status"
+      />
+    </div>
+
+    <v-virtual-scroll
+      v-if="filteredStatusItems.length"
+      class="overflow-y-auto flex-grow-1"
+      :items="filteredStatusItems"
+      :item-height="62"
+    >
+      <template #default="{ item }">
+        <div class="my-1 mx-2">
+          <ImportStatusSummary
+            :item="item"
+            v-model:expanded="expandedItems[item.dataFeed]"
+          />
+        </div>
+      </template>
+    </v-virtual-scroll>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -22,11 +37,16 @@ import {
   type ExportStatus,
   type ImportStatus,
 } from '@deltares/fews-pi-requests'
-import { onMounted, onUnmounted, ref } from 'vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { configManager } from '@/services/application-config'
 import { createTransformRequestFn } from '@/lib/requests/transformRequest'
 import type { TopologyNode } from '@deltares/fews-pi-requests'
-import type { ImportExportStatusItem } from './statusTypes'
+import BaseTaskFilterControl from '@/components/tasks/BaseTaskFilterControl.vue'
+import type {
+  ImportExportStatusItem,
+  StatusResultFilter,
+  StatusSource,
+} from './statusTypes'
 import ImportStatusSummary from './ImportStatusSummary.vue'
 
 interface Props {
@@ -37,11 +57,44 @@ defineProps<Props>()
 
 const statusItems = ref<ImportExportStatusItem[]>([])
 const expandedItems = ref<Record<string, boolean>>({})
+const selectedSources = ref<StatusSource[]>(['import', 'export'])
+const selectedResults = ref<StatusResultFilter[]>([
+  'successful',
+  'unsuccessful',
+])
 let active: boolean = false
+
+const sourceFilterOptions: Array<{
+  id: string
+  title: string
+  value: StatusSource
+}> = [
+  { id: 'import', title: 'Import', value: 'import' },
+  { id: 'export', title: 'Export', value: 'export' },
+]
+
+const resultFilterOptions: Array<{
+  id: string
+  title: string
+  value: StatusResultFilter
+}> = [
+  { id: 'successful', title: 'Successful', value: 'successful' },
+  { id: 'unsuccessful', title: 'Unsuccessful', value: 'unsuccessful' },
+]
 
 const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
 const webServiceProvider = new PiWebserviceProvider(baseUrl, {
   transformRequestFn: createTransformRequestFn(),
+})
+
+const filteredStatusItems = computed<ImportExportStatusItem[]>(() => {
+  return statusItems.value.filter((item) => {
+    const sourceMatches = selectedSources.value.includes(item.statusType)
+    const resultType: StatusResultFilter =
+      item.filesFailedCount > 0 ? 'unsuccessful' : 'successful'
+    const resultMatches = selectedResults.value.includes(resultType)
+    return sourceMatches && resultMatches
+  })
 })
 
 onUnmounted(() => {
@@ -89,3 +142,9 @@ async function loadStatuses() {
   }
 }
 </script>
+
+<style scoped>
+.status-panel {
+  min-height: 0;
+}
+</style>

--- a/src/components/systemmonitor/ImportStatusControl.vue
+++ b/src/components/systemmonitor/ImportStatusControl.vue
@@ -33,15 +33,8 @@
 </template>
 
 <script setup lang="ts">
-import {
-  PiWebserviceProvider,
-  type ExportStatus,
-  type ImportStatus,
-  type TopologyNode,
-} from '@deltares/fews-pi-requests'
+import { type TopologyNode } from '@deltares/fews-pi-requests'
 import { computed, onMounted, onUnmounted, ref } from 'vue'
-import { configManager } from '@/services/application-config'
-import { createTransformRequestFn } from '@/lib/requests/transformRequest'
 import BaseTaskFilterControl from '@/components/tasks/BaseTaskFilterControl.vue'
 import type {
   ImportExportStatusItem,
@@ -49,6 +42,7 @@ import type {
   StatusSource,
 } from './statusTypes'
 import ImportStatusSummary from './ImportStatusSummary.vue'
+import { useImportExportStatus } from './useImportExportStatus'
 
 interface Props {
   topologyNode?: TopologyNode
@@ -61,14 +55,15 @@ interface Emits {
 }
 const emit = defineEmits<Emits>()
 
-const statusItems = ref<ImportExportStatusItem[]>([])
+const { statusItems, startPolling, stopPolling } = useImportExportStatus({
+  pollIntervalMs: 10000,
+})
 const expandedItems = ref<Record<string, boolean>>({})
 const selectedSources = ref<StatusSource[]>(['import', 'export'])
 const selectedResults = ref<StatusResultFilter[]>([
   'successful',
   'unsuccessful',
 ])
-let active: boolean = false
 
 const sourceFilterOptions: Array<{
   id: string
@@ -88,11 +83,6 @@ const resultFilterOptions: Array<{
   { id: 'unsuccessful', title: 'Unsuccessful', value: 'unsuccessful' },
 ]
 
-const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
-const webServiceProvider = new PiWebserviceProvider(baseUrl, {
-  transformRequestFn: createTransformRequestFn(),
-})
-
 const filteredStatusItems = computed<ImportExportStatusItem[]>(() => {
   return statusItems.value.filter((item) => {
     const sourceMatches = selectedSources.value.includes(item.statusType)
@@ -104,49 +94,12 @@ const filteredStatusItems = computed<ImportExportStatusItem[]>(() => {
 })
 
 onUnmounted(() => {
-  active = false
+  stopPolling()
 })
 
 onMounted(async () => {
-  active = true
-  await loadStatuses()
+  await startPolling()
 })
-
-function normalizeStatuses(
-  items: (ImportStatus | ExportStatus)[],
-  statusType: 'import' | 'export',
-): ImportExportStatusItem[] {
-  return items.map((item) => ({
-    ...item,
-    statusType,
-  }))
-}
-
-async function loadStatuses() {
-  try {
-    if (!active) return
-
-    const [importResult, exportResult] = await Promise.allSettled([
-      webServiceProvider.getImportStatus(),
-      webServiceProvider.getExportStatus(),
-    ])
-
-    const importItems =
-      importResult.status === 'fulfilled'
-        ? normalizeStatuses(importResult.value.importStatus, 'import')
-        : []
-    const exportItems =
-      exportResult.status === 'fulfilled'
-        ? normalizeStatuses(exportResult.value.exportStatus, 'export')
-        : []
-
-    statusItems.value = [...importItems, ...exportItems]
-  } catch (error) {
-    console.warn(error)
-  } finally {
-    setTimeout(loadStatuses, 10000)
-  }
-}
 </script>
 
 <style scoped>

--- a/src/components/systemmonitor/ImportStatusControl.vue
+++ b/src/components/systemmonitor/ImportStatusControl.vue
@@ -33,7 +33,6 @@
 </template>
 
 <script setup lang="ts">
-import { type TopologyNode } from '@deltares/fews-pi-requests'
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import BaseTaskFilterControl from '@/components/tasks/BaseTaskFilterControl.vue'
 import type {
@@ -43,12 +42,6 @@ import type {
 } from './statusTypes'
 import ImportStatusSummary from './ImportStatusSummary.vue'
 import { useImportExportStatus } from './useImportExportStatus'
-
-interface Props {
-  topologyNode?: TopologyNode
-}
-
-defineProps<Props>()
 
 interface Emits {
   openLogTaskRun: [taskRunId: string]

--- a/src/components/systemmonitor/ImportStatusSummary.story.ts
+++ b/src/components/systemmonitor/ImportStatusSummary.story.ts
@@ -1,0 +1,102 @@
+import { defineComponent, h, ref } from 'vue'
+import ImportStatusSummary from './ImportStatusSummary.vue'
+import type { ImportExportStatusItem } from './statusTypes'
+import { useConfigStore } from '@/stores/config'
+
+const baseItem: ImportExportStatusItem = {
+  mcId: 'mc-1',
+  taskRunId: 'task-run-1',
+  workflowId: 'wf-1',
+  workflowName: 'Workflow 1',
+  directory: '/import/dir',
+  dataFeed: 'feed-1',
+  dataFeedName: 'Feed Name 1',
+  dataFeedDescription: 'Feed description 1',
+  lastSuccessfulTime: '2026-01-01T12:00:00Z',
+  lastSuccessfulFile: 'last-successful-file.csv',
+  filesSuccessfulCount: 4,
+  filesFailedCount: 1,
+  status: 'OK',
+  statusType: 'import',
+}
+
+function configureLogPanel(enabled: boolean) {
+  const configStore = useConfigStore()
+  configStore.general = {
+    ...configStore.general,
+    sidePanel: {
+      ...configStore.general.sidePanel,
+      logDisplay: {
+        enabled,
+        logDisplayId: 'log-display-1',
+      },
+    },
+  }
+}
+
+export const LogsEnabled = defineComponent(() => {
+  const expanded = ref(true)
+  const emittedTaskRunId = ref('')
+
+  configureLogPanel(true)
+
+  return () =>
+    h('div', [
+      h(ImportStatusSummary, {
+        item: { ...baseItem, taskRunId: '  task-run-1  ' },
+        expanded: expanded.value,
+        'onUpdate:expanded': (value: boolean) => {
+          expanded.value = value
+        },
+        onOpenLogTaskRun: (taskRunId: string) => {
+          emittedTaskRunId.value = taskRunId
+        },
+      }),
+      h('div', { 'data-testid': 'emitted-task-run' }, emittedTaskRunId.value),
+    ])
+})
+
+export const LogsDisabled = defineComponent(() => {
+  const expanded = ref(true)
+  const emittedTaskRunId = ref('')
+
+  configureLogPanel(false)
+
+  return () =>
+    h('div', [
+      h(ImportStatusSummary, {
+        item: { ...baseItem, taskRunId: 'task-run-2' },
+        expanded: expanded.value,
+        'onUpdate:expanded': (value: boolean) => {
+          expanded.value = value
+        },
+        onOpenLogTaskRun: (taskRunId: string) => {
+          emittedTaskRunId.value = taskRunId
+        },
+      }),
+      h('div', { 'data-testid': 'emitted-task-run' }, emittedTaskRunId.value),
+    ])
+})
+
+export const OptionalFieldsMissing = defineComponent(() => {
+  const expanded = ref(true)
+
+  configureLogPanel(true)
+
+  return () =>
+    h(ImportStatusSummary, {
+      item: {
+        ...baseItem,
+        taskRunId: undefined,
+        workflowId: ' ',
+        workflowName: '',
+        status: undefined,
+        dataFeedName: ' ',
+        dataFeedDescription: '',
+      },
+      expanded: expanded.value,
+      'onUpdate:expanded': (value: boolean) => {
+        expanded.value = value
+      },
+    })
+})

--- a/src/components/systemmonitor/ImportStatusSummary.vue
+++ b/src/components/systemmonitor/ImportStatusSummary.vue
@@ -17,7 +17,11 @@
           :variant="isDark ? 'tonal' : 'flat'"
           size="small"
         >
-          {{ item.lastSuccessfulTime ? toHumanReadableDateTime(item.lastSuccessfulTime) : '-' }}
+          {{
+            item.lastSuccessfulTime
+              ? toHumanReadableDateTime(item.lastSuccessfulTime)
+              : '-'
+          }}
         </v-chip>
       </v-list-item>
       <v-list-item class="flex-grow-1 align-self-left ps-2">
@@ -307,5 +311,4 @@ function onTaskRunIdClick(taskRunId?: string): void {
   opacity: 0;
   transform: translateY(136px);
 }
-
 </style>

--- a/src/components/systemmonitor/ImportStatusSummary.vue
+++ b/src/components/systemmonitor/ImportStatusSummary.vue
@@ -74,8 +74,25 @@
         </v-list-item>
 
         <v-list-item>
-          <v-list-item-subtitle>Data feed name</v-list-item-subtitle>
-          <span class="text-body-2">{{ textValue(item.dataFeedName) }}</span>
+          <v-list-item-subtitle>{{ feedMeta.label }}</v-list-item-subtitle>
+          <div class="d-flex align-center ga-1">
+            <span class="text-body-2">{{ textValue(feedMeta.value) }}</span>
+            <v-tooltip
+              v-if="feedMeta.showTooltip"
+              location="top"
+              :text="item.dataFeedDescription"
+            >
+              <template #activator="{ props }">
+                <v-icon
+                  v-bind="props"
+                  size="16"
+                  icon="mdi-information-outline"
+                  color="primary"
+                  @click.stop
+                />
+              </template>
+            </v-tooltip>
+          </div>
         </v-list-item>
 
         <v-list-item>
@@ -125,6 +142,7 @@
   </v-card>
 </template>
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { ImportExportStatusItem } from './statusTypes'
 import { toHumanReadableDateTime } from '@/lib/date'
 import { useDark } from '@/services/useDark'
@@ -151,6 +169,23 @@ function onExpansionPanelToggle() {
 function textValue(value?: string): string {
   return value && value.trim() !== '' ? value : '-'
 }
+
+function hasText(value?: string): boolean {
+  return Boolean(value && value.trim() !== '')
+}
+
+const feedMeta = computed(() => {
+  const hasName = hasText(item.dataFeedName)
+  const hasDescription = hasText(item.dataFeedDescription)
+  const hasFeed = hasText(item.dataFeed)
+  const useFallback = !hasName && hasDescription && hasFeed
+
+  return {
+    label: useFallback ? 'Data feed' : 'Data feed name',
+    value: useFallback ? item.dataFeed : item.dataFeedName,
+    showTooltip: hasDescription && (hasName || useFallback),
+  }
+})
 </script>
 
 <style scoped>

--- a/src/components/systemmonitor/ImportStatusSummary.vue
+++ b/src/components/systemmonitor/ImportStatusSummary.vue
@@ -123,7 +123,7 @@
         </v-list-item>
 
         <v-list-item>
-          <v-list-item-subtitle>Last file</v-list-item-subtitle>
+          <v-list-item-subtitle>Last Successful File</v-list-item-subtitle>
           <span class="text-body-2">{{ item.lastSuccessfulFile }}</span>
         </v-list-item>
 

--- a/src/components/systemmonitor/ImportStatusSummary.vue
+++ b/src/components/systemmonitor/ImportStatusSummary.vue
@@ -45,9 +45,9 @@
           <transition name="fade-slide">
             <v-chip
               v-show="!expanded && item.filesFailedCount > 0"
-              :color="item.filesFailedCount ? 'error' : 'grey'"
+              :color="item.filesFailedCount ? 'error' : 'surface-variant'"
               size="small"
-              variant="flat"
+              :variant="isDark ? 'tonal' : 'flat'"
             >
               {{ item.filesFailedCount }}
             </v-chip>
@@ -62,24 +62,31 @@
           <div class="d-flex align-center ga-2">
             <span class="text-body-2">{{ item.taskRunId }}</span>
             <v-tooltip
-              v-model="showLogsNotFoundTooltip"
               location="top"
-              text="Logs not found"
-              :open-on-hover="false"
-              :open-on-focus="false"
-              :open-on-click="false"
-              :disabled="!showLogsNotFoundTooltip"
+              text="Open logs for task run"
+              :disabled="showLogsNotFoundTooltip"
             >
-              <template #activator="{ props }">
-                <v-btn
-                  v-bind="props"
-                  icon="mdi-file-clock"
-                  variant="text"
-                  density="compact"
-                  size="small"
-                  aria-label="Open logs for task run"
-                  @click.stop="onTaskRunIdClick(item.taskRunId)"
-                />
+              <template #activator="{ props: hoverProps }">
+                <v-tooltip
+                  v-model="showLogsNotFoundTooltip"
+                  location="top"
+                  text="Logs not found"
+                  :open-on-hover="false"
+                  :open-on-focus="false"
+                  :open-on-click="false"
+                >
+                  <template #activator="{ props: errorProps }">
+                    <v-btn
+                      v-bind="mergeProps(hoverProps, errorProps)"
+                      icon="mdi-launch"
+                      variant="text"
+                      density="compact"
+                      size="small"
+                      aria-label="Open logs for task run"
+                      @click.stop="onTaskRunIdClick(item.taskRunId)"
+                    />
+                  </template>
+                </v-tooltip>
               </template>
             </v-tooltip>
           </div>
@@ -140,8 +147,8 @@
                 <v-chip
                   v-if="expanded"
                   size="small"
-                  color="grey"
-                  variant="flat"
+                  color="surface-variant"
+                  :variant="isDark ? 'tonal' : 'flat'"
                 >
                   {{ item.filesSuccessfulCount }}
                 </v-chip>
@@ -154,9 +161,9 @@
               <transition name="fade-slide">
                 <v-chip
                   v-if="expanded"
-                  :color="item.filesFailedCount ? 'error' : 'grey'"
+                  :color="item.filesFailedCount ? 'error' : 'surface-variant'"
                   size="small"
-                  variant="flat"
+                  :variant="isDark ? 'tonal' : 'flat'"
                 >
                   {{ item.filesFailedCount }}
                 </v-chip>
@@ -169,7 +176,7 @@
   </v-card>
 </template>
 <script setup lang="ts">
-import { computed, onUnmounted, ref } from 'vue'
+import { computed, mergeProps, onUnmounted, ref } from 'vue'
 import type { ImportExportStatusItem } from './statusTypes'
 import { toHumanReadableDateTime } from '@/lib/date'
 import { useDark } from '@/services/useDark'

--- a/src/components/systemmonitor/ImportStatusSummary.vue
+++ b/src/components/systemmonitor/ImportStatusSummary.vue
@@ -53,9 +53,9 @@
     </div>
     <v-expand-transition>
       <div v-if="expanded">
-        <v-list-item>
+        <v-list-item v-if="hasText(item.taskRunId)">
           <v-list-item-subtitle>Task run ID</v-list-item-subtitle>
-          <div v-if="hasText(item.taskRunId)" class="d-flex align-center ga-2">
+          <div class="d-flex align-center ga-2">
             <span class="text-body-2">{{ item.taskRunId }}</span>
             <v-tooltip
               v-model="showLogsNotFoundTooltip"
@@ -79,17 +79,16 @@
               </template>
             </v-tooltip>
           </div>
-          <span v-else class="text-body-2">-</span>
         </v-list-item>
 
-        <v-list-item>
+        <v-list-item v-if="hasText(item.workflowId)">
           <v-list-item-subtitle>Workflow ID</v-list-item-subtitle>
-          <span class="text-body-2">{{ textValue(item.workflowId) }}</span>
+          <span class="text-body-2">{{ item.workflowId }}</span>
         </v-list-item>
 
-        <v-list-item>
+        <v-list-item v-if="hasText(item.workflowName)">
           <v-list-item-subtitle>Workflow name</v-list-item-subtitle>
-          <span class="text-body-2">{{ textValue(item.workflowName) }}</span>
+          <span class="text-body-2">{{ item.workflowName }}</span>
         </v-list-item>
 
         <v-list-item>
@@ -97,10 +96,10 @@
           <span class="text-body-2">{{ item.directory }}</span>
         </v-list-item>
 
-        <v-list-item>
+        <v-list-item v-if="feedMeta.visible">
           <v-list-item-subtitle>{{ feedMeta.label }}</v-list-item-subtitle>
           <div class="d-flex align-center ga-1">
-            <span class="text-body-2">{{ textValue(feedMeta.value) }}</span>
+            <span class="text-body-2">{{ feedMeta.value }}</span>
             <v-tooltip
               v-if="feedMeta.showTooltip"
               location="top"
@@ -124,9 +123,9 @@
           <span class="text-body-2">{{ item.lastSuccessfulFile }}</span>
         </v-list-item>
 
-        <v-list-item>
+        <v-list-item v-if="hasText(item.status)">
           <v-list-item-subtitle>Status</v-list-item-subtitle>
-          <span class="text-body-2">{{ textValue(item.status) }}</span>
+          <span class="text-body-2">{{ item.status }}</span>
         </v-list-item>
 
         <div class="d-flex w-100 justify-space-between align-left">
@@ -210,10 +209,6 @@ function onExpansionPanelToggle() {
   }
 }
 
-function textValue(value?: string): string {
-  return value && value.trim() !== '' ? value : '-'
-}
-
 function hasText(value?: string): boolean {
   return Boolean(value && value.trim() !== '')
 }
@@ -224,10 +219,29 @@ const feedMeta = computed(() => {
   const hasFeed = hasText(item.dataFeed)
   const useFallback = !hasName && hasDescription && hasFeed
 
+  if (hasName) {
+    return {
+      visible: true,
+      label: 'Data feed name',
+      value: item.dataFeedName,
+      showTooltip: hasDescription,
+    }
+  }
+
+  if (useFallback) {
+    return {
+      visible: true,
+      label: 'Data feed',
+      value: item.dataFeed,
+      showTooltip: true,
+    }
+  }
+
   return {
-    label: useFallback ? 'Data feed' : 'Data feed name',
-    value: useFallback ? item.dataFeed : item.dataFeedName,
-    showTooltip: hasDescription && (hasName || useFallback),
+    visible: false,
+    label: 'Data feed name',
+    value: '',
+    showTooltip: false,
   }
 })
 

--- a/src/components/systemmonitor/ImportStatusSummary.vue
+++ b/src/components/systemmonitor/ImportStatusSummary.vue
@@ -10,22 +10,27 @@
     <div class="d-flex w-100 justify-space-between align-left">
       <v-list-item class="px-2 date-time-item">
         <v-list-item-subtitle v-if="expanded">
-          Last import time
+          Last successful time
         </v-list-item-subtitle>
         <v-chip
-          :color="item.lastImportTimeBackgroundColor"
+          :color="item.lastSuccessfulTimeBackgroundColor"
           :variant="isDark ? 'tonal' : 'flat'"
           size="small"
         >
-          {{ toHumanReadableDateTime(item.lastImportTime) }}
+          {{ item.lastSuccessfulTime ? toHumanReadableDateTime(item.lastSuccessfulTime) : '-' }}
         </v-chip>
       </v-list-item>
       <v-list-item class="flex-grow-1 align-self-left ps-2">
-        <v-list-item-subtitle> Source </v-list-item-subtitle>
+        <v-list-item-subtitle>
+          Source
+          <v-chip size="x-small" class="ms-1" variant="tonal">
+            {{ item.statusType }}
+          </v-chip>
+        </v-list-item-subtitle>
         <span
           class="text-body-2 text-truncate"
           :class="[
-            item.fileFailed > 0 && !expanded
+            item.filesFailedCount > 0 && !expanded
               ? 'datafeed-label'
               : 'datafeed-label long',
           ]"
@@ -35,12 +40,12 @@
         <template v-slot:append>
           <transition name="fade-slide">
             <v-chip
-              v-show="!expanded && item.fileFailed > 0"
-              :color="item.fileFailed ? 'error' : 'grey'"
+              v-show="!expanded && item.filesFailedCount > 0"
+              :color="item.filesFailedCount ? 'error' : 'grey'"
               size="small"
               variant="flat"
             >
-              {{ item.fileFailed }}
+              {{ item.filesFailedCount }}
             </v-chip>
           </transition>
         </template>
@@ -49,18 +54,43 @@
     <v-expand-transition>
       <div v-if="expanded">
         <v-list-item>
+          <v-list-item-subtitle>Task run ID</v-list-item-subtitle>
+          <span class="text-body-2">{{ textValue(item.taskRunId) }}</span>
+        </v-list-item>
+
+        <v-list-item>
+          <v-list-item-subtitle>Workflow ID</v-list-item-subtitle>
+          <span class="text-body-2">{{ textValue(item.workflowId) }}</span>
+        </v-list-item>
+
+        <v-list-item>
+          <v-list-item-subtitle>Workflow name</v-list-item-subtitle>
+          <span class="text-body-2">{{ textValue(item.workflowName) }}</span>
+        </v-list-item>
+
+        <v-list-item>
           <v-list-item-subtitle>Directory</v-list-item-subtitle>
           <span class="text-body-2">{{ item.directory }}</span>
         </v-list-item>
 
         <v-list-item>
+          <v-list-item-subtitle>Data feed name</v-list-item-subtitle>
+          <span class="text-body-2">{{ textValue(item.dataFeedName) }}</span>
+        </v-list-item>
+
+        <v-list-item>
           <v-list-item-subtitle>Last file</v-list-item-subtitle>
-          <span class="text-body-2">{{ item.lastFileImported }}</span>
+          <span class="text-body-2">{{ item.lastSuccessfulFile }}</span>
+        </v-list-item>
+
+        <v-list-item>
+          <v-list-item-subtitle>Status</v-list-item-subtitle>
+          <span class="text-body-2">{{ textValue(item.status) }}</span>
         </v-list-item>
 
         <div class="d-flex w-100 justify-space-between align-left">
           <v-list-item class="flex-grow-1">
-            <v-list-item-subtitle>Files imported</v-list-item-subtitle>
+            <v-list-item-subtitle>Files successful</v-list-item-subtitle>
             <template v-slot:append>
               <transition name="fade-slide">
                 <v-chip
@@ -69,7 +99,7 @@
                   color="grey"
                   variant="flat"
                 >
-                  {{ item.fileRead }}
+                  {{ item.filesSuccessfulCount }}
                 </v-chip>
               </transition>
             </template>
@@ -80,11 +110,11 @@
               <transition name="fade-slide">
                 <v-chip
                   v-if="expanded"
-                  :color="item.fileFailed ? 'error' : 'grey'"
+                  :color="item.filesFailedCount ? 'error' : 'grey'"
                   size="small"
                   variant="flat"
                 >
-                  {{ item.fileFailed }}
+                  {{ item.filesFailedCount }}
                 </v-chip>
               </transition>
             </template>
@@ -95,16 +125,12 @@
   </v-card>
 </template>
 <script setup lang="ts">
-import type { ImportStatus } from '@deltares/fews-pi-requests'
+import type { ImportExportStatusItem } from './statusTypes'
 import { toHumanReadableDateTime } from '@/lib/date'
 import { useDark } from '@/services/useDark'
 
-export interface ImportStatusDirectory extends ImportStatus {
-  directory: string
-}
-
 interface Props {
-  item: ImportStatusDirectory
+  item: ImportExportStatusItem
 }
 const { item } = defineProps<Props>()
 
@@ -120,6 +146,10 @@ function onExpansionPanelToggle() {
   if (globalThis.getSelection()?.toString() === '') {
     expanded.value = !expanded.value
   }
+}
+
+function textValue(value?: string): string {
+  return value && value.trim() !== '' ? value : '-'
 }
 </script>
 

--- a/src/components/systemmonitor/ImportStatusSummary.vue
+++ b/src/components/systemmonitor/ImportStatusSummary.vue
@@ -55,7 +55,31 @@
       <div v-if="expanded">
         <v-list-item>
           <v-list-item-subtitle>Task run ID</v-list-item-subtitle>
-          <span class="text-body-2">{{ textValue(item.taskRunId) }}</span>
+          <div v-if="hasText(item.taskRunId)" class="d-flex align-center ga-2">
+            <span class="text-body-2">{{ item.taskRunId }}</span>
+            <v-tooltip
+              v-model="showLogsNotFoundTooltip"
+              location="top"
+              text="Logs not found"
+              :open-on-hover="false"
+              :open-on-focus="false"
+              :open-on-click="false"
+              :disabled="!showLogsNotFoundTooltip"
+            >
+              <template #activator="{ props }">
+                <v-btn
+                  v-bind="props"
+                  icon="mdi-file-clock"
+                  variant="text"
+                  density="compact"
+                  size="small"
+                  aria-label="Open logs for task run"
+                  @click.stop="onTaskRunIdClick(item.taskRunId)"
+                />
+              </template>
+            </v-tooltip>
+          </div>
+          <span v-else class="text-body-2">-</span>
         </v-list-item>
 
         <v-list-item>
@@ -142,15 +166,21 @@
   </v-card>
 </template>
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onUnmounted, ref } from 'vue'
 import type { ImportExportStatusItem } from './statusTypes'
 import { toHumanReadableDateTime } from '@/lib/date'
 import { useDark } from '@/services/useDark'
+import { useConfigStore } from '@/stores/config'
 
 interface Props {
   item: ImportExportStatusItem
 }
 const { item } = defineProps<Props>()
+
+interface Emits {
+  openLogTaskRun: [taskRunId: string]
+}
+const emit = defineEmits<Emits>()
 
 const expanded = defineModel<boolean>('expanded', {
   required: false,
@@ -158,6 +188,20 @@ const expanded = defineModel<boolean>('expanded', {
 })
 
 const isDark = useDark()
+const configStore = useConfigStore()
+const showLogsNotFoundTooltip = ref<boolean>(false)
+let hideTooltipTimer: ReturnType<typeof setTimeout> | null = null
+
+const canOpenLogsPanel = computed<boolean>(() => {
+  const logDisplayConfig = configStore.general.sidePanel?.logDisplay
+  return Boolean(logDisplayConfig?.enabled && logDisplayConfig.logDisplayId)
+})
+
+onUnmounted(() => {
+  if (hideTooltipTimer) {
+    clearTimeout(hideTooltipTimer)
+  }
+})
 
 function onExpansionPanelToggle() {
   // Only expand when no text is selected
@@ -186,6 +230,31 @@ const feedMeta = computed(() => {
     showTooltip: hasDescription && (hasName || useFallback),
   }
 })
+
+function onTaskRunIdClick(taskRunId?: string): void {
+  const normalizedTaskRunId = taskRunId?.trim()
+  if (!normalizedTaskRunId) return
+
+  if (!canOpenLogsPanel.value) {
+    showLogsNotFoundTooltip.value = !showLogsNotFoundTooltip.value
+
+    if (hideTooltipTimer) {
+      clearTimeout(hideTooltipTimer)
+      hideTooltipTimer = null
+    }
+
+    if (showLogsNotFoundTooltip.value) {
+      hideTooltipTimer = setTimeout(() => {
+        showLogsNotFoundTooltip.value = false
+      }, 2000)
+    }
+
+    return
+  }
+
+  showLogsNotFoundTooltip.value = false
+  emit('openLogTaskRun', normalizedTaskRunId)
+}
 </script>
 
 <style scoped>
@@ -224,4 +293,5 @@ const feedMeta = computed(() => {
   opacity: 0;
   transform: translateY(136px);
 }
+
 </style>

--- a/src/components/systemmonitor/statusTypes.ts
+++ b/src/components/systemmonitor/statusTypes.ts
@@ -1,0 +1,24 @@
+export type StatusSource = 'import' | 'export'
+
+export type StatusSourceFilter = 'both' | StatusSource
+
+export type StatusResultFilter = 'successful' | 'unsuccessful'
+
+export interface ImportExportStatusItem {
+  mcId: string
+  taskRunId?: string
+  workflowId?: string
+  workflowName?: string
+  directory: string
+  suspended?: boolean
+  dataFeed: string
+  dataFeedName?: string
+  dataFeedDescription?: string
+  lastSuccessfulTime?: string
+  lastSuccessfulFile: string
+  filesSuccessfulCount: number
+  filesFailedCount: number
+  lastSuccessfulTimeBackgroundColor?: string
+  status?: string
+  statusType: StatusSource
+}

--- a/src/components/systemmonitor/useImportExportStatus.ts
+++ b/src/components/systemmonitor/useImportExportStatus.ts
@@ -1,0 +1,82 @@
+import {
+  PiWebserviceProvider,
+  type ExportStatus,
+  type ImportStatus,
+} from '@deltares/fews-pi-requests'
+import { ref } from 'vue'
+import { createTransformRequestFn } from '@/lib/requests/transformRequest'
+import { configManager } from '@/services/application-config'
+import type { ImportExportStatusItem } from './statusTypes'
+
+interface UseImportExportStatusOptions {
+  pollIntervalMs: number
+}
+
+const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
+const webServiceProvider = new PiWebserviceProvider(baseUrl, {
+  transformRequestFn: createTransformRequestFn(),
+})
+
+export function normalizeStatuses(
+  items: (ImportStatus | ExportStatus)[],
+  statusType: 'import' | 'export',
+): ImportExportStatusItem[] {
+  return items.map((item) => ({
+    ...item,
+    statusType,
+  }))
+}
+
+export function useImportExportStatus(options: UseImportExportStatusOptions) {
+  const statusItems = ref<ImportExportStatusItem[]>([])
+  let active = false
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  function stopPolling() {
+    active = false
+    if (timer) {
+      clearTimeout(timer)
+      timer = undefined
+    }
+  }
+
+  async function loadStatuses() {
+    try {
+      if (!active) return
+
+      const [importResult, exportResult] = await Promise.allSettled([
+        webServiceProvider.getImportStatus(),
+        webServiceProvider.getExportStatus(),
+      ])
+
+      const importItems =
+        importResult.status === 'fulfilled'
+          ? normalizeStatuses(importResult.value.importStatus, 'import')
+          : []
+      const exportItems =
+        exportResult.status === 'fulfilled'
+          ? normalizeStatuses(exportResult.value.exportStatus, 'export')
+          : []
+
+      statusItems.value = [...importItems, ...exportItems]
+    } catch (error) {
+      console.warn(error)
+    } finally {
+      if (active) {
+        timer = setTimeout(loadStatuses, options.pollIntervalMs)
+      }
+    }
+  }
+
+  async function startPolling() {
+    if (active) return
+    active = true
+    await loadStatuses()
+  }
+
+  return {
+    statusItems,
+    startPolling,
+    stopPolling,
+  }
+}

--- a/src/components/topology/TopologySidePanel.vue
+++ b/src/components/topology/TopologySidePanel.vue
@@ -53,6 +53,7 @@
           : {}
       "
       @close="closeSidePanel()"
+      @open-log-task-run="openLogTaskRun"
     />
   </template>
 
@@ -158,13 +159,17 @@ const enabledGeneralSidePanels = computed<GeneralSidePanel[]>(() => {
   // FIXME: For now we always enable share, should be removed once SidePanel configuration is implemented for it.
   return generalSidePanels.filter(
     (sidePanel) =>
-      sidePanel.type === 'share' || sidePanelConfig?.[sidePanel.type]?.enabled,
+      sidePanel.type === 'share' ||
+      sidePanelConfig?.[sidePanel.type]?.enabled,
   )
 })
 
-function settingsForSidePanel(): { logDisplayId: string } {
+function settingsForSidePanel(): { logDisplayId: string; taskRunId?: string } {
   const sidePanelConfig = configStore.general.sidePanel
-  return { logDisplayId: sidePanelConfig?.logDisplay?.logDisplayId ?? '' }
+  return {
+    logDisplayId: sidePanelConfig?.logDisplay?.logDisplayId ?? '',
+    taskRunId: selectedLogTaskRunId.value,
+  }
 }
 
 const hasMultipleEnabledSidePanels = computed<boolean>(
@@ -177,17 +182,39 @@ const currentGeneralSidePanel = ref<GeneralSidePanel | null>(
 )
 // There can be only one active side panel, special or general, at a time.
 const activeSidePanelType = ref<SidePanelType | null>(null)
+const selectedLogTaskRunId = ref<string | undefined>(undefined)
 
 function setCurrentGeneralSidePanel(sidePanel: GeneralSidePanel): void {
+  if (sidePanel.type === 'logDisplay') {
+    // Manual opening of logs panel should not carry a stale task run filter.
+    selectedLogTaskRunId.value = undefined
+  }
   currentGeneralSidePanel.value = sidePanel
   activeSidePanelType.value = sidePanel.type
 }
 
 function closeSidePanel(): void {
   activeSidePanelType.value = null
+  selectedLogTaskRunId.value = undefined
 }
 
 function toggleActiveSidePanel(type: SidePanelType): void {
+  if (type === 'logDisplay' && activeSidePanelType.value !== 'logDisplay') {
+    // Manual opening of logs panel should not carry a stale task run filter.
+    selectedLogTaskRunId.value = undefined
+  }
   activeSidePanelType.value = activeSidePanelType.value === type ? null : type
+}
+
+function openLogTaskRun(taskRunId: string): void {
+  const logDisplayPanel = enabledGeneralSidePanels.value.find(
+    (panel) => panel.type === 'logDisplay',
+  )
+
+  if (!logDisplayPanel) return
+
+  selectedLogTaskRunId.value = taskRunId
+  currentGeneralSidePanel.value = logDisplayPanel
+  activeSidePanelType.value = 'logDisplay'
 }
 </script>

--- a/src/components/topology/TopologySidePanel.vue
+++ b/src/components/topology/TopologySidePanel.vue
@@ -159,8 +159,7 @@ const enabledGeneralSidePanels = computed<GeneralSidePanel[]>(() => {
   // FIXME: For now we always enable share, should be removed once SidePanel configuration is implemented for it.
   return generalSidePanels.filter(
     (sidePanel) =>
-      sidePanel.type === 'share' ||
-      sidePanelConfig?.[sidePanel.type]?.enabled,
+      sidePanel.type === 'share' || sidePanelConfig?.[sidePanel.type]?.enabled,
   )
 })
 

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -86,7 +86,7 @@
   },
   "sidePanel": {
     "documentFile": "Informationen",
-    "importStatus": "Import Status",
+    "importStatus": "Import/Export Status",
     "logDisplay": "Logs",
     "nonCurrentData": "Nicht-Aktuelle Daten",
     "runTask": "Aufgabe ausführen",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -86,7 +86,7 @@
   },
   "sidePanel": {
     "documentFile": "More info",
-    "importStatus": "Import status",
+    "importStatus": "Import/Export status",
     "logDisplay": "Logs",
     "nonCurrentData": "Non-current data",
     "runTask": "Run tasks",

--- a/src/views/SystemMonitorDisplayView.vue
+++ b/src/views/SystemMonitorDisplayView.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="d-flex flex-column h-100 w-100">
-    <v-card-title>Import Status</v-card-title>
+    <v-card-title>Import/Export Status</v-card-title>
     <ImportStatusComponent :timeOut="1000" class="overflow-y-auto" />
   </div>
 </template>

--- a/tests/components/ImportStatusSummary.spec.ts
+++ b/tests/components/ImportStatusSummary.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('ImportStatusSummary runtime behavior', () => {
+  test('emits trimmed taskRunId when logs are enabled', async ({ mount }) => {
+    const component = await mount(
+      'systemmonitor/ImportStatusSummary/LogsEnabled',
+    )
+
+    await component.getByLabel('Open logs for task run').click()
+
+    await expect(component.getByTestId('emitted-task-run')).toHaveText(
+      'task-run-1',
+    )
+  })
+
+  test('shows tooltip and does not emit when logs are disabled', async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(
+      'systemmonitor/ImportStatusSummary/LogsDisabled',
+    )
+
+    await component.getByLabel('Open logs for task run').click()
+    await expect(page.getByText('Logs not found')).toBeVisible()
+    await expect(component.getByTestId('emitted-task-run')).toHaveText('')
+  })
+
+  test('toggles and auto-hides logs unavailable tooltip', async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(
+      'systemmonitor/ImportStatusSummary/LogsDisabled',
+    )
+    const tooltip = page.getByText('Logs not found')
+
+    await component.getByLabel('Open logs for task run').click()
+    await expect(tooltip).toBeVisible()
+
+    await component.getByLabel('Open logs for task run').click()
+    await expect(tooltip).not.toBeVisible()
+
+    await component.getByLabel('Open logs for task run').click()
+    await expect(tooltip).toBeVisible()
+    await expect(tooltip).not.toBeVisible()
+  })
+
+  test('hides optional backend fields when values are not populated', async ({
+    mount,
+  }) => {
+    const component = await mount(
+      'systemmonitor/ImportStatusSummary/OptionalFieldsMissing',
+    )
+
+    await expect(component.getByText('Task run ID')).toHaveCount(0)
+    await expect(component.getByText('Workflow ID')).toHaveCount(0)
+    await expect(component.getByText('Workflow name')).toHaveCount(0)
+    await expect(component.getByText('Status')).toHaveCount(0)
+  })
+})

--- a/tests/unit/components/importExportStatus.contract.test.ts
+++ b/tests/unit/components/importExportStatus.contract.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const statusTypesPath = resolve(
+  process.cwd(),
+  'src/components/systemmonitor/statusTypes.ts',
+)
+const importStatusControlPath = resolve(
+  process.cwd(),
+  'src/components/systemmonitor/ImportStatusControl.vue',
+)
+const importStatusSummaryPath = resolve(
+  process.cwd(),
+  'src/components/systemmonitor/ImportStatusSummary.vue',
+)
+const logSidePanelPath = resolve(
+  process.cwd(),
+  'src/components/sidepanel/LogSidePanel.vue',
+)
+
+function read(path: string): string {
+  return readFileSync(path, 'utf-8')
+}
+
+describe('Import/Export status requirements contract', () => {
+  it('defines shared import/export status source model', () => {
+    const source = read(statusTypesPath)
+
+    expect(source).toContain("export type StatusSource = 'import' | 'export'")
+    expect(source).toContain('export interface ImportExportStatusItem')
+    expect(source).toContain('statusType: StatusSource')
+  })
+
+  it('loads both import and export statuses and merges rows', () => {
+    const source = read(importStatusControlPath)
+
+    expect(source).toContain('Promise.allSettled([')
+    expect(source).toContain('webServiceProvider.getImportStatus()')
+    expect(source).toContain('webServiceProvider.getExportStatus()')
+    expect(source).toContain(
+      'normalizeStatuses(importResult.value.importStatus, \"import\")'.replace(
+        /\"/g,
+        "'",
+      ),
+    )
+    expect(source).toContain(
+      'normalizeStatuses(exportResult.value.exportStatus, \"export\")'.replace(
+        /\"/g,
+        "'",
+      ),
+    )
+    expect(source).toContain(
+      'statusItems.value = [...importItems, ...exportItems]',
+    )
+  })
+
+  it('keeps source and result filters for the status panel', () => {
+    const source = read(importStatusControlPath)
+
+    expect(source).toContain(
+      "const selectedSources = ref<StatusSource[]>(['import', 'export'])",
+    )
+    expect(source).toContain(
+      "const selectedResults = ref<StatusResultFilter[]>([\n  'successful',\n  'unsuccessful',\n])",
+    )
+    expect(source).toContain(
+      'const sourceMatches = selectedSources.value.includes(item.statusType)',
+    )
+    expect(source).toContain(
+      "item.filesFailedCount > 0 ? 'unsuccessful' : 'successful'",
+    )
+    expect(source).toContain(
+      'const resultMatches = selectedResults.value.includes(resultType)',
+    )
+  })
+
+  it('opens logs from taskRunId click and emits selected id', () => {
+    const source = read(importStatusSummaryPath)
+
+    expect(source).toContain('@click.stop="onTaskRunIdClick(item.taskRunId)"')
+    expect(source).toContain("emit('openLogTaskRun', normalizedTaskRunId)")
+  })
+
+  it('shows logs-unavailable tooltip behavior with toggle and auto-hide', () => {
+    const source = read(importStatusSummaryPath)
+
+    expect(source).toContain('text="Logs not found"')
+    expect(source).toContain(
+      'showLogsNotFoundTooltip.value = !showLogsNotFoundTooltip.value',
+    )
+    expect(source).toContain('setTimeout(() => {')
+    expect(source).toContain('showLogsNotFoundTooltip.value = false')
+    expect(source).toContain('}, 2000)')
+  })
+
+  it('shows optional expanded fields only when backend populates values', () => {
+    const source = read(importStatusSummaryPath)
+
+    expect(source).toContain('<v-list-item v-if="hasText(item.taskRunId)">')
+    expect(source).toContain('<v-list-item v-if="hasText(item.workflowId)">')
+    expect(source).toContain('<v-list-item v-if="hasText(item.workflowName)">')
+    expect(source).toContain('<v-list-item v-if="hasText(item.status)">')
+  })
+
+  it('implements strict feed meta rules for name/description fallback', () => {
+    const source = read(importStatusSummaryPath)
+
+    expect(source).toContain('const hasName = hasText(item.dataFeedName)')
+    expect(source).toContain(
+      'const hasDescription = hasText(item.dataFeedDescription)',
+    )
+    expect(source).toContain('const hasFeed = hasText(item.dataFeed)')
+    expect(source).toContain(
+      'const useFallback = !hasName && hasDescription && hasFeed',
+    )
+    expect(source).toContain("label: 'Data feed name'")
+    expect(source).toContain("label: 'Data feed'")
+    expect(source).toContain('visible: false')
+  })
+
+  it('filters logs by selected taskRunId in logs panel', () => {
+    const source = read(logSidePanelPath)
+
+    expect(source).toContain(
+      'const selectedTaskRunId = computed(() => props.settings.taskRunId?.trim() ?? \"\")'.replace(
+        /\"/g,
+        "'",
+      ),
+    )
+    expect(source).toContain(
+      '(!selectedTaskRunId.value || log.taskRunId === selectedTaskRunId.value)',
+    )
+  })
+})

--- a/tests/unit/components/importExportStatus.contract.test.ts
+++ b/tests/unit/components/importExportStatus.contract.test.ts
@@ -10,6 +10,10 @@ const importStatusControlPath = resolve(
   process.cwd(),
   'src/components/systemmonitor/ImportStatusControl.vue',
 )
+const importExportStatusComposablePath = resolve(
+  process.cwd(),
+  'src/components/systemmonitor/useImportExportStatus.ts',
+)
 const importStatusSummaryPath = resolve(
   process.cwd(),
   'src/components/systemmonitor/ImportStatusSummary.vue',
@@ -33,7 +37,7 @@ describe('Import/Export status requirements contract', () => {
   })
 
   it('loads both import and export statuses and merges rows', () => {
-    const source = read(importStatusControlPath)
+    const source = read(importExportStatusComposablePath)
 
     expect(source).toContain('Promise.allSettled([')
     expect(source).toContain('webServiceProvider.getImportStatus()')
@@ -52,6 +56,17 @@ describe('Import/Export status requirements contract', () => {
     )
     expect(source).toContain(
       'statusItems.value = [...importItems, ...exportItems]',
+    )
+  })
+
+  it('uses shared import/export status composable in control panel', () => {
+    const source = read(importStatusControlPath)
+
+    expect(source).toContain(
+      "import { useImportExportStatus } from './useImportExportStatus'",
+    )
+    expect(source).toContain(
+      'const { statusItems, startPolling, stopPolling } = useImportExportStatus({',
     )
   })
 


### PR DESCRIPTION
## Pull Request Template

### Description

The Import and Export status views were merged into one unified overview.
A shared status model was introduced for both sources.
Source and Status filters were added.
Clicking taskRunId now supports opening the Logs side panel (with fallback tooltip behavior if logs are unavailable).
Optional backend fields are only shown when populated.
New runtime and contract tests were added for the updated behavior.
Data feed display now prioritizes dataFeedName, uses dataFeedDescription as tooltip text, falls back to dataFeed when needed, and hides the section when metadata is missing.

### Screenshots (if applicable)

### Link to documentation (if applicable)

Add link to public Github pages (only documentation about configuration)

### Checklist
- [ ] Make the title short and concise
- [ ] Select the correct label to include it in the release notes:
    - `rel: new feature`
    - `rel: improvement`
    - `rel: fixes`
    - `rel: ignore`
    Select to `rel: ignore` if this pull request fixes a New Feature or Improvement in the coming release. Update related Pull Request.
- [ ] Update documentation.
- [ ] Update tests.
