### PR TITLE
Do not set the timesDefault from the wms layer capabilities

### DIFF
--- a/src/components/spatialdisplay/SpatialDisplay.vue
+++ b/src/components/spatialdisplay/SpatialDisplay.vue
@@ -18,7 +18,6 @@
         :layer-capabilities="layerCapabilities"
         :bounding-box="boundingBox"
         :times="times"
-        :times-default="timesDefault"
         :settings="settings.map"
         v-model:elevation="elevation"
         @update:current-time="currentTime = $event"
@@ -136,7 +135,7 @@ const filterOptions = computed(() => {
 })
 
 const baseUrl = configManager.get('VITE_FEWS_WEBSERVICES_URL')
-const { layerCapabilities, times, timesDefault, startPolling, stopPolling } =
+const { layerCapabilities, times, startPolling, stopPolling } =
   useWmsLayerCapabilities(baseUrl, () => props.layerName, taskRunId)
 
 function getDisplayEnabledFromLocationAttributes(


### PR DESCRIPTION
### Description

Revert to the previous behaviour where the real current time is used to set the follow now option in Grid Display / WMS time slider. The new behavior is not working for forecast data where defaultTime from the WMS getCapabilities request was used.